### PR TITLE
fix(python3): set explicit pyodide indexURL in worker

### DIFF
--- a/src/commands/python3/python3.node-import.test.ts
+++ b/src/commands/python3/python3.node-import.test.ts
@@ -1,0 +1,54 @@
+import { execFile } from "node:child_process";
+import { resolve } from "node:path";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const binPath = resolve(__dirname, "../../../dist/bin/just-bash.js");
+
+function withSourceMapsEnabled(): NodeJS.ProcessEnv {
+  const existingNodeOptions = process.env.NODE_OPTIONS?.trim();
+  const nodeOptions = existingNodeOptions
+    ? `${existingNodeOptions} --enable-source-maps`
+    : "--enable-source-maps";
+
+  return {
+    ...process.env,
+    NODE_OPTIONS: nodeOptions,
+  };
+}
+
+async function runNode(
+  args: string[],
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  try {
+    const { stdout, stderr } = await execFileAsync("node", args, { env });
+    return { stdout, stderr, exitCode: 0 };
+  } catch (error: unknown) {
+    const e = error as { stdout?: string; stderr?: string; code?: number };
+    return {
+      stdout: e.stdout ?? "",
+      stderr: e.stderr ?? "",
+      exitCode: e.code ?? 1,
+    };
+  }
+}
+
+describe("python3 node import behavior", () => {
+  it(
+    "should execute python3 through just-bash with source maps enabled",
+    { timeout: 60000 },
+    async () => {
+      const sourceMapEnv = withSourceMapsEnabled();
+      const result = await runNode(
+        [binPath, "--python", "-c", 'python3 -c "print(1 + 2)"'],
+        sourceMapEnv,
+      );
+
+      expect(result.stdout).toBe("3\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    },
+  );
+});

--- a/src/commands/python3/worker.ts
+++ b/src/commands/python3/worker.ts
@@ -6,6 +6,8 @@
  * User Python code runs with dangerous globals blocked.
  */
 
+import { createRequire } from "node:module";
+import { dirname } from "node:path";
 import { parentPort, workerData } from "node:worker_threads";
 import { loadPyodide, type PyodideInterface } from "pyodide";
 import {
@@ -32,6 +34,8 @@ export interface WorkerOutput {
 
 let pyodideInstance: PyodideInterface | null = null;
 let pyodideLoading: Promise<PyodideInterface> | null = null;
+const require = createRequire(import.meta.url);
+const pyodideIndexURL = `${dirname(require.resolve("pyodide/pyodide.mjs"))}/`;
 
 async function getPyodide(): Promise<PyodideInterface> {
   if (pyodideInstance) {
@@ -40,7 +44,7 @@ async function getPyodide(): Promise<PyodideInterface> {
   if (pyodideLoading) {
     return pyodideLoading;
   }
-  pyodideLoading = loadPyodide();
+  pyodideLoading = loadPyodide({ indexURL: pyodideIndexURL });
   pyodideInstance = await pyodideLoading;
   return pyodideInstance;
 }


### PR DESCRIPTION
## Summary
- set an explicit `indexURL` when calling `loadPyodide()` in the python3 worker
- infer the index path from `require.resolve('pyodide/pyodide.mjs')` so source-map stack rewriting cannot mis-resolve assets
- add a minimal regression test that verifies `just-bash --python` works with `NODE_OPTIONS=--enable-source-maps`

## Why
Issue #94 Pyodide's implicit index inference can break under Node source maps (for example in Next.js dev), causing worker startup failures and Python timeouts. Passing an explicit `indexURL` removes that ambiguity.

## Validation
- `pnpm lint:fix`
- `pnpm knip`
- `pnpm typecheck`
- `pnpm test:run`
