### PR TITLE
Add per-URL method restrictions to network allow-list

### DIFF
--- a/src/network/allow-list.ts
+++ b/src/network/allow-list.ts
@@ -119,6 +119,19 @@ function entryToUrl(entry: AllowedUrlEntry): string {
 }
 
 /**
+ * Finds the first allow-list entry that matches the given URL.
+ * Returns the matching entry (string or AllowedUrl object), or undefined.
+ */
+export function findMatchingEntry(
+  url: string,
+  allowedUrlPrefixes: AllowedUrlEntry[],
+): AllowedUrlEntry | undefined {
+  return allowedUrlPrefixes.find((entry) =>
+    matchesAllowListEntry(url, entryToUrl(entry)),
+  );
+}
+
+/**
  * Checks if a URL is allowed by any entry in the allow-list.
  *
  * @param url The URL to check
@@ -456,6 +469,26 @@ export function validateAllowList(
       errors.push(
         `Query strings and fragments are ignored in allow-list entries: "${entry}"`,
       );
+    }
+
+    // Validate per-URL methods field
+    if (typeof rawEntry === "object" && rawEntry.methods) {
+      const validMethods = new Set([
+        "GET",
+        "HEAD",
+        "POST",
+        "PUT",
+        "DELETE",
+        "PATCH",
+        "OPTIONS",
+      ]);
+      for (const m of rawEntry.methods) {
+        if (typeof m !== "string" || !validMethods.has(m)) {
+          errors.push(
+            `Invalid HTTP method "${m}" in allow-list entry for "${rawEntry.url}"`,
+          );
+        }
+      }
     }
   }
 

--- a/src/network/allow-list/e2e.test.ts
+++ b/src/network/allow-list/e2e.test.ts
@@ -459,6 +459,107 @@ function runAllowListTests(name: string, createAdapter: AdapterFactory) {
       });
     });
 
+    describe("per-URL methods", () => {
+      it("restricts methods on a per-URL basis", async () => {
+        const env = await createAdapter({
+          network: {
+            allowedUrlPrefixes: [
+              { url: "https://api.example.com", methods: ["GET"] },
+            ],
+            allowedMethods: ["GET", "POST"],
+          },
+        });
+
+        const r1 = await env.exec("curl https://api.example.com/data");
+        expect(r1.exitCode).toBe(0);
+        expect(r1.stdout).toBe(MOCK_SUCCESS_BODY);
+        expect(r1.stderr).toBe("");
+
+        const r2 = await env.exec("curl -X POST https://api.example.com/data");
+        expect(r2.exitCode).toBe(3);
+        expect(r2.stdout).toBe("");
+        expect(r2.stderr).toBe(
+          "curl: (3) HTTP method 'POST' not allowed. Allowed methods: GET\n",
+        );
+      });
+
+      it("falls back to global allowedMethods when entry has no methods", async () => {
+        const env = await createAdapter({
+          network: {
+            allowedUrlPrefixes: [
+              "https://api.example.com",
+              { url: "https://cdn.example.com", methods: ["GET"] },
+            ],
+            allowedMethods: ["GET", "POST"],
+          },
+        });
+
+        // Plain string entry uses global methods — POST allowed
+        const r1 = await env.exec("curl -X POST https://api.example.com/data");
+        expect(r1.exitCode).toBe(0);
+        expect(r1.stdout).toBe(MOCK_SUCCESS_BODY);
+        expect(r1.stderr).toBe("");
+
+        // Object entry with per-URL methods — POST blocked
+        const r2 = await env.exec(
+          "curl -X POST https://cdn.example.com/file.txt",
+        );
+        expect(r2.exitCode).toBe(3);
+        expect(r2.stdout).toBe("");
+        expect(r2.stderr).toBe(
+          "curl: (3) HTTP method 'POST' not allowed. Allowed methods: GET\n",
+        );
+      });
+
+      it("per-URL methods work with GET default", async () => {
+        const env = await createAdapter({
+          network: {
+            allowedUrlPrefixes: [
+              { url: "https://api.example.com", methods: ["GET", "POST"] },
+            ],
+          },
+        });
+
+        // POST allowed by per-URL methods even though global default is GET, HEAD
+        const r1 = await env.exec("curl -X POST https://api.example.com/data");
+        expect(r1.exitCode).toBe(0);
+        expect(r1.stdout).toBe(MOCK_SUCCESS_BODY);
+        expect(r1.stderr).toBe("");
+      });
+
+      it("blocks redirect when target has stricter per-URL methods", async () => {
+        const env = await createAdapter({
+          network: {
+            allowedUrlPrefixes: [
+              {
+                url: "https://api.example.com/redirect-to-allowed",
+                methods: ["GET", "POST"],
+              },
+              { url: "https://api.example.com/data", methods: ["GET"] },
+            ],
+          },
+        });
+
+        // GET follows redirect and succeeds — both entries allow GET
+        const r1 = await env.exec(
+          "curl https://api.example.com/redirect-to-allowed",
+        );
+        expect(r1.exitCode).toBe(0);
+        expect(r1.stdout).toBe(MOCK_SUCCESS_BODY);
+        expect(r1.stderr).toBe("");
+
+        // POST is allowed on the source but not on the redirect target
+        const r2 = await env.exec(
+          "curl -X POST https://api.example.com/redirect-to-allowed",
+        );
+        expect(r2.exitCode).toBe(47);
+        expect(r2.stdout).toBe("");
+        expect(r2.stderr).toBe(
+          "curl: (47) Redirect target not in allow-list: https://api.example.com/data\n",
+        );
+      });
+    });
+
     describe("curl with file output", () => {
       it("writes to file only for allowed URLs", async () => {
         const env = await createAdapter({

--- a/src/network/allow-list/unit.test.ts
+++ b/src/network/allow-list/unit.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  findMatchingEntry,
   isPrivateIp,
   isUrlAllowed,
   matchesAllowListEntry,
@@ -470,6 +471,53 @@ describe("validateAllowList", () => {
       ]);
       expect(errors).toHaveLength(3);
     });
+  });
+
+  describe("per-URL methods validation", () => {
+    it("accepts valid methods on AllowedUrl entries", () => {
+      const errors = validateAllowList([
+        { url: "https://api.example.com", methods: ["GET", "POST"] },
+      ]);
+      expect(errors).toEqual([]);
+    });
+
+    it("rejects invalid method strings", () => {
+      const methods = [
+        "GET",
+        "INVALID",
+      ] as unknown as import("../types.js").HttpMethod[];
+      const errors = validateAllowList([
+        { url: "https://api.example.com", methods },
+      ]);
+      expect(errors).toHaveLength(1);
+      expect(errors[0]).toContain('Invalid HTTP method "INVALID"');
+    });
+
+    it("accepts entries without methods field", () => {
+      const errors = validateAllowList([{ url: "https://api.example.com" }]);
+      expect(errors).toEqual([]);
+    });
+  });
+});
+
+describe("findMatchingEntry", () => {
+  it("returns the matching string entry", () => {
+    const entries = ["https://api.example.com", "https://cdn.example.com"];
+    const result = findMatchingEntry("https://api.example.com/data", entries);
+    expect(result).toBe("https://api.example.com");
+  });
+
+  it("returns the matching AllowedUrl entry", () => {
+    const entry = { url: "https://api.example.com", methods: ["GET" as const] };
+    const result = findMatchingEntry("https://api.example.com/data", [entry]);
+    expect(result).toBe(entry);
+  });
+
+  it("returns undefined when no entry matches", () => {
+    const result = findMatchingEntry("https://evil.com/data", [
+      "https://api.example.com",
+    ]);
+    expect(result).toBeUndefined();
   });
 });
 

--- a/src/network/fetch.ts
+++ b/src/network/fetch.ts
@@ -11,6 +11,7 @@ import { lookup as dnsLookup } from "node:dns";
 import { DefenseInDepthBox } from "../security/defense-in-depth-box.js";
 import { _clearTimeout, _setTimeout } from "../timers.js";
 import {
+  findMatchingEntry,
   isPrivateIp,
   isUrlAllowed,
   matchesAllowListEntry,
@@ -196,17 +197,32 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
   }
 
   /**
-   * Checks if an HTTP method is allowed by the configuration.
+   * Returns the effective allowed methods for a URL. If the matching
+   * allow-list entry specifies per-URL methods, those are used;
+   * otherwise falls back to the global allowedMethods.
+   */
+  function getEffectiveMethods(url: string): HttpMethod[] {
+    if (config.dangerouslyAllowFullInternetAccess)
+      return allowedMethods as HttpMethod[];
+    const entry = findMatchingEntry(url, entries);
+    if (entry && typeof entry === "object" && entry.methods) {
+      return entry.methods;
+    }
+    return allowedMethods as HttpMethod[];
+  }
+
+  /**
+   * Checks if an HTTP method is allowed for the given URL.
    * @throws MethodNotAllowedError if the method is not allowed
    */
-  function checkMethodAllowed(method: string): void {
+  function checkMethodAllowed(method: string, effective: HttpMethod[]): void {
     if (config.dangerouslyAllowFullInternetAccess) {
       return;
     }
 
     const upperMethod = method.toUpperCase();
-    if (!allowedMethods.includes(upperMethod as HttpMethod)) {
-      throw new MethodNotAllowedError(upperMethod, allowedMethods);
+    if (!effective.includes(upperMethod as HttpMethod)) {
+      throw new MethodNotAllowedError(upperMethod, effective);
     }
   }
 
@@ -221,7 +237,7 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
 
     // Check if URL and method are allowed
     await checkAllowed(url);
-    checkMethodAllowed(method);
+    checkMethodAllowed(method, getEffectiveMethods(url));
 
     let currentUrl = url;
     let redirectCount = 0;
@@ -279,9 +295,11 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
           // Resolve relative URLs
           const redirectUrl = new URL(location, currentUrl).href;
 
-          // Check redirect target against allow-list and private IP ranges
+          // Check redirect target against allow-list, private IP ranges,
+          // and per-URL method restrictions
           try {
             await checkAllowed(redirectUrl);
+            checkMethodAllowed(method, getEffectiveMethods(redirectUrl));
           } catch {
             throw new RedirectNotAllowedError(redirectUrl);
           }

--- a/src/network/types.ts
+++ b/src/network/types.ts
@@ -34,12 +34,17 @@ export interface RequestTransform {
 }
 
 /**
- * An allowed URL entry with optional header transforms.
+ * An allowed URL entry with optional header transforms and per-URL method restrictions.
  * Transforms are applied at the fetch boundary so secrets never enter the sandbox.
  */
 export interface AllowedUrl {
   url: string;
   transform?: RequestTransform[];
+  /**
+   * Allowed HTTP methods for this specific URL prefix.
+   * When set, overrides the global `allowedMethods` for requests matching this entry.
+   */
+  methods?: HttpMethod[];
 }
 
 /**


### PR DESCRIPTION
Fixes #163

Adds optional `methods` field to AllowedUrl entries — overrides the
global allowedMethods for that prefix. Also enforced on redirect targets.