### PR TITLE
Add grep -f flag to read patterns from file

### DIFF
--- a/.changeset/cold-grapes-like.md
+++ b/.changeset/cold-grapes-like.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add `grep -f FILE` flag to read patterns from a file (one per line)

--- a/packages/just-bash/src/commands/grep/grep.basic.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.basic.test.ts
@@ -739,4 +739,145 @@ describe("grep", () => {
       expect(result.stdout).toBe("!@#\n");
     });
   });
+
+  describe("-f flag (patterns from file)", () => {
+    it("should read a single pattern from file", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "hello\n",
+          "/data.txt": "hello world\nfoo bar\nhello again\n",
+        },
+      });
+      const result = await env.exec("grep -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello world\nhello again\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should read multiple patterns from file", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "hello\nbar\n",
+          "/data.txt": "hello world\nfoo bar\nbaz qux\n",
+        },
+      });
+      const result = await env.exec("grep -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello world\nfoo bar\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should work with -F for fixed string matching", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "hello\n",
+          "/data.txt": "hello2\nhello\nworld\n",
+        },
+      });
+      const result = await env.exec("grep -F -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello2\nhello\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should work with -F and multiple patterns from file", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "foo.bar\nbaz*qux\n",
+          "/data.txt": "foo.bar\nfooXbar\nbaz*qux\nbazqux\n",
+        },
+      });
+      const result = await env.exec("grep -F -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("foo.bar\nbaz*qux\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should work with -i for case-insensitive matching", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "hello\n",
+          "/data.txt": "Hello\nHELLO\nworld\n",
+        },
+      });
+      const result = await env.exec("grep -i -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("Hello\nHELLO\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should error when pattern file does not exist", async () => {
+      const env = new Bash({
+        files: { "/data.txt": "hello\n" },
+      });
+      const result = await env.exec("grep -f /missing.txt /data.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "grep: /missing.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(2);
+    });
+
+    it("should work with --file= long form", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "hello\n",
+          "/data.txt": "hello world\nfoo bar\n",
+        },
+      });
+      const result = await env.exec("grep --file=/patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello world\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should produce no output for empty pattern file", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "",
+          "/data.txt": "hello world\nfoo bar\n",
+        },
+      });
+      const result = await env.exec("grep -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should match every line when pattern file contains a blank line", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "\n",
+          "/data.txt": "hello world\nfoo bar\n",
+        },
+      });
+      const result = await env.exec("grep -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello world\nfoo bar\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should match every line when pattern file mixes blank and real patterns", async () => {
+      const env = new Bash({
+        files: {
+          "/patterns.txt": "foo\n\nbar\n",
+          "/data.txt": "hello world\nfoo bar\nbaz qux\n",
+        },
+      });
+      const result = await env.exec("grep -f /patterns.txt /data.txt");
+      expect(result.stdout).toBe("hello world\nfoo bar\nbaz qux\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should match the exact issue #166 scenario", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'echo "hello" > a.txt; echo "hello2" > b.txt; grep -F -f a.txt b.txt',
+      );
+      expect(result.stdout).toBe("hello2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
 });

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -36,6 +36,7 @@ const grepHelp = {
     "-B NUM                   print NUM lines of leading context",
     "-C NUM                   print NUM lines of context",
     "-e PATTERN               use PATTERN for matching",
+    "-f FILE, --file=FILE     obtain patterns from FILE",
     "    --include=GLOB       search only files matching GLOB",
     "    --exclude=GLOB       skip files matching GLOB",
     "    --exclude-dir=DIR    skip directories matching DIR",
@@ -73,6 +74,7 @@ export const grepCommand: Command = {
     const excludePatterns: string[] = [];
     const excludeDirPatterns: string[] = [];
     let pattern: string | null = null;
+    let patternFile: string | null = null;
     const files: string[] = [];
 
     // Parse arguments
@@ -82,6 +84,19 @@ export const grepCommand: Command = {
       if (arg.startsWith("-") && arg !== "-") {
         if (arg === "-e" && i + 1 < args.length) {
           pattern = args[++i];
+          continue;
+        }
+
+        if (arg === "-f" && i + 1 < args.length) {
+          patternFile = args[++i];
+          continue;
+        }
+        if (arg.startsWith("--file=")) {
+          patternFile = arg.slice("--file=".length);
+          continue;
+        }
+        if (arg === "--file" && i + 1 < args.length) {
+          patternFile = args[++i];
           continue;
         }
 
@@ -175,16 +190,48 @@ export const grepCommand: Command = {
           else if (flag === "h" || flag === "--no-filename") noFilename = true;
           else if (flag === "q" || flag === "--quiet" || flag === "--silent")
             quietMode = true;
-          else if (flag.startsWith("--")) {
+          else if (flag === "f" || flag === "--file") {
+            if (i + 1 < args.length) {
+              patternFile = args[++i];
+            } else {
+              return unknownOption("grep", `-${flag}`);
+            }
+            break;
+          } else if (flag.startsWith("--")) {
             return unknownOption("grep", flag);
           } else if (flag.length === 1) {
             return unknownOption("grep", `-${flag}`);
           }
         }
-      } else if (pattern === null) {
+      } else if (pattern === null && patternFile === null) {
         pattern = arg;
       } else {
         files.push(arg);
+      }
+    }
+
+    if (patternFile !== null) {
+      try {
+        const filePath = ctx.fs.resolvePath(ctx.cwd, patternFile);
+        const content = await ctx.fs.readFile(filePath);
+        // Split into patterns. A trailing newline is a pattern terminator,
+        // not a separator, so drop the empty element it produces. Remaining
+        // empty lines are kept — they are empty patterns that match every
+        // line (matching real grep).
+        const lines = content.split("\n");
+        if (lines.length > 0 && lines[lines.length - 1] === "") {
+          lines.pop();
+        }
+        if (lines.length === 0) {
+          return { stdout: "", stderr: "", exitCode: 1 };
+        }
+        pattern = lines.join("\n");
+      } catch {
+        return {
+          stdout: "",
+          stderr: `grep: ${patternFile}: No such file or directory\n`,
+          exitCode: 2,
+        };
       }
     }
 
@@ -194,6 +241,25 @@ export const grepCommand: Command = {
         stderr: "grep: missing pattern\n",
         exitCode: 2,
       };
+    }
+
+    // Handle newline-separated patterns (from -f or embedded newlines).
+    // Each line is a separate pattern; a line matches if any pattern matches.
+    // Empty lines are preserved — they are empty patterns that match every
+    // line (matching real grep).
+    if (pattern.includes("\n")) {
+      const patterns = pattern.split("\n");
+      if (fixedStrings) {
+        pattern = patterns
+          .map((p) => p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+          .join("|");
+      } else {
+        pattern = patterns.map((p) => `(?:${p})`).join("|");
+      }
+      fixedStrings = false;
+      if (!perlRegex) {
+        extendedRegex = true;
+      }
     }
 
     // Build regex using shared search-engine
@@ -718,6 +784,7 @@ export const flagsForFuzzing: CommandFuzzInfo = {
     { flag: "-B", type: "value", valueHint: "number" },
     { flag: "-C", type: "value", valueHint: "number" },
     { flag: "-e", type: "value", valueHint: "pattern" },
+    { flag: "-f", type: "value", valueHint: "path" },
   ],
   stdinType: "text",
   needsArgs: true,


### PR DESCRIPTION
`grep -F -f a.txt b.txt` fails with "invalid option -- 'f'":

```
$ echo "hello" > a.txt
$ echo "hello2" > b.txt
$ grep -F -f a.txt b.txt
grep: invalid option -- 'f'
```

This adds the `-f FILE` flag, which reads patterns from a file
(one per line) and treats them as alternation.

Fixes #166