### PR TITLE
Fix #20: createBashTool now passes customCommands to Bash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+package-lock.json
 .DS_Store
 .vscode
 .idea

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -34,6 +34,12 @@ export interface CreateBashToolOptions {
   commands?: CommandName[];
 
   /**
+   * Custom commands to register alongside built-in commands.
+   * These take precedence over built-ins with the same name.
+   */
+  customCommands?: BashOptions["customCommands"];
+
+  /**
    * Network configuration for commands like curl.
    * Disabled by default for security.
    */
@@ -150,6 +156,7 @@ export function createBashTool(
     cwd: options.cwd,
     network: options.network,
     commands: options.commands,
+    customCommands: options.customCommands,
     logger: options.logger,
   });
 


### PR DESCRIPTION
- Fixes #20
- `createBashTool()`now passes through the `customCommands` option to the underlying `Bash` instance
- Copilot / Opus added two tests as well