### PR TITLE
Make MountableFs available to browser environments

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -41,6 +41,11 @@ export type {
   RmOptions,
   SymlinkEntry,
 } from "./fs/interface.js";
+export {
+  MountableFs,
+  type MountableFsOptions,
+  type MountConfig,
+} from "./fs/mountable-fs/index.js";
 export type { NetworkConfig } from "./network/index.js";
 export {
   NetworkAccessDeniedError,


### PR DESCRIPTION
We need MountableFs in browser environments but it's currently only exported from the main entry point, which Vite/bundlers resolve to the browser bundle where it's missing. Unlike OverlayFs and ReadWriteFs, MountableFs doesn't have any Node.js dependencies so it should be safe to include in the browser export.

We currently have a patch to enable this, but would be nice to remove that.