### PR TITLE
Treat `python3 -` as read-from-stdin (matches CPython)

### DIFF
--- a/packages/just-bash/src/commands/python3/python3.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.test.ts
@@ -74,6 +74,41 @@ describe("python3", () => {
       expect(result.stdout).toBe("123\n");
       expect(result.exitCode).toBe(0);
     });
+
+    it("should read Python code from stdin when invoked as `python3 -`", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec('echo "print(456)" | python3 -');
+      expect(result.stdout).toBe("456\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should read Python code from a heredoc when invoked as `python3 - <<EOF`", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(
+        "python3 - <<'PY'\nimport sys\nprint('argv0=' + sys.argv[0])\nPY\n",
+      );
+      expect(result.stdout).toBe("argv0=-\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should pass trailing args after `-` as sys.argv[1:]", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(
+        "echo 'import sys; print(sys.argv)' | python3 - foo bar",
+      );
+      expect(result.stdout).toBe("['-', 'foo', 'bar']\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should run an empty program when `python3 -` receives no stdin", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec("python3 - < /dev/null");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("error handling", () => {

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -145,6 +145,10 @@ function parseArgs(args: string[]): ParsedArgs | ExecResult {
         result.scriptArgs = args.slice(firstArgIndex + 2);
       }
     } else {
+      // `-` is the conventional CPython sentinel for "read program from
+      // standard input" (see `man python3`). It must NOT be treated as a
+      // file path. Carry it through as a sentinel so execute() can route
+      // to the stdin branch while still preserving any trailing scriptArgs.
       result.scriptFile = arg;
       result.scriptArgs = args.slice(firstArgIndex + 1);
     }
@@ -541,6 +545,12 @@ export const python3Command: Command = {
       }
       pythonCode = `import runpy; runpy.run_module('${parsed.module}', run_name='__main__')`;
       scriptPath = parsed.module;
+    } else if (parsed.scriptFile === "-") {
+      // CPython's `python3 -` reads the program from standard input.
+      // Empty stdin runs an empty program (exit 0) — matching CPython's
+      // behavior in non-interactive contexts where no program is provided.
+      pythonCode = ctx.stdin;
+      scriptPath = "-";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
 


### PR DESCRIPTION
## Summary

`python3 -` (and every form that uses the explicit `-` sentinel) currently fails with `python3: can't open file '-': [Errno 2] No such file or directory` (exit 2). `parseArgs` admits `-` as the first non-flag arg but then falls into the generic else branch that assigns `result.scriptFile = arg`, so `execute()` tries to open a file literally named `-`.

Per `man python3`:
> `-`    Read program from standard input.

This breaks every CPython-conventional way of piping a program in:

```
python3 -                    # piped stdin
python3 - <<'EOF' ... EOF    # heredoc
echo 'print(1)' | python3 -  # piped stdin
```

## Fix

- Carry `-` through `parseArgs` as a sentinel (`scriptFile === "-"`), still capturing trailing args.
- Add a branch in `execute()` that routes the sentinel to `ctx.stdin` with `argv[0] = "-"` (matching CPython).
- Empty stdin runs an empty program and exits 0 — matches CPython's non-interactive behavior when no program is supplied.

The bareword form (`python3 << 'EOF'` / `echo … | python3` with no dash) already worked and is unaffected.

## Why this matters

Downstream consumers that route LLM-generated bash through just-bash have to pre-process scripts to rewrite `python3 - <<` → `python3 <<` before exec, because `-` is the form humans (and models trained on real bash) reach for first. With this fix, that workaround can be removed.

## Test plan

- [x] Added 4 new tests in `python3.test.ts`:
  - `python3 -` with a piped program
  - `python3 - <<'PY' ... PY` heredoc, asserting `sys.argv[0] == '-'`
  - Trailing args propagate: `echo … | python3 - foo bar` → `sys.argv == ['-', 'foo', 'bar']`
  - `python3 - < /dev/null` → exit 0 with empty output
- [x] `pnpm vitest run --config vitest.wasm.config.ts src/commands/python3/` — 206/206 pass
- [x] `pnpm typecheck`, `pnpm lint:fix`, `pnpm knip` — clean
- [x] `pnpm test:run --exclude src/spec-tests` — 9367/9367 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)