### PR TITLE
Fix subshell function isolation and add hardlink security tests

### DIFF
--- a/src/interpreter/subshell-group.ts
+++ b/src/interpreter/subshell-group.ts
@@ -63,6 +63,13 @@ export async function executeSubshell(
   // Save options so subshell changes (like set -e) don't affect parent
   const savedOptions = { ...ctx.state.options };
 
+  // Save functions so subshell definitions don't leak to parent
+  // This is critical for proper subshell isolation - in real bash, function
+  // definitions inside (...) are isolated and don't affect the parent shell
+  // Note: Aliases are stored in env with BASH_ALIAS_ prefix, so they're
+  // already isolated via savedEnv
+  const savedFunctions = new Map(ctx.state.functions);
+
   // Save local variable scoping state for subshell isolation
   // Subshell gets a copy of these, but changes don't affect parent
   const savedLocalScopes = ctx.state.localScopes;
@@ -116,6 +123,7 @@ export async function executeSubshell(
     ctx.state.env = savedEnv;
     ctx.state.cwd = savedCwd;
     ctx.state.options = savedOptions;
+    ctx.state.functions = savedFunctions;
     ctx.state.localScopes = savedLocalScopes;
     ctx.state.localVarStack = savedLocalVarStack;
     ctx.state.localVarDepth = savedLocalVarDepth;

--- a/src/security/sandbox/sandbox-escape.test.ts
+++ b/src/security/sandbox/sandbox-escape.test.ts
@@ -222,9 +222,9 @@ describe("Sandbox Escape Prevention", () => {
       expect(result.stdout).not.toMatch(/outer:.*subdir/);
     });
 
-    it("should define and call functions in subshell", async () => {
-      // Note: In just-bash, function definitions may leak out of subshells
-      // (differs from real bash behavior where subshells isolate functions)
+    it("should isolate function definitions in subshell", async () => {
+      // Functions defined in subshells should NOT leak to parent scope
+      // This matches real bash behavior
       const result = await bash.exec(`
         (
           myfunc() { echo "defined"; }
@@ -233,8 +233,8 @@ describe("Sandbox Escape Prevention", () => {
         myfunc 2>/dev/null || echo "not defined"
       `);
       expect(result.exitCode).toBe(0);
-      // Function leaks out in just-bash implementation
-      expect(result.stdout).toBe("defined\ndefined\n");
+      // Function should be isolated to subshell - not callable from parent
+      expect(result.stdout).toBe("defined\nnot defined\n");
     });
   });
 


### PR DESCRIPTION
  Security fix: Functions defined inside subshells (...) now properly
  isolate and don't leak to the parent scope, matching real bash behavior.

  Previously, `(myfunc() { ... }); myfunc` would incorrectly succeed
  because function definitions leaked out of subshells. Now the function
  is correctly isolated and the outer call fails as expected.

  Fix: Save and restore ctx.state.functions in executeSubshell().
  Note: Aliases already isolated via env (BASH_ALIAS_ prefix).

  Also adds 11 comprehensive hardlink security tests to OverlayFS:
  - Hardlinks can't reference files outside overlay
  - Hardlinks use copy semantics (no shared content)
  - Path traversal blocked in source/destination
  - Null byte validation
  - Directory hardlinks rejected
  - Symlink-to-outside hardlinks blocked