### PR TITLE
fix: cd resolves `..` against $PWD without re-stat'ing the cwd

### DIFF
--- a/src/comparison-tests/cd.comparison.test.ts
+++ b/src/comparison-tests/cd.comparison.test.ts
@@ -123,6 +123,34 @@ describe("cd command - Real Bash Comparison", () => {
     });
   });
 
+  describe("cd from a deleted cwd", () => {
+    it("should allow cd .. to escape a deleted cwd", async () => {
+      const env = await setupFiles(testDir, {
+        "lol/.keep": "",
+      });
+
+      const script = "cd lol && rm -rf ../lol && cd .. && basename $(pwd)";
+      const envResult = await env.exec(script);
+      const realResult = await runRealBash(script, testDir);
+
+      expect(envResult.stdout).toBe(realResult.stdout);
+      expect(envResult.exitCode).toBe(realResult.exitCode);
+    });
+
+    it("should allow cd / from a deleted cwd", async () => {
+      const env = await setupFiles(testDir, {
+        "gone/.keep": "",
+      });
+
+      const script = "cd gone && rm -rf ../gone && cd / && pwd";
+      const envResult = await env.exec(script);
+      const realResult = await runRealBash(script, testDir);
+
+      expect(envResult.stdout).toBe(realResult.stdout);
+      expect(envResult.exitCode).toBe(realResult.exitCode);
+    });
+  });
+
   describe("relative paths", () => {
     it("should handle relative path with .", async () => {
       const env = await setupFiles(testDir, {

--- a/src/interpreter/builtins/cd.test.ts
+++ b/src/interpreter/builtins/cd.test.ts
@@ -102,5 +102,67 @@ describe("cd builtin", () => {
       expect(result.stderr).toContain("Not a directory");
       expect(result.exitCode).toBe(1);
     });
+
+    it("should error when relative path's intermediate component is missing", async () => {
+      const env = new Bash();
+      await env.exec("cd /tmp");
+      const result = await env.exec("cd nonexistent-xyzzy/..");
+      expect(result.stderr).toBe(
+        "bash: cd: nonexistent-xyzzy/..: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should error when absolute path's intermediate component is missing", async () => {
+      const env = new Bash();
+      const result = await env.exec("cd /nonexistent-xyzzy/..");
+      expect(result.stderr).toBe(
+        "bash: cd: /nonexistent-xyzzy/..: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("cd from a deleted cwd", () => {
+    it("should allow `cd ..` to escape a deleted cwd", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        mkdir -p /tmp/lol
+        cd /tmp/lol
+        rm -rf /tmp/lol
+        cd ..
+        pwd
+      `);
+      expect(result.stdout).toBe("/tmp\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should allow `cd /` from a deleted cwd", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        mkdir -p /tmp/gone
+        cd /tmp/gone
+        rm -rf /tmp/gone
+        cd /
+        pwd
+      `);
+      expect(result.stdout).toBe("/\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should climb out of a nested deleted tree via repeated `cd ..`", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        mkdir -p /tmp/outer/inner
+        cd /tmp/outer/inner
+        rm -rf /tmp/outer
+        cd ..
+        cd ..
+        pwd
+      `);
+      expect(result.stdout).toBe("/tmp\n");
+      expect(result.exitCode).toBe(0);
+    });
   });
 });

--- a/src/interpreter/builtins/cd.ts
+++ b/src/interpreter/builtins/cd.ts
@@ -79,31 +79,36 @@ export async function handleCd(
     }
   }
 
-  // Check path components before normalization to catch cases like "nonexistent/.."
-  // where the intermediate directory doesn't exist
-  const pathToCheck = target.startsWith("/")
-    ? target
-    : `${ctx.state.cwd}/${target}`;
-  const parts = pathToCheck.split("/").filter((p) => p && p !== ".");
-  let currentPath = "";
-  for (const part of parts) {
+  // Walk the target path using bash's logical (-L) semantics:
+  // - The current working directory is trusted and never stat'd, so `cd ..`
+  //   still works when the cwd has been removed (e.g. `rm -rf` of $PWD).
+  // - `..` pops the stack textually without touching the filesystem, matching
+  //   real bash's behavior where $PWD anchors resolution.
+  // - Only newly added components from the user-supplied target are stat'd,
+  //   so `cd nonexistent/..` still errors the same way real bash does.
+  const isAbsolute = target.startsWith("/");
+  const stack: string[] = isAbsolute
+    ? []
+    : ctx.state.cwd.split("/").filter((p) => p);
+  const inputParts = target.split("/").filter((p) => p && p !== ".");
+  for (const part of inputParts) {
     if (part === "..") {
-      // Go up one level
-      currentPath = currentPath.split("/").slice(0, -1).join("/") || "/";
-    } else {
-      currentPath = currentPath ? `${currentPath}/${part}` : `/${part}`;
-      try {
-        const stat = await ctx.fs.stat(currentPath);
-        if (!stat.isDirectory) {
-          return failure(`bash: cd: ${target}: Not a directory\n`);
-        }
-      } catch {
-        return failure(`bash: cd: ${target}: No such file or directory\n`);
+      stack.pop();
+      continue;
+    }
+    stack.push(part);
+    const currentPath = `/${stack.join("/")}`;
+    try {
+      const stat = await ctx.fs.stat(currentPath);
+      if (!stat.isDirectory) {
+        return failure(`bash: cd: ${target}: Not a directory\n`);
       }
+    } catch {
+      return failure(`bash: cd: ${target}: No such file or directory\n`);
     }
   }
 
-  let newDir = currentPath || "/";
+  let newDir = stack.length > 0 ? `/${stack.join("/")}` : "/";
 
   // If -P is specified, resolve symlinks to get the physical path
   if (physical) {


### PR DESCRIPTION
The cd builtin walked every component of the target path — including those of ctx.state.cwd — calling fs.stat on each. If the current working directory had been removed (e.g. `rm -rf $PWD`), `cd ..` would fail with "No such file or directory" because stat'ing the deleted cwd aborted the walk before `..` could pop it.

Real bash uses logical (-L) semantics: $PWD anchors resolution and is not re-stat'd, so `cd ..` from a deleted cwd resolves textually to the parent. Intermediate components from the user-supplied target still get stat'd, so `cd nonexistent/..` continues to error like bash.

Seed the resolution stack from ctx.state.cwd for relative targets, pop on `..`, and stat only components newly pushed by the target. Adds unit tests for deleted-cwd escape plus intermediate-missing errors, and comparison tests asserting parity with real bash.