### PR TITLE
feat(jq): add raw input mode

### DIFF
--- a/src/commands/jq/jq.raw-input.test.ts
+++ b/src/commands/jq/jq.raw-input.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("jq raw input (-R)", () => {
+  it("should read stdin lines as strings with -R", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\nb\\n' | jq -R '.'");
+    expect(result.stdout).toBe('"a"\n"b"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should preserve blank lines with -R", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\n\\nb' | jq -R '.'");
+    expect(result.stdout).toBe('"a"\n""\n"b"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp raw stdin into a single string with -Rs", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\nb\\n' | jq -Rs '.'");
+    expect(result.stdout).toBe('"a\\nb\\n"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should read raw input from files line by line", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "first\n",
+        "/b.txt": "second",
+      },
+    });
+    const result = await env.exec("jq -R '.' /a.txt /b.txt");
+    expect(result.stdout).toBe('"first"\n"second"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp raw input across files without inserting separators", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "first\n",
+        "/b.txt": "second",
+      },
+    });
+    const result = await env.exec("jq -Rs '.' /a.txt /b.txt");
+    expect(result.stdout).toBe('"first\\nsecond"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should handle stdin marker together with files in raw mode", async () => {
+    const env = new Bash({
+      files: {
+        "/file.txt": "file\n",
+      },
+    });
+    const result = await env.exec("printf 'stdin\\n' | jq -R '.' - /file.txt");
+    expect(result.stdout).toBe('"stdin"\n"file"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should allow raw input with raw output", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'hello\\n' | jq -Rr '.'");
+    expect(result.stdout).toBe("hello\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should produce no output for empty raw input", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf '' | jq -R '.'");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp empty raw input into an empty string", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf '' | jq -Rs '.'");
+    expect(result.stdout).toBe('""\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/src/commands/jq/jq.test.ts
+++ b/src/commands/jq/jq.test.ts
@@ -335,6 +335,7 @@ describe("jq", () => {
       const env = new Bash();
       const result = await env.exec("jq --help");
       expect(result.stdout).toMatch(/jq.*JSON/);
+      expect(result.stdout).toContain("-R, --raw-input");
       expect(result.exitCode).toBe(0);
     });
   });

--- a/src/commands/jq/jq.ts
+++ b/src/commands/jq/jq.ts
@@ -117,6 +117,7 @@ const jqHelp = {
   summary: "command-line JSON processor",
   usage: "jq [OPTIONS] FILTER [FILE]",
   options: [
+    "-R, --raw-input   read input as raw strings, not JSON",
     "-r, --raw-output  output strings without quotes",
     "-c, --compact     compact output (no pretty printing)",
     "-e, --exit-status set exit status based on output",
@@ -204,6 +205,7 @@ export const jqCommand: Command = {
     if (hasHelpFlag(args)) return showHelp(jqHelp);
 
     let raw = false;
+    let rawInput = false;
     let compact = false;
     let exitStatus = false;
     let slurp = false;
@@ -217,7 +219,8 @@ export const jqCommand: Command = {
 
     for (let i = 0; i < args.length; i++) {
       const a = args[i];
-      if (a === "-r" || a === "--raw-output") raw = true;
+      if (a === "-R" || a === "--raw-input") rawInput = true;
+      else if (a === "-r" || a === "--raw-output") raw = true;
       else if (a === "-c" || a === "--compact-output") compact = true;
       else if (a === "-e" || a === "--exit-status") exitStatus = true;
       else if (a === "-s" || a === "--slurp") slurp = true;
@@ -235,7 +238,8 @@ export const jqCommand: Command = {
       else if (a.startsWith("--")) return unknownOption("jq", a);
       else if (a.startsWith("-")) {
         for (const c of a.slice(1)) {
-          if (c === "r") raw = true;
+          if (c === "R") rawInput = true;
+          else if (c === "r") raw = true;
           else if (c === "c") compact = true;
           else if (c === "e") exitStatus = true;
           else if (c === "s") slurp = true;
@@ -300,6 +304,20 @@ export const jqCommand: Command = {
 
       if (nullInput) {
         values = evaluate(null, ast, evalOptions);
+      } else if (rawInput && slurp) {
+        const rawText = inputs.map(({ content }) => content).join("");
+        values = evaluate(rawText, ast, evalOptions);
+      } else if (rawInput) {
+        for (const { content } of inputs) {
+          const lines = content.split("\n");
+          if (lines.length > 0 && lines.at(-1) === "") {
+            lines.pop();
+          }
+
+          for (const line of lines) {
+            values.push(...evaluate(line, ast, evalOptions));
+          }
+        }
       } else if (slurp) {
         // Slurp mode: combine all inputs into single array
         // Use JSON stream parser to handle concatenated JSON (not just NDJSON)
@@ -390,6 +408,7 @@ import type { CommandFuzzInfo } from "../fuzz-flags-types.js";
 export const flagsForFuzzing: CommandFuzzInfo = {
   name: "jq",
   flags: [
+    { flag: "-R", type: "boolean" },
     { flag: "-r", type: "boolean" },
     { flag: "-c", type: "boolean" },
     { flag: "-e", type: "boolean" },

--- a/src/comparison-tests/fixtures/jq.raw-input.comparison.fixtures.json
+++ b/src/comparison-tests/fixtures/jq.raw-input.comparison.fixtures.json
@@ -1,0 +1,52 @@
+{
+  "352162774da404df": {
+    "command": "printf 'a\\n\\nb' | jq -R '.'",
+    "files": {},
+    "stdout": "\"a\"\n\"\"\n\"b\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3eccd43ed92a3c69": {
+    "command": "jq -Rs '.' a.txt b.txt",
+    "files": {
+      "a.txt": "first\n",
+      "b.txt": "second"
+    },
+    "stdout": "\"first\\nsecond\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4527747d8e92f72c": {
+    "command": "printf 'stdin\\n' | jq -R '.' - file.txt",
+    "files": {
+      "file.txt": "file\n"
+    },
+    "stdout": "\"stdin\"\n\"file\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4ef4020b99945f34": {
+    "command": "printf 'a\\nb\\n' | jq -Rs '.'",
+    "files": {},
+    "stdout": "\"a\\nb\\n\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ed6d0745a5d92cef": {
+    "command": "printf 'a\\nb\\n' | jq -R '.'",
+    "files": {},
+    "stdout": "\"a\"\n\"b\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ff334c372880449c": {
+    "command": "jq -R '.' a.txt b.txt",
+    "files": {
+      "a.txt": "first\n",
+      "b.txt": "second"
+    },
+    "stdout": "\"first\"\n\"second\"\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/src/comparison-tests/jq.raw-input.comparison.test.ts
+++ b/src/comparison-tests/jq.raw-input.comparison.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+describe("jq raw input - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  describe("stdin", () => {
+    it("should read stdin lines as strings with -R", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\nb\\n' | jq -R '.'");
+    });
+
+    it("should preserve blank lines with -R", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\n\\nb' | jq -R '.'");
+    });
+
+    it("should slurp raw stdin with -Rs", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\nb\\n' | jq -Rs '.'");
+    });
+  });
+
+  describe("files", () => {
+    it("should read files line by line with -R", async () => {
+      const env = await setupFiles(testDir, {
+        "a.txt": "first\n",
+        "b.txt": "second",
+      });
+      await compareOutputs(env, testDir, "jq -R '.' a.txt b.txt");
+    });
+
+    it("should slurp files without separators with -Rs", async () => {
+      const env = await setupFiles(testDir, {
+        "a.txt": "first\n",
+        "b.txt": "second",
+      });
+      await compareOutputs(env, testDir, "jq -Rs '.' a.txt b.txt");
+    });
+
+    it("should support stdin marker with files in raw mode", async () => {
+      const env = await setupFiles(testDir, {
+        "file.txt": "file\n",
+      });
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'stdin\\n' | jq -R '.' - file.txt",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `-R` / `--raw-input` support to `jq`
- match jq raw input behavior for line-by-line and slurped raw text modes
- add unit and comparison coverage for stdin, files, blank lines, and `-` stdin marker

## Testing
- pnpm lint:fix
- pnpm lint
- pnpm build
- pnpm knip
- pnpm test:comparison
- pnpm test:run -- src/commands/jq/jq.test.ts src/commands/jq/jq.raw-input.test.ts