### PR TITLE
Change mount dir to /, which always exists

### DIFF
--- a/src/cli/just-bash.test.ts
+++ b/src/cli/just-bash.test.ts
@@ -292,33 +292,29 @@ describe("just-bash CLI", () => {
   });
 
   describe("mount point behavior", () => {
-    it("should mount files at /home/user/project", () => {
+    it("should mount files at /", () => {
       fs.writeFileSync(path.join(tempDir, "test.txt"), "mounted");
-      const result = runCli([
-        "-c",
-        "'cat /home/user/project/test.txt'",
-        "--root",
-        tempDir,
-      ]);
+      const result = runCli(["-c", "'cat /test.txt'", "--root", tempDir]);
       expect(result.stdout).toBe("mounted");
       expect(result.exitCode).toBe(0);
     });
 
     it("should set cwd to mount point by default", () => {
       const result = runCli(["-c", "'pwd'", "--root", tempDir]);
-      expect(result.stdout.trim()).toBe("/home/user/project");
+      expect(result.stdout.trim()).toBe("/");
     });
 
     it("should allow --cwd to override working directory", () => {
+      fs.mkdirSync(path.join(tempDir, "subdir"));
       const result = runCli([
         "-c",
         "'pwd'",
         "--root",
         tempDir,
         "--cwd",
-        "/tmp",
+        "/subdir",
       ]);
-      expect(result.stdout.trim()).toBe("/tmp");
+      expect(result.stdout.trim()).toBe("/subdir");
     });
   });
 

--- a/src/cli/just-bash.ts
+++ b/src/cli/just-bash.ts
@@ -79,7 +79,7 @@ Security:
   - No network access
 
 Filesystem:
-  The root directory is mounted at /home/user/project in the virtual filesystem.
+  The root directory is mounted at / in the virtual filesystem.
   The working directory starts at this mount point.
 
 Examples:
@@ -264,7 +264,7 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Create OverlayFS - files are mounted at /home/user/project by default
+  // Create OverlayFS - files are mounted at / by default
   // Read-only by default for security (use --allow-write to enable writes)
   const fs = new OverlayFs({
     root: options.root,

--- a/src/fs/overlay-fs/overlay-fs.test.ts
+++ b/src/fs/overlay-fs/overlay-fs.test.ts
@@ -38,9 +38,9 @@ describe("OverlayFs", () => {
   });
 
   describe("mount point", () => {
-    it("should default to /home/user/project", () => {
+    it("should default to /", () => {
       const overlay = new OverlayFs({ root: tempDir });
-      expect(overlay.getMountPoint()).toBe("/home/user/project");
+      expect(overlay.getMountPoint()).toBe("/");
     });
 
     it("should allow custom mount point", () => {
@@ -52,13 +52,16 @@ describe("OverlayFs", () => {
       fs.writeFileSync(path.join(tempDir, "test.txt"), "content");
       const overlay = new OverlayFs({ root: tempDir });
 
-      const content = await overlay.readFile("/home/user/project/test.txt");
+      const content = await overlay.readFile("/test.txt");
       expect(content).toBe("content");
     });
 
-    it("should not read files outside mount point", async () => {
+    it("should not read files outside custom mount point", async () => {
       fs.writeFileSync(path.join(tempDir, "test.txt"), "content");
-      const overlay = new OverlayFs({ root: tempDir });
+      const overlay = new OverlayFs({
+        root: tempDir,
+        mountPoint: "/home/user/project",
+      });
 
       await expect(overlay.readFile("/test.txt")).rejects.toThrow("ENOENT");
     });
@@ -68,13 +71,16 @@ describe("OverlayFs", () => {
       fs.writeFileSync(path.join(tempDir, "b.txt"), "b");
       const overlay = new OverlayFs({ root: tempDir });
 
-      const entries = await overlay.readdir("/home/user/project");
+      const entries = await overlay.readdir("/");
       expect(entries).toContain("a.txt");
       expect(entries).toContain("b.txt");
     });
 
-    it("should create mount point parent directories", async () => {
-      const overlay = new OverlayFs({ root: tempDir });
+    it("should create mount point parent directories for custom mount", async () => {
+      const overlay = new OverlayFs({
+        root: tempDir,
+        mountPoint: "/home/user/project",
+      });
 
       expect(await overlay.exists("/home")).toBe(true);
       expect(await overlay.exists("/home/user")).toBe(true);

--- a/src/fs/overlay-fs/overlay-fs.ts
+++ b/src/fs/overlay-fs/overlay-fs.ts
@@ -55,7 +55,7 @@ export interface OverlayFsOptions {
 
   /**
    * The virtual mount point where the root directory appears.
-   * Defaults to "/home/user/project".
+   * Defaults to "/".
    */
   mountPoint?: string;
 
@@ -68,7 +68,7 @@ export interface OverlayFsOptions {
 }
 
 /** Default mount point for OverlayFs */
-const DEFAULT_MOUNT_POINT = "/home/user/project";
+const DEFAULT_MOUNT_POINT = "/";
 
 export class OverlayFs implements IFileSystem {
   private readonly root: string;


### PR DESCRIPTION
previously the FS would mount /home/user/project, and that would lead the agent to literally `/home/user/project`