### PR TITLE
feat: export AST parser surface from browser and index entries

### DIFF
--- a/src/browser.ts
+++ b/src/browser.ts
@@ -53,6 +53,35 @@ export {
   TooManyRedirectsError,
 } from "./network/index.js";
 export type {
+  ArithmeticCommandNode,
+  AssignmentNode,
+  CaseNode,
+  CommandNode,
+  CompoundCommandNode,
+  ConditionalCommandNode,
+  ForNode,
+  FunctionDefNode,
+  GroupNode,
+  IfNode,
+  PipelineNode,
+  RedirectionNode,
+  ScriptNode,
+  SimpleCommandNode,
+  StatementNode,
+  SubshellNode,
+  UntilNode,
+  WhileNode,
+  WordNode,
+  WordPart,
+} from "./ast/types.js";
+export { LexerError } from "./parser/lexer.js";
+export { parse, Parser } from "./parser/parser.js";
+export { ParseException } from "./parser/types.js";
+export { BashTransformPipeline } from "./transform/pipeline.js";
+export { CommandCollectorPlugin } from "./transform/plugins/command-collector.js";
+export { TeePlugin } from "./transform/plugins/tee-plugin.js";
+export { serialize } from "./transform/serialize.js";
+export type {
   BashExecResult,
   Command,
   CommandContext,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,25 @@
 // AST types (for plugin authors)
 export type {
+  ArithmeticCommandNode,
+  AssignmentNode,
+  CaseNode,
   CommandNode,
+  CompoundCommandNode,
+  ConditionalCommandNode,
+  ForNode,
+  FunctionDefNode,
+  GroupNode,
+  IfNode,
   PipelineNode,
+  RedirectionNode,
   ScriptNode,
   SimpleCommandNode,
   StatementNode,
+  SubshellNode,
+  UntilNode,
+  WhileNode,
   WordNode,
+  WordPart,
 } from "./ast/types.js";
 export type {
   BashLogger,
@@ -71,7 +85,9 @@ export {
   TooManyRedirectsError,
 } from "./network/index.js";
 // Parser
-export { parse } from "./parser/parser.js";
+export { LexerError } from "./parser/lexer.js";
+export { parse, Parser } from "./parser/parser.js";
+export { ParseException } from "./parser/types.js";
 export type {
   CommandFinished as SandboxCommandFinished,
   OutputMessage,


### PR DESCRIPTION
## Summary

Additive re-exports for the **AST / parser / transform surface** from both `src/browser.ts` and `src/index.ts`. No runtime code is changed — every identifier being exported here is already compiled into `dist/bundle/browser.js` (because `Bash` uses the parser internally). The patch only widens the public export surface.

Pattern mirrors #186 (`feat: export MountableFs from browser entry point`).

## Motivation

Downstream consumers running in the **browser** (e.g. building an AST-backed bash allow-list, lint/format tooling, shell-script syntax highlighters) need access to `parse()` plus the AST node types. Today they are reachable only from the Node entry point, which transitively imports `node:fs` / `node:path` via `sandbox/` and `fs/read-write-fs/`. Those Node imports are unresolvable in a browser bundler even if the consumer never actually calls them.

With this PR, browser consumers can:

```ts
import { parse, type ScriptNode } from 'just-bash';

const ast = parse('ls -la | wc -l && echo done');
for (const stmt of ast.statements) {
  // walk the AST
}
```

## What changes

- `src/browser.ts` (+29 lines):
  - `type` re-exports for AST node interfaces: `ArithmeticCommandNode, AssignmentNode, CaseNode, CommandNode, CompoundCommandNode, ConditionalCommandNode, ForNode, FunctionDefNode, GroupNode, IfNode, PipelineNode, RedirectionNode, ScriptNode, SimpleCommandNode, StatementNode, SubshellNode, UntilNode, WhileNode, WordNode, WordPart`
  - value re-exports: `parse`, `Parser`, `ParseException`, `LexerError`, `BashTransformPipeline`, `CommandCollectorPlugin`, `TeePlugin`, `serialize`
- `src/index.ts` (+18 lines):
  - broadens the AST `type` re-exports so Node and browser consumers see the same set
  - adds `Parser`, `ParseException`, `LexerError` class re-exports alongside the existing `parse`

## Safety

- None of the newly-exposed modules import from `node:*` (verified by grep). The parser, AST types, and transform pipeline are pure TypeScript.
- `src/browser.bundle.test.ts` continues to pass after rebuild — no new `node:fs` / `node:path` / `node:child_process` imports land in `dist/bundle/browser.js`.
- `pnpm build` succeeds unchanged.

## Validation

Locally confirmed with:

```
pnpm install --ignore-scripts --no-frozen-lockfile
pnpm build
node -e "import('./dist/bundle/browser.js').then(m => console.log(typeof m.parse))"
# prints: function
```

Full `pnpm validate` was not run end-to-end by the submitter; maintainers, please run your usual gates.

## Ships well with

We are using this downstream right now by vendoring the rebuilt artifacts into our repo and aliasing `just-bash` to the vendored copy. We'd much rather consume an upstream release with these exports than maintain a vendor indefinitely — so landing this unblocks us deleting our vendor in a single commit.
