### PR TITLE
fix: handle Windows backslash separators in isPathWithinRoot

### DIFF
--- a/src/fs/real-fs-utils.test.ts
+++ b/src/fs/real-fs-utils.test.ts
@@ -132,6 +132,15 @@ describe("isPathWithinRoot", () => {
     expect(isPathWithinRoot("/tmp/datastore", "/tmp/data")).toBe(false);
     expect(isPathWithinRoot("/tmp/data/file", "/tmp/data")).toBe(true);
   });
+
+  it("handles Windows backslash separators", () => {
+    expect(isPathWithinRoot("D:\\project\\file.txt", "D:\\project")).toBe(true);
+    expect(isPathWithinRoot("D:\\project\\a\\b", "D:\\project")).toBe(true);
+    expect(isPathWithinRoot("D:\\project", "D:\\project")).toBe(true);
+    // boundary attack with backslash
+    expect(isPathWithinRoot("D:\\projects", "D:\\project")).toBe(false);
+    expect(isPathWithinRoot("D:\\project-evil", "D:\\project")).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/fs/real-fs-utils.ts
+++ b/src/fs/real-fs-utils.ts
@@ -25,7 +25,9 @@ export function isPathWithinRoot(
   resolved: string,
   canonicalRoot: string,
 ): boolean {
-  return resolved === canonicalRoot || resolved.startsWith(`${canonicalRoot}/`);
+  if (resolved === canonicalRoot) return true;
+  const sep = resolved[canonicalRoot.length];
+  return (sep === "/" || sep === "\\") && resolved.startsWith(canonicalRoot);
 }
 
 /**
@@ -213,7 +215,8 @@ export function sanitizeSymlinkTarget(
   }
 
   if (isPathWithinRoot(resolved, canonicalRoot)) {
-    const relativePath = resolved.slice(canonicalRoot.length) || "/";
+    const relativePath =
+      resolved.slice(canonicalRoot.length).replace(/\\/g, "/") || "/";
     return { withinRoot: true, relativePath };
   }
 


### PR DESCRIPTION
On Windows, path.join() / path.resolve() produce paths with backslash separators. isPathWithinRoot() hardcoded '/' in its startsWith check, causing every stat/read/write on OverlayFs to ENOENT on Windows.

- Accept both '/' and '\' as valid separators after the root prefix
- Normalize backslash to '/' in sanitizeSymlinkTarget relativePath
- Add Windows backslash test cases for isPathWithinRoot