### PR TITLE
Upgrade the tool to run in a @vercel/sandbox with just 1 param change

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,14 +141,26 @@ Creates a bash tool for use with the [AI SDK](https://ai-sdk.dev/), because [age
 import { createBashTool } from "just-bash/ai";
 import { generateText } from "ai";
 
-const bashTool = createBashTool({
+const { tool, filesystem } = createBashTool({
   files: { "/data/users.json": '[{"name": "Alice"}, {"name": "Bob"}]' },
 });
 
 const result = await generateText({
   model: "anthropic/claude-haiku-4.5",
-  tools: { bash: bashTool },
+  tools: { bash: tool },
   prompt: "Count the users in /data/users.json",
+});
+
+// Read files the AI created
+const output = await filesystem.readFile("/output.txt");
+```
+
+To run commands in a real VM with full binary support (node, python, etc.), just add `fullVM: true`:
+
+```typescript
+const { tool, filesystem } = createBashTool({
+  files: { "/data/users.json": '[{"name": "Alice"}]' },
+  fullVM: true, // Uses @vercel/sandbox under the hood
 });
 ```
 

--- a/src/ai/ai.test.ts
+++ b/src/ai/ai.test.ts
@@ -6,7 +6,7 @@ type BashResult = { stdout: string; stderr: string; exitCode: number };
 
 // Helper to execute tool and get result (handles async iterable case)
 async function exec(
-  tool: ReturnType<typeof createBashTool>,
+  tool: ReturnType<typeof createBashTool>["tool"],
   command: string,
 ): Promise<BashResult> {
   if (!tool.execute) {
@@ -21,16 +21,22 @@ async function exec(
 }
 
 describe("createBashTool", () => {
-  it("creates a tool with correct structure", () => {
-    const tool = createBashTool();
+  it("returns tool and filesystem", () => {
+    const { tool, filesystem } = createBashTool();
 
+    expect(tool).toBeDefined();
     expect(tool.description).toContain("Execute bash commands");
     expect(tool.inputSchema).toBeDefined();
     expect(tool.execute).toBeInstanceOf(Function);
+
+    expect(filesystem).toBeDefined();
+    expect(typeof filesystem.exec).toBe("function");
+    expect(typeof filesystem.writeFiles).toBe("function");
+    expect(typeof filesystem.readFile).toBe("function");
   });
 
   it("executes commands and returns results", async () => {
-    const tool = createBashTool();
+    const { tool } = createBashTool();
     const result = await exec(tool, "echo hello");
 
     expect(result).toEqual({
@@ -41,7 +47,7 @@ describe("createBashTool", () => {
   });
 
   it("includes file hints in description when files provided", () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       files: {
         "/src/index.ts": "export const x = 1;",
         "/README.md": "# Hello",
@@ -55,7 +61,7 @@ describe("createBashTool", () => {
   });
 
   it("limits file hints to 5 files", () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       files: {
         "/a.txt": "a",
         "/b.txt": "b",
@@ -71,7 +77,7 @@ describe("createBashTool", () => {
   });
 
   it("can read files from virtual filesystem", async () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       files: {
         "/test.txt": "file content here",
       },
@@ -87,7 +93,7 @@ describe("createBashTool", () => {
   });
 
   it("restricts commands when commands option provided", async () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       commands: ["echo", "cat"],
     });
 
@@ -102,7 +108,7 @@ describe("createBashTool", () => {
   });
 
   it("shows available commands in description when filtered", () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       commands: ["echo", "cat", "grep"],
     });
 
@@ -110,7 +116,7 @@ describe("createBashTool", () => {
   });
 
   it("includes extra instructions in description", () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       extraInstructions: "This is a special environment for testing.",
     });
 
@@ -120,7 +126,7 @@ describe("createBashTool", () => {
   });
 
   it("mentions network when configured", () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       network: { dangerouslyAllowFullInternetAccess: true },
     });
 
@@ -128,7 +134,7 @@ describe("createBashTool", () => {
   });
 
   it("sets environment variables", async () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       env: { MY_VAR: "my_value" },
     });
 
@@ -137,7 +143,7 @@ describe("createBashTool", () => {
   });
 
   it("uses custom cwd", async () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       cwd: "/custom/path",
       files: { "/custom/path/file.txt": "content" },
     });
@@ -147,7 +153,7 @@ describe("createBashTool", () => {
   });
 
   it("help command works and lists available commands", async () => {
-    const tool = createBashTool();
+    const { tool } = createBashTool();
     const result = await exec(tool, "help");
 
     expect(result.exitCode).toBe(0);
@@ -157,7 +163,7 @@ describe("createBashTool", () => {
   });
 
   it("help shows only registered commands when filtered", async () => {
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       commands: ["echo", "cat", "help"],
     });
 
@@ -172,7 +178,7 @@ describe("createBashTool", () => {
 
   it("calls onCall callback before command execution", async () => {
     const calls: string[] = [];
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       onCall: (command) => calls.push(command),
     });
 
@@ -189,7 +195,7 @@ describe("createBashTool", () => {
       exitCode: 0,
     }));
 
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       customCommands: [hello],
     });
 
@@ -208,7 +214,7 @@ describe("createBashTool", () => {
       exitCode: 0,
     }));
 
-    const tool = createBashTool({
+    const { tool } = createBashTool({
       customCommands: [customEcho],
     });
 
@@ -217,6 +223,60 @@ describe("createBashTool", () => {
       stdout: "custom: test\n",
       stderr: "",
       exitCode: 0,
+    });
+  });
+
+  describe("filesystem integration", () => {
+    it("tool and filesystem share state", async () => {
+      const { tool, filesystem } = createBashTool();
+
+      // Write via filesystem
+      await filesystem.writeFiles({ "/shared/file.txt": "filesystem content" });
+
+      // Read via tool
+      const result = await exec(tool, "cat /shared/file.txt");
+      expect(result.stdout).toBe("filesystem content");
+
+      // Write via tool
+      await exec(tool, 'echo "tool content" > /shared/tool-file.txt');
+
+      // Read via filesystem
+      const content = await filesystem.readFile("/shared/tool-file.txt");
+      expect(content).toBe("tool content\n");
+    });
+
+    it("filesystem can read files created with files option", async () => {
+      const { filesystem } = createBashTool({
+        files: { "/data/test.txt": "initial content" },
+      });
+
+      const content = await filesystem.readFile("/data/test.txt");
+      expect(content).toBe("initial content");
+    });
+
+    it("filesystem can write files before tool execution", async () => {
+      const { tool, filesystem } = createBashTool();
+
+      await filesystem.writeFiles({ "/config.json": '{"debug": true}' });
+
+      const result = await exec(tool, "cat /config.json");
+      expect(result.stdout).toBe('{"debug": true}');
+    });
+  });
+
+  describe("fullVM option", () => {
+    it("changes description when fullVM is true", () => {
+      const { tool } = createBashTool({ fullVM: true });
+
+      expect(tool.description).toContain("full VM environment");
+      expect(tool.description).toContain("node, python");
+    });
+
+    it("uses simulated description when fullVM is false", () => {
+      const { tool } = createBashTool({ fullVM: false });
+
+      expect(tool.description).toContain("simulated bash environment");
+      expect(tool.description).not.toContain("full VM");
     });
   });
 });

--- a/src/ai/index.ts
+++ b/src/ai/index.ts
@@ -1,25 +1,36 @@
 import { type Tool, tool, zodSchema } from "ai";
 import { z } from "zod";
-import { Bash, type BashLogger, type BashOptions } from "../Bash.js";
+import type { BashLogger, BashOptions } from "../Bash.js";
 import type { CommandName } from "../commands/registry.js";
-import type { IFileSystem, InitialFiles } from "../fs/interface.js";
+import type { InitialFiles } from "../fs/interface.js";
+import { BashSandbox } from "../sandbox/BashSandbox.js";
 
 type BashToolInput = { command: string };
 type BashToolOutput = { stdout: string; stderr: string; exitCode: number };
 
 export interface CreateBashToolOptions {
   /**
-   * Initial files to populate the virtual filesystem.
-   * The tool instructions will include common operations on a sample of these files.
-   * Ignored if `fs` is provided.
+   * Run commands in a full VM (@vercel/sandbox) instead of the simulated bash.
+   * When true, commands run in a real environment with full binary support
+   * (node, python, etc.).
+   *
+   * @default false
+   *
+   * @example
+   * ```typescript
+   * // Upgrade to full VM - just add fullVM: true
+   * const { tool, filesystem } = createBashTool({
+   *   files: { "/data/users.json": '[...]' },
+   *   fullVM: true,
+   * });
+   * ```
    */
-  files?: InitialFiles;
+  fullVM?: boolean;
 
   /**
-   * Custom filesystem implementation (e.g., OverlayFs for copy-on-write behavior).
-   * If provided, `files` option is ignored.
+   * Initial files to populate the filesystem.
    */
-  fs?: IFileSystem;
+  files?: InitialFiles;
 
   /**
    * Additional instructions to append to the tool description.
@@ -30,18 +41,21 @@ export interface CreateBashToolOptions {
    * Optional list of command names to register.
    * If not provided, all built-in commands are available.
    * Use this to restrict which commands can be executed.
+   * Only applies when fullVM is false.
    */
   commands?: CommandName[];
 
   /**
    * Custom commands to register alongside built-in commands.
    * These take precedence over built-ins with the same name.
+   * Only applies when fullVM is false.
    */
   customCommands?: BashOptions["customCommands"];
 
   /**
    * Network configuration for commands like curl.
    * Disabled by default for security.
+   * Only applies when fullVM is false.
    */
   network?: BashOptions["network"];
 
@@ -64,17 +78,48 @@ export interface CreateBashToolOptions {
   /**
    * Optional logger for execution tracing.
    * Logs exec commands (info), stdout (debug), stderr (info), and exit codes (info).
+   * Only applies when fullVM is false.
    */
   logger?: BashLogger;
 }
 
-function generateInstructions(options: CreateBashToolOptions): string {
+export interface CreateBashToolResult {
+  /**
+   * AI SDK compatible tool for executing bash commands.
+   */
+  tool: Tool<BashToolInput, BashToolOutput>;
+
+  /**
+   * The filesystem interface for reading/writing files.
+   * Use this to add files before the AI runs, or read files the AI created.
+   *
+   * When `fullVM: true`, this is backed by @vercel/sandbox.
+   * Otherwise, it's an in-memory virtual filesystem.
+   */
+  filesystem: BashSandbox;
+}
+
+function generateInstructions(
+  options: CreateBashToolOptions,
+  isFullVM = false,
+): string {
   const lines: string[] = [
-    "Execute bash commands in a virtual environment.",
-    "",
-    "This is a simulated bash environment with a virtual filesystem. Commands run in isolation without access to the host system.",
+    "Execute bash commands in a sandboxed environment.",
     "",
   ];
+
+  if (isFullVM) {
+    lines.push(
+      "This is a full VM environment with real binary execution support.",
+    );
+    lines.push("You can run any command including node, python, etc.");
+  } else {
+    lines.push(
+      "This is a simulated bash environment with a virtual filesystem.",
+    );
+    lines.push("Commands run in isolation without access to the host system.");
+  }
+  lines.push("");
 
   // Add file discovery hints if files are provided
   if (options.files && Object.keys(options.files).length > 0) {
@@ -119,54 +164,77 @@ function generateInstructions(options: CreateBashToolOptions): string {
   return lines.join("\n").trim();
 }
 
-/**
- * Creates an AI SDK tool for executing bash commands in a virtual environment.
- *
- * @example
- * ```typescript
- * import { createBashTool } from "bash-env/ai";
- * import { generateText } from "ai";
- *
- * const bashTool = createBashTool({
- *   files: {
- *     "/src/index.ts": "export const hello = 'world';",
- *     "/README.md": "# My Project",
- *   },
- * });
- *
- * const result = await generateText({
- *   model: yourModel,
- *   tools: { bash: bashTool },
- *   prompt: "List all TypeScript files",
- * });
- * ```
- */
 const bashToolSchema = z.object({
   command: z.string().describe("The bash command to execute"),
 });
 
+/**
+ * Creates an AI SDK tool for executing bash commands in a sandboxed environment.
+ *
+ * Returns both the tool and the filesystem, so you can interact with
+ * files before/after the AI runs.
+ *
+ * @example Simple usage (in-memory bash simulation)
+ * ```typescript
+ * import { createBashTool } from "just-bash/ai";
+ * import { generateText } from "ai";
+ *
+ * const { tool } = createBashTool({
+ *   files: { "/data/users.json": '[{"name": "Alice"}]' },
+ * });
+ *
+ * const result = await generateText({
+ *   model: yourModel,
+ *   tools: { bash: tool },
+ *   prompt: "Count the users in /data/users.json",
+ * });
+ * ```
+ *
+ * @example Upgrade to full VM - just add fullVM: true
+ * ```typescript
+ * const { tool, filesystem } = createBashTool({
+ *   files: { "/data/users.json": '[{"name": "Alice"}]' },
+ *   fullVM: true,
+ * });
+ *
+ * // Now commands run in a real VM with node, python, etc.
+ * ```
+ *
+ * @example Interact with filesystem before/after AI runs
+ * ```typescript
+ * const { tool, filesystem } = createBashTool({
+ *   files: { "/data/input.json": '{}' },
+ * });
+ *
+ * // Write files that the AI can see
+ * await filesystem.writeFiles({ "/config.json": '{"debug": true}' });
+ *
+ * // Run AI
+ * await generateText({ model, tools: { bash: tool }, prompt: "..." });
+ *
+ * // Read what AI created
+ * const output = await filesystem.readFile("/output.txt");
+ * ```
+ */
 export function createBashTool(
   options: CreateBashToolOptions = {},
-): Tool<BashToolInput, BashToolOutput> {
-  // Create a shared Bash instance with optional command filtering
-  const bashEnv = new Bash({
-    fs: options.fs,
-    files: options.fs ? undefined : options.files, // files ignored if fs provided
-    env: options.env,
+): CreateBashToolResult {
+  const filesystem = new BashSandbox({
+    fullVM: options.fullVM,
+    files: options.files,
     cwd: options.cwd,
+    env: options.env,
     network: options.network,
     commands: options.commands,
     customCommands: options.customCommands,
-    logger: options.logger,
   });
 
-  return tool({
-    description: generateInstructions(options),
+  const bashTool = tool({
+    description: generateInstructions(options, options.fullVM),
     inputSchema: zodSchema(bashToolSchema),
     execute: async ({ command }) => {
       options.onCall?.(command);
-      const result = await bashEnv.exec(command);
-
+      const result = await filesystem.exec(command);
       return {
         stdout: result.stdout,
         stderr: result.stderr,
@@ -174,6 +242,8 @@ export function createBashTool(
       };
     },
   });
+
+  return { tool: bashTool, filesystem };
 }
 
-export type BashTool = ReturnType<typeof createBashTool>;
+export type BashTool = ReturnType<typeof createBashTool>["tool"];

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,14 +39,31 @@ export {
   RedirectNotAllowedError,
   TooManyRedirectsError,
 } from "./network/index.js";
+// Legacy Sandbox API (deprecated)
 export type {
   CommandFinished as SandboxCommandFinished,
   OutputMessage,
   SandboxOptions,
   WriteFilesInput,
 } from "./sandbox/index.js";
-// Vercel Sandbox API compatible exports
-export { Command as SandboxCommand, Sandbox } from "./sandbox/index.js";
+// New Sandbox API
+/** @deprecated Use BashSandbox instead */
+export {
+  BashProvider,
+  type BashProviderOptions,
+  BashSandbox,
+  type BashSandboxOptions,
+  Command as SandboxCommand,
+  type FileContent as SandboxFileContent,
+  type FileInput as SandboxFileInput,
+  Sandbox,
+  type SandboxExecOptions,
+  type SandboxExecResult,
+  type SandboxProvider,
+  type ToolOptions,
+  VercelProvider,
+  type VercelProviderOptions,
+} from "./sandbox/index.js";
 export type {
   BashExecResult,
   Command,

--- a/src/sandbox/BashSandbox.test.ts
+++ b/src/sandbox/BashSandbox.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { BashSandbox } from "./BashSandbox.js";
+import type { SandboxProvider } from "./provider.js";
+
+type BashResult = { stdout: string; stderr: string; exitCode: number };
+
+// Helper to execute tool and get result (handles async iterable case)
+async function execTool(
+  tool: ReturnType<BashSandbox["tool"]>,
+  command: string,
+): Promise<BashResult> {
+  if (!tool.execute) {
+    throw new Error("Tool has no execute function");
+  }
+  const result = await tool.execute(
+    { command },
+    { toolCallId: "test", messages: [] },
+  );
+  // Our implementation always returns a plain object, not an async iterable
+  return result as BashResult;
+}
+
+describe("BashSandbox", () => {
+  describe("default (just-bash) provider", () => {
+    it("should execute commands", async () => {
+      const sandbox = new BashSandbox();
+      const result = await sandbox.exec("echo hello");
+      expect(result.stdout).toBe("hello\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should initialize with files", async () => {
+      const sandbox = new BashSandbox({
+        files: { "/data/test.txt": "hello world" },
+      });
+      const result = await sandbox.exec("cat /data/test.txt");
+      expect(result.stdout).toBe("hello world");
+    });
+
+    it("should write and read files", async () => {
+      const sandbox = new BashSandbox();
+      await sandbox.writeFiles({
+        "/app/config.json": '{"debug": true}',
+      });
+      const content = await sandbox.readFile("/app/config.json");
+      expect(content).toBe('{"debug": true}');
+    });
+
+    it("should support base64 encoding for writeFiles", async () => {
+      const sandbox = new BashSandbox();
+      await sandbox.writeFiles({
+        "/data/file.txt": {
+          content: Buffer.from("hello").toString("base64"),
+          encoding: "base64",
+        },
+      });
+      const content = await sandbox.readFile("/data/file.txt");
+      expect(content).toBe("hello");
+    });
+
+    it("should support base64 encoding for readFile", async () => {
+      const sandbox = new BashSandbox();
+      await sandbox.writeFiles({ "/data/file.txt": "hello" });
+      const base64 = await sandbox.readFile("/data/file.txt", "base64");
+      expect(base64).toBe(Buffer.from("hello").toString("base64"));
+    });
+
+    it("should create directories", async () => {
+      const sandbox = new BashSandbox();
+      await sandbox.mkdir("/app/logs", { recursive: true });
+      const result = await sandbox.exec("ls -d /app/logs");
+      expect(result.stdout).toBe("/app/logs\n");
+    });
+
+    it("should respect cwd option", async () => {
+      const sandbox = new BashSandbox({ cwd: "/tmp" });
+      const result = await sandbox.exec("pwd");
+      expect(result.stdout).toBe("/tmp\n");
+    });
+
+    it("should respect env option", async () => {
+      const sandbox = new BashSandbox({ env: { MY_VAR: "test123" } });
+      const result = await sandbox.exec("echo $MY_VAR");
+      expect(result.stdout).toBe("test123\n");
+    });
+
+    it("should expose sandbox provider", async () => {
+      const sandbox = new BashSandbox();
+      expect(sandbox.sandbox).toBeDefined();
+      expect(typeof sandbox.sandbox.exec).toBe("function");
+    });
+  });
+
+  describe("custom provider", () => {
+    it("should use custom provider", async () => {
+      const mockProvider: SandboxProvider = {
+        exec: async () => ({
+          stdout: "custom output",
+          stderr: "",
+          exitCode: 0,
+        }),
+        writeFiles: async () => {},
+        readFile: async () => "custom content",
+        mkdir: async () => {},
+        stop: async () => {},
+      };
+
+      const sandbox = new BashSandbox({ provider: mockProvider });
+      const result = await sandbox.exec("anything");
+      expect(result.stdout).toBe("custom output");
+
+      const content = await sandbox.readFile("/any/path");
+      expect(content).toBe("custom content");
+    });
+  });
+
+  describe("tool()", () => {
+    it("should return an AI SDK compatible tool", async () => {
+      const sandbox = new BashSandbox({
+        files: { "/data/test.txt": "hello" },
+      });
+      const bashTool = sandbox.tool();
+
+      expect(bashTool).toBeDefined();
+      expect(bashTool.description).toContain("bash");
+      expect(bashTool.execute).toBeDefined();
+    });
+
+    it("should execute commands via tool", async () => {
+      const sandbox = new BashSandbox();
+      const bashTool = sandbox.tool();
+
+      const result = await execTool(bashTool, "echo test");
+      expect(result.stdout).toBe("test\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should share state between tool and direct operations", async () => {
+      const sandbox = new BashSandbox();
+      const bashTool = sandbox.tool();
+
+      // Write via direct API
+      await sandbox.writeFiles({ "/shared/file.txt": "from direct" });
+
+      // Read via tool
+      const result = await execTool(bashTool, "cat /shared/file.txt");
+      expect(result.stdout).toBe("from direct");
+
+      // Write via tool
+      await execTool(bashTool, 'echo "from tool" > /shared/tool-file.txt');
+
+      // Read via direct API
+      const content = await sandbox.readFile("/shared/tool-file.txt");
+      expect(content).toBe("from tool\n");
+    });
+
+    it("should call onCall callback", async () => {
+      const sandbox = new BashSandbox();
+      const commands: string[] = [];
+      const bashTool = sandbox.tool({
+        onCall: (cmd) => commands.push(cmd),
+      });
+
+      await execTool(bashTool, "echo one");
+      await execTool(bashTool, "echo two");
+
+      expect(commands).toEqual(["echo one", "echo two"]);
+    });
+
+    it("should include extraInstructions in description", async () => {
+      const sandbox = new BashSandbox();
+      const bashTool = sandbox.tool({
+        extraInstructions: "This is a TypeScript project.",
+      });
+
+      expect(bashTool.description).toContain("This is a TypeScript project.");
+    });
+
+    it("should list available files in description", async () => {
+      const sandbox = new BashSandbox({
+        files: {
+          "/src/index.ts": "export const x = 1;",
+          "/package.json": "{}",
+        },
+      });
+      const bashTool = sandbox.tool();
+
+      expect(bashTool.description).toContain("/src/index.ts");
+      expect(bashTool.description).toContain("/package.json");
+    });
+  });
+
+  describe("stop()", () => {
+    it("should be callable (no-op for bash provider)", async () => {
+      const sandbox = new BashSandbox();
+      await expect(sandbox.stop()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/sandbox/BashSandbox.ts
+++ b/src/sandbox/BashSandbox.ts
@@ -1,0 +1,292 @@
+/**
+ * BashSandbox - Stateful sandbox with AI SDK tool support.
+ *
+ * @example
+ * ```typescript
+ * import { BashSandbox } from "just-bash";
+ *
+ * // Create sandbox (default: just-bash)
+ * const sandbox = new BashSandbox({
+ *   files: { "/data/users.json": '[{"name": "Alice"}]' },
+ * });
+ *
+ * // Use as AI SDK tool
+ * const agent = new ToolLoopAgent({
+ *   tools: { bash: sandbox.tool() },
+ * });
+ *
+ * // Direct operations
+ * await sandbox.exec("ls -la");
+ * await sandbox.writeFiles({ "/config.json": "{}" });
+ * const content = await sandbox.readFile("/config.json");
+ *
+ * // Switch to full VM (@vercel/sandbox)
+ * const vmSandbox = new BashSandbox({ fullVM: true });
+ * ```
+ */
+
+import { type Tool, tool, zodSchema } from "ai";
+import { z } from "zod";
+import type { BashOptions } from "../Bash.js";
+import type { CommandName } from "../commands/registry.js";
+import type { InitialFiles } from "../fs/interface.js";
+import type {
+  ExecOptions,
+  ExecResult,
+  FileInput,
+  SandboxProvider,
+} from "./provider.js";
+import { BashProvider } from "./providers/bash-provider.js";
+import { VercelProvider } from "./providers/vercel-provider.js";
+
+export interface BashSandboxOptions {
+  /**
+   * Use @vercel/sandbox for real VM execution.
+   * When true, commands run in a real environment with full binary support.
+   * Default: false (uses just-bash in-memory sandbox)
+   */
+  fullVM?: boolean;
+
+  /**
+   * Custom sandbox provider.
+   * Takes precedence over fullVM option.
+   */
+  provider?: SandboxProvider;
+
+  /**
+   * Initial files to populate the filesystem.
+   * Ignored when fullVM is true (use writeFiles after creation).
+   */
+  files?: InitialFiles;
+
+  /**
+   * Current working directory.
+   */
+  cwd?: string;
+
+  /**
+   * Environment variables.
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Path to a directory to use as the root of an OverlayFs.
+   * Reads come from this directory, writes stay in memory.
+   * Only applicable when fullVM is false.
+   */
+  overlayRoot?: string;
+
+  /**
+   * Network configuration for commands like curl.
+   * Only applicable when fullVM is false.
+   */
+  network?: BashOptions["network"];
+
+  /**
+   * Execution limits to prevent runaway compute.
+   * Only applicable when fullVM is false.
+   */
+  executionLimits?: BashOptions["executionLimits"];
+
+  /**
+   * Optional list of command names to register.
+   * Only applicable when fullVM is false.
+   */
+  commands?: CommandName[];
+
+  /**
+   * Custom commands to register alongside built-in commands.
+   * Only applicable when fullVM is false.
+   */
+  customCommands?: BashOptions["customCommands"];
+
+  /**
+   * Timeout in milliseconds (only for fullVM).
+   */
+  timeoutMs?: number;
+}
+
+export interface ToolOptions {
+  /**
+   * Additional instructions to append to the tool description.
+   */
+  extraInstructions?: string;
+
+  /**
+   * Callback invoked before each command execution.
+   */
+  onCall?: (command: string) => void;
+}
+
+type BashToolInput = { command: string };
+type BashToolOutput = { stdout: string; stderr: string; exitCode: number };
+
+const bashToolSchema = z.object({
+  command: z.string().describe("The bash command to execute"),
+});
+
+export class BashSandbox {
+  private _provider: SandboxProvider;
+  private options: BashSandboxOptions;
+
+  constructor(options: BashSandboxOptions = {}) {
+    this.options = options;
+
+    // Determine provider
+    if (options.provider) {
+      this._provider = options.provider;
+    } else if (options.fullVM) {
+      this._provider = new VercelProvider({
+        cwd: options.cwd,
+        env: options.env,
+        timeoutMs: options.timeoutMs,
+      });
+    } else {
+      this._provider = new BashProvider({
+        files: options.files,
+        cwd: options.cwd,
+        env: options.env,
+        overlayRoot: options.overlayRoot,
+        network: options.network,
+        executionLimits: options.executionLimits,
+        commands: options.commands,
+        customCommands: options.customCommands,
+      });
+    }
+  }
+
+  /**
+   * Get the underlying sandbox provider for direct access.
+   */
+  get sandbox(): SandboxProvider {
+    return this._provider;
+  }
+
+  /**
+   * Execute a command in the sandbox.
+   */
+  async exec(cmd: string, opts?: ExecOptions): Promise<ExecResult> {
+    return this._provider.exec(cmd, opts);
+  }
+
+  /**
+   * Write files to the sandbox filesystem.
+   */
+  async writeFiles(files: Record<string, FileInput>): Promise<void> {
+    return this._provider.writeFiles(files);
+  }
+
+  /**
+   * Read a file from the sandbox filesystem.
+   */
+  async readFile(path: string, encoding?: "utf-8" | "base64"): Promise<string> {
+    return this._provider.readFile(path, encoding);
+  }
+
+  /**
+   * Create a directory in the sandbox filesystem.
+   */
+  async mkdir(path: string, opts?: { recursive?: boolean }): Promise<void> {
+    return this._provider.mkdir(path, opts);
+  }
+
+  /**
+   * Stop/cleanup the sandbox.
+   * No-op for just-bash, required for fullVM.
+   */
+  async stop(): Promise<void> {
+    return this._provider.stop();
+  }
+
+  /**
+   * Create an AI SDK compatible tool that uses this sandbox.
+   * The tool shares state with the sandbox - files added via writeFiles
+   * are visible to the AI, and files created by the AI are readable via readFile.
+   */
+  tool(options: ToolOptions = {}): Tool<BashToolInput, BashToolOutput> {
+    const description = this.generateToolDescription(options);
+
+    return tool({
+      description,
+      inputSchema: zodSchema(bashToolSchema),
+      execute: async ({ command }) => {
+        options.onCall?.(command);
+        const result = await this._provider.exec(command);
+        return {
+          stdout: result.stdout,
+          stderr: result.stderr,
+          exitCode: result.exitCode,
+        };
+      },
+    });
+  }
+
+  private generateToolDescription(options: ToolOptions): string {
+    const lines: string[] = [
+      "Execute bash commands in a sandboxed environment.",
+      "",
+    ];
+
+    if (this.options.fullVM) {
+      lines.push(
+        "This is a full VM environment with real binary execution support.",
+      );
+      lines.push("You can run any command including node, python, etc.");
+    } else {
+      lines.push(
+        "This is a simulated bash environment with a virtual filesystem.",
+      );
+      lines.push(
+        "Commands run in isolation without access to the host system.",
+      );
+    }
+    lines.push("");
+
+    // Add file discovery hints if files are provided (only for bash provider)
+    if (
+      !this.options.fullVM &&
+      this.options.files &&
+      Object.keys(this.options.files).length > 0
+    ) {
+      const filePaths = Object.keys(this.options.files);
+      const sampleFiles = filePaths.slice(0, 5);
+
+      lines.push("Available files:");
+      for (const file of sampleFiles) {
+        lines.push(`  ${file}`);
+      }
+      if (filePaths.length > 5) {
+        lines.push(`  ... and ${filePaths.length - 5} more`);
+      }
+      lines.push("");
+    }
+
+    lines.push("Common operations:");
+    lines.push("  ls -la              # List files with details");
+    lines.push("  find . -name '*.ts' # Find files by pattern");
+    lines.push("  grep -r 'pattern' . # Search file contents");
+    lines.push("  cat <file>          # View file contents");
+    lines.push("");
+
+    lines.push("To discover commands and their options:");
+    lines.push("  help                # List all available commands");
+    lines.push("  <command> --help    # Show options for a specific command");
+    lines.push("");
+
+    if (this.options.commands?.length) {
+      lines.push(`Available commands: ${this.options.commands.join(", ")}`);
+      lines.push("");
+    }
+
+    if (this.options.network) {
+      lines.push("Network access via curl is enabled for this environment.");
+      lines.push("");
+    }
+
+    if (options.extraInstructions) {
+      lines.push(options.extraInstructions);
+    }
+
+    return lines.join("\n").trim();
+  }
+}

--- a/src/sandbox/index.ts
+++ b/src/sandbox/index.ts
@@ -1,3 +1,26 @@
+// New API
+export {
+  BashSandbox,
+  type BashSandboxOptions,
+  type ToolOptions,
+} from "./BashSandbox.js";
+export type {
+  ExecOptions as SandboxExecOptions,
+  ExecResult as SandboxExecResult,
+  FileContent,
+  FileInput,
+  SandboxProvider,
+} from "./provider.js";
+export {
+  BashProvider,
+  type BashProviderOptions,
+} from "./providers/bash-provider.js";
+export {
+  VercelProvider,
+  type VercelProviderOptions,
+} from "./providers/vercel-provider.js";
+
+// Legacy API (deprecated but kept for backwards compatibility)
 export type {
   CommandFinished,
   OutputMessage,

--- a/src/sandbox/provider.ts
+++ b/src/sandbox/provider.ts
@@ -1,0 +1,53 @@
+/**
+ * Provider interface for sandbox implementations.
+ * This allows swapping between just-bash (default) and @vercel/sandbox (fullVM).
+ */
+
+export interface ExecResult {
+  stdout: string;
+  stderr: string;
+  exitCode: number;
+}
+
+export interface FileContent {
+  content: string;
+  encoding?: "utf-8" | "base64";
+}
+
+export type FileInput = string | FileContent;
+
+export interface ExecOptions {
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+/**
+ * Common interface for sandbox providers.
+ * Implemented by BashProvider (just-bash) and VercelProvider (@vercel/sandbox).
+ */
+export interface SandboxProvider {
+  /**
+   * Execute a command and return the result.
+   */
+  exec(cmd: string, opts?: ExecOptions): Promise<ExecResult>;
+
+  /**
+   * Write files to the sandbox filesystem.
+   */
+  writeFiles(files: Record<string, FileInput>): Promise<void>;
+
+  /**
+   * Read a file from the sandbox filesystem.
+   */
+  readFile(path: string, encoding?: "utf-8" | "base64"): Promise<string>;
+
+  /**
+   * Create a directory.
+   */
+  mkdir(path: string, opts?: { recursive?: boolean }): Promise<void>;
+
+  /**
+   * Stop/cleanup the sandbox (no-op for just-bash, required for VM).
+   */
+  stop(): Promise<void>;
+}

--- a/src/sandbox/providers/bash-provider.ts
+++ b/src/sandbox/providers/bash-provider.ts
@@ -1,0 +1,138 @@
+/**
+ * BashProvider - SandboxProvider implementation using just-bash.
+ * This is the default provider for BashSandbox.
+ */
+
+import { Bash, type BashOptions } from "../../Bash.js";
+import type { IFileSystem, InitialFiles } from "../../fs/interface.js";
+import { OverlayFs } from "../../fs/overlay-fs/index.js";
+import type {
+  ExecOptions,
+  ExecResult,
+  FileInput,
+  SandboxProvider,
+} from "../provider.js";
+
+export interface BashProviderOptions {
+  /**
+   * Initial files to populate the virtual filesystem.
+   */
+  files?: InitialFiles;
+
+  /**
+   * Current working directory. Defaults to /home/user.
+   */
+  cwd?: string;
+
+  /**
+   * Environment variables.
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Path to a directory to use as the root of an OverlayFs.
+   * Reads come from this directory, writes stay in memory.
+   */
+  overlayRoot?: string;
+
+  /**
+   * Network configuration for commands like curl.
+   * Disabled by default for security.
+   */
+  network?: BashOptions["network"];
+
+  /**
+   * Execution limits to prevent runaway compute.
+   */
+  executionLimits?: BashOptions["executionLimits"];
+
+  /**
+   * Optional list of command names to register.
+   * If not provided, all built-in commands are available.
+   */
+  commands?: BashOptions["commands"];
+
+  /**
+   * Custom commands to register alongside built-in commands.
+   */
+  customCommands?: BashOptions["customCommands"];
+}
+
+export class BashProvider implements SandboxProvider {
+  private bash: Bash;
+
+  constructor(options: BashProviderOptions = {}) {
+    // Determine filesystem
+    let fs: IFileSystem | undefined;
+    if (options.overlayRoot) {
+      fs = new OverlayFs({ root: options.overlayRoot });
+    }
+
+    this.bash = new Bash({
+      fs,
+      files: fs ? undefined : options.files,
+      cwd: options.cwd,
+      env: options.env,
+      network: options.network,
+      executionLimits: options.executionLimits,
+      commands: options.commands,
+      customCommands: options.customCommands,
+    });
+  }
+
+  async exec(cmd: string, opts?: ExecOptions): Promise<ExecResult> {
+    const result = await this.bash.exec(cmd, opts);
+    return {
+      stdout: result.stdout,
+      stderr: result.stderr,
+      exitCode: result.exitCode,
+    };
+  }
+
+  async writeFiles(files: Record<string, FileInput>): Promise<void> {
+    for (const [path, content] of Object.entries(files)) {
+      let data: string;
+      if (typeof content === "string") {
+        data = content;
+      } else {
+        if (content.encoding === "base64") {
+          data = Buffer.from(content.content, "base64").toString("utf-8");
+        } else {
+          data = content.content;
+        }
+      }
+
+      // Ensure parent directory exists
+      const parentDir = path.substring(0, path.lastIndexOf("/")) || "/";
+      if (parentDir !== "/") {
+        await this.bash.exec(`mkdir -p "${parentDir}"`);
+      }
+
+      await this.bash.writeFile(path, data);
+    }
+  }
+
+  async readFile(path: string, encoding?: "utf-8" | "base64"): Promise<string> {
+    const content = await this.bash.readFile(path);
+    if (encoding === "base64") {
+      return Buffer.from(content).toString("base64");
+    }
+    return content;
+  }
+
+  async mkdir(path: string, opts?: { recursive?: boolean }): Promise<void> {
+    const flags = opts?.recursive ? "-p " : "";
+    await this.bash.exec(`mkdir ${flags}"${path}"`);
+  }
+
+  async stop(): Promise<void> {
+    // No-op for just-bash
+  }
+
+  /**
+   * Get the underlying Bash instance for advanced operations.
+   */
+  get bashInstance(): Bash {
+    return this.bash;
+  }
+}

--- a/src/sandbox/providers/vercel-provider.ts
+++ b/src/sandbox/providers/vercel-provider.ts
@@ -1,0 +1,153 @@
+/**
+ * VercelProvider - SandboxProvider implementation using @vercel/sandbox.
+ * This provider runs commands in a real VM with full binary execution support.
+ *
+ * Note: @vercel/sandbox is a peer dependency and must be installed separately.
+ */
+
+import type {
+  ExecOptions,
+  ExecResult,
+  FileInput,
+  SandboxProvider,
+} from "../provider.js";
+
+export interface VercelProviderOptions {
+  /**
+   * Current working directory.
+   */
+  cwd?: string;
+
+  /**
+   * Environment variables.
+   */
+  env?: Record<string, string>;
+
+  /**
+   * Timeout in milliseconds.
+   */
+  timeoutMs?: number;
+}
+
+// Type definitions for @vercel/sandbox (to avoid hard dependency)
+interface VercelSandbox {
+  runCommand(
+    cmd: string,
+    opts?: { cwd?: string; env?: Record<string, string> },
+  ): Promise<VercelCommand>;
+  writeFiles(
+    files: Record<string, string | { content: string; encoding?: string }>,
+  ): Promise<void>;
+  readFile(path: string, encoding?: string): Promise<string>;
+  stop(): Promise<void>;
+}
+
+interface VercelCommand {
+  wait(): Promise<{ exitCode: number }>;
+  stdout(): Promise<string>;
+  stderr(): Promise<string>;
+}
+
+interface VercelSandboxModule {
+  Sandbox: {
+    create(opts?: {
+      cwd?: string;
+      env?: Record<string, string>;
+      timeoutMs?: number;
+    }): Promise<VercelSandbox>;
+  };
+}
+
+export class VercelProvider implements SandboxProvider {
+  private vm: VercelSandbox | null = null;
+  private options: VercelProviderOptions;
+  private initPromise: Promise<void> | null = null;
+
+  constructor(options: VercelProviderOptions = {}) {
+    this.options = options;
+  }
+
+  private async ensureInitialized(): Promise<VercelSandbox> {
+    if (this.vm) {
+      return this.vm;
+    }
+
+    if (!this.initPromise) {
+      this.initPromise = this.initialize();
+    }
+
+    await this.initPromise;
+    // After initialize(), this.vm is guaranteed to be set
+    // biome-ignore lint/style/noNonNullAssertion: vm is set by initialize()
+    return this.vm!;
+  }
+
+  private async initialize(): Promise<void> {
+    let vercelSandbox: VercelSandboxModule;
+    try {
+      // Dynamic import - @vercel/sandbox is a peer dependency
+      // @ts-expect-error - @vercel/sandbox is optional peer dependency
+      vercelSandbox = (await import("@vercel/sandbox")) as VercelSandboxModule;
+    } catch {
+      throw new Error(
+        "Failed to import @vercel/sandbox. Install it with: pnpm add @vercel/sandbox",
+      );
+    }
+
+    this.vm = await vercelSandbox.Sandbox.create({
+      cwd: this.options.cwd,
+      env: this.options.env,
+      timeoutMs: this.options.timeoutMs,
+    });
+  }
+
+  async exec(cmd: string, opts?: ExecOptions): Promise<ExecResult> {
+    const vm = await this.ensureInitialized();
+    const command = await vm.runCommand(cmd, opts);
+    const finished = await command.wait();
+    return {
+      stdout: await command.stdout(),
+      stderr: await command.stderr(),
+      exitCode: finished.exitCode,
+    };
+  }
+
+  async writeFiles(files: Record<string, FileInput>): Promise<void> {
+    const vm = await this.ensureInitialized();
+    // Convert to @vercel/sandbox format
+    const converted: Record<
+      string,
+      string | { content: string; encoding?: string }
+    > = {};
+    for (const [path, content] of Object.entries(files)) {
+      if (typeof content === "string") {
+        converted[path] = content;
+      } else {
+        converted[path] = {
+          content: content.content,
+          encoding: content.encoding,
+        };
+      }
+    }
+    await vm.writeFiles(converted);
+  }
+
+  async readFile(path: string, encoding?: "utf-8" | "base64"): Promise<string> {
+    const vm = await this.ensureInitialized();
+    return vm.readFile(path, encoding);
+  }
+
+  async mkdir(path: string, opts?: { recursive?: boolean }): Promise<void> {
+    const vm = await this.ensureInitialized();
+    const flags = opts?.recursive ? "-p " : "";
+    await vm.runCommand(`mkdir ${flags}"${path}"`);
+  }
+
+  async stop(): Promise<void> {
+    if (this.vm) {
+      await this.vm.stop();
+      this.vm = null;
+      this.initPromise = null;
+    }
+  }
+}


### PR DESCRIPTION
refactors the createBashTool to return an object containing the tool, to make it easier to expose the underlying filesystem (sandbox vs in memory)