### PR TITLE
Bug fixes across network, sqlite3, xan, rg, terminal rendering, and CI

### DIFF
--- a/.changeset/free-tools-chew.md
+++ b/.changeset/free-tools-chew.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Bug fixes across network, sqlite3, xan, rg, terminal rendering, and CI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,18 +27,21 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      # Third-party actions in this privileged job are pinned to full
+      # commit SHAs so a moved tag or compromised upstream cannot inject
+      # code into a workflow holding contents:write + id-token:write.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           lfs: true
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       # Node 24 (LTS Krypton) ships npm >= 11.12, which has Trusted Publisher
       # OIDC authentication. Node 22's bundled npm 10.x can sign provenance
       # attestations but cannot use OIDC tokens to authenticate the publish
       # itself, leading to a confusing 404 after provenance signing succeeds.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "24"
           cache: "pnpm"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ todo/
 .docs-test-tmp/
 fuzz-*.log
 .claude/settings.local.json
+.deepsec/

--- a/examples/website/app/components/Terminal.tsx
+++ b/examples/website/app/components/Terminal.tsx
@@ -30,6 +30,32 @@ function getTheme(isDark: boolean) {
   };
 }
 
+// Strip ANSI escape sequences from a URL-supplied string before it
+// reaches `term.write` (which would otherwise interpret OSC 8 hyperlinks
+// as clickable <a href="javascript:..."> links — see the XSS finding).
+// Order matters: OSC ends with BEL (0x07) or ESC \\, so we drop those
+// first before the generic ESC catch-all stripper.
+function sanitizeAgentQuery(s: string): string {
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+  let cleaned = s.replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "");
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+  cleaned = cleaned.replace(/\x1b\[[\d;?]*[A-Za-z@~]/g, "");
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+  cleaned = cleaned.replace(/\x1b[@-_]/g, "");
+  // Strip remaining C0/C1 control characters (keep \t, \n, \r are
+  // already harmless after the OSC strip; but bash and terminal both
+  // mishandle them so we drop everything in 0x00–0x1F).
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+  cleaned = cleaned.replace(/[\x00-\x1F\x7F]/g, "");
+  return cleaned;
+}
+
+// Quote a string so that bash treats it as a single argument regardless
+// of contents. Single-quote everything; embedded "'" becomes "'\\''".
+function bashSingleQuote(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
 export default function TerminalComponent() {
   const terminalRef = useRef<HTMLDivElement>(null);
 
@@ -87,8 +113,14 @@ export default function TerminalComponent() {
       if (agentQuery) {
         // Clean the URL
         window.history.replaceState({}, "", window.location.pathname);
-        // Execute the agent command
-        void inputHandler.executeCommand(`agent "${agentQuery}"`);
+        // Sanitize the URL-supplied query before it reaches term.write
+        // and the bash parser. Without this, embedded ANSI/OSC sequences
+        // render as clickable links (OSC 8 hyperlink XSS) and stray
+        // double quotes break out of the shell-quoted argument.
+        const sanitized = sanitizeAgentQuery(agentQuery);
+        // Execute the agent command, single-quoting the argument so the
+        // bash parser treats it as a literal string regardless of contents.
+        void inputHandler.executeCommand(`agent ${bashSingleQuote(sanitized)}`);
       } else if (inputHandler.history.length === 0) {
         // Pre-populate command if history is empty and no query param
         inputHandler.setInitialCommand('agent "What is just-bash?"');

--- a/examples/website/app/components/lite-terminal/LiteTerminal.ts
+++ b/examples/website/app/components/lite-terminal/LiteTerminal.ts
@@ -12,6 +12,31 @@ import { InputHandler } from "./input-handler";
 const MAX_SCROLLBACK_LINES = 100_000;
 
 /**
+ * URL schemes considered safe for clickable terminal links.
+ * Specifically blocks `javascript:`, `data:`, `vbscript:`, `file:`, etc.
+ * which would execute attacker-controlled code or read local resources
+ * if assigned to an <a href>.
+ */
+const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
+
+function isSafeLinkUrl(url: string): boolean {
+  try {
+    // Use a base so relative URLs (which we should NOT render as links
+    // anyway) don't accidentally become unsafe when resolved.
+    const parsed = new URL(url, "https://example.invalid/");
+    if (!SAFE_LINK_PROTOCOLS.has(parsed.protocol)) return false;
+    // If the URL was relative, the parsed origin is example.invalid —
+    // refuse to render that as a clickable absolute link.
+    if (parsed.hostname === "example.invalid" && !/^https?:|^mailto:/i.test(url)) {
+      return false;
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Lightweight terminal implementation optimized for iOS
  * Drop-in compatible with xterm.js API surface used in this project
  */
@@ -607,8 +632,11 @@ export class LiteTerminal {
     const classes = this.getStyleClasses(style);
     const inlineStyle = this.getInlineStyle(style);
 
-    // If style has a link (from OSC 8), create an anchor element
-    if (style.link) {
+    // If style has a link (from OSC 8), create an anchor element.
+    // Validate the URL scheme — without this, an OSC 8 sequence with
+    // `javascript:` (or `data:`, `vbscript:`, etc.) becomes a clickable
+    // anchor that fires arbitrary JS in this origin (XSS).
+    if (style.link && isSafeLinkUrl(style.link)) {
       const link = document.createElement("a");
       link.href = style.link;
       link.target = "_blank";

--- a/examples/website/app/components/terminal-parts/agent-command.ts
+++ b/examples/website/app/components/terminal-parts/agent-command.ts
@@ -23,7 +23,34 @@ function sanitizeTerminalError(message: string): string {
     .replace(/[A-Z]:\\[^\s'",)}\]:]+/g, "<path>");
 }
 
-// Format text for terminal: normalize newlines and convert tabs to spaces
+// Strip ANSI escape sequences from model-controlled text before it
+// reaches `term.write`. Without this, OSC 8 hyperlink sequences emitted
+// by the LLM (or echoed from tool output / prompt-injection sources)
+// render as <a href="javascript:..."> in the terminal — XSS in this
+// origin. Order: drop OSC sequences (terminated by BEL or ESC \\)
+// first because they carry payloads with characters that the generic
+// CSI matcher would partially eat.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const OSC_RE = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const CSI_RE = /\x1b\[[\d;?]*[A-Za-z@~]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const ESC_OTHER_RE = /\x1b[@-_]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const C0_C1_RE = /[\x00-\x08\x0B-\x1F\x7F]/g;
+
+function stripAnsi(text: string): string {
+  return text
+    .replace(OSC_RE, "")
+    .replace(CSI_RE, "")
+    .replace(ESC_OTHER_RE, "")
+    .replace(C0_C1_RE, "");
+}
+
+// Format text for terminal: normalize newlines and convert tabs to spaces.
+// Callers MUST run `stripAnsi` on any model-controlled content first;
+// this function intentionally preserves escape sequences so that
+// surrounding styling we add ourselves (\x1b[2m ... \x1b[0m) survives.
 function formatForTerminal(text: string): string {
   return text.replace(/\t/g, "  ").replace(/\r?\n/g, "\r\n");
 }
@@ -149,7 +176,15 @@ export function createAgentCommand(term: TerminalWriter) {
         }
 
         if (displayResult && displayResult.trim()) {
-          const resultLines = displayResult.split("\n").filter((l: string) => l.trim());
+          // Strip ANSI from each tool-output line BEFORE wrapping it in
+          // our `\x1b[2m ... \x1b[0m` styling. Without this, an OSC 8
+          // hyperlink embedded in tool output would survive the wrap
+          // and render as a clickable link in the terminal — XSS in
+          // this origin if the URL scheme is `javascript:`.
+          const resultLines = displayResult
+            .split("\n")
+            .map((l: string) => stripAnsi(l))
+            .filter((l: string) => l.trim());
           const linesToShow = resultLines.slice(0, MAX_TOOL_OUTPUT_LINES);
           let output = linesToShow.map((line) => `\x1b[2m${line}\x1b[0m`).join("\n");
           if (resultLines.length > MAX_TOOL_OUTPUT_LINES) {
@@ -180,10 +215,16 @@ export function createAgentCommand(term: TerminalWriter) {
           try {
             const data = JSON.parse(jsonStr);
 
-            // Stream text line-by-line (complete lines only to preserve ASCII art)
+            // Stream text line-by-line (complete lines only to preserve ASCII art).
+            // stripAnsi the model-emitted delta BEFORE buffering: this
+            // removes OSC 8 hyperlinks and other escape sequences that
+            // the LLM might emit (or echo from prompt-injection sources)
+            // without losing the legitimate styling that `formatMarkdown`
+            // adds afterward.
             if (data.type === "text-delta" && data.delta) {
-              fullText += data.delta; // Track for message history
-              lineBuffer += data.delta;
+              const safeDelta = stripAnsi(String(data.delta));
+              fullText += safeDelta; // Track for message history
+              lineBuffer += safeDelta;
 
               // Check for complete lines to stream
               const lastNewline = lineBuffer.lastIndexOf("\n");
@@ -214,8 +255,12 @@ export function createAgentCommand(term: TerminalWriter) {
                 fullText += "\n";
               }
               const args = data.input as Record<string, unknown>;
+              // stripAnsi on every model-controlled segment — these come
+              // from the LLM's tool-call args and could carry OSC 8
+              // sequences via prompt injection.
+              const safeToolName = stripAnsi(String(data.toolName));
               if (data.toolName === "bash" && args.command) {
-                const cmd = String(args.command).replace(/\t/g, "  ");
+                const cmd = stripAnsi(String(args.command)).replace(/\t/g, "  ");
                 const lines = cmd.split("\n");
                 // Write each line separately for proper terminal rendering
                 term.write(`\x1b[36m$ ${lines[0]}\x1b[0m\r\n`);
@@ -223,11 +268,15 @@ export function createAgentCommand(term: TerminalWriter) {
                   term.write(`\x1b[36m${lines[i]}\x1b[0m\r\n`);
                 }
               } else if (data.toolName === "readFile" && args.path) {
-                term.write(`\x1b[36m[readFile] ${args.path}\x1b[0m\r\n`);
+                term.write(
+                  `\x1b[36m[readFile] ${stripAnsi(String(args.path))}\x1b[0m\r\n`,
+                );
               } else if (data.toolName === "writeFile" && args.path) {
-                term.write(`\x1b[36m[writeFile] ${args.path}\x1b[0m\r\n`);
+                term.write(
+                  `\x1b[36m[writeFile] ${stripAnsi(String(args.path))}\x1b[0m\r\n`,
+                );
               } else {
-                term.write(`\x1b[36m[${data.toolName}]\x1b[0m\r\n`);
+                term.write(`\x1b[36m[${safeToolName}]\x1b[0m\r\n`);
               }
 
               toolCallsMap.set(data.toolCallId, {
@@ -262,8 +311,11 @@ export function createAgentCommand(term: TerminalWriter) {
               term.write("\x1b[2m\x1b[3m"); // dim + italic
             }
             else if (data.type === "reasoning-delta" && data.delta) {
-              // Stream thinking tokens as they arrive
-              term.write(formatForTerminal(data.delta));
+              // Stream thinking tokens as they arrive — strip ANSI from
+              // the model-emitted delta so embedded OSC 8 hyperlinks
+              // can't render as clickable links inside our dim/italic
+              // wrapper.
+              term.write(formatForTerminal(stripAnsi(String(data.delta))));
               resetThinkingTimer(); // Keep resetting while actively streaming
             }
             else if (data.type === "reasoning-end") {
@@ -273,18 +325,20 @@ export function createAgentCommand(term: TerminalWriter) {
                 isStreaming = false;
               }
             }
-            // Handle errors
+            // Handle errors. Error strings can be model-controlled
+            // (e.g. tool execution echoing back attacker content), so
+            // stripAnsi before wrapping in our \x1b[31m red styling.
             else if (data.type === "error") {
               const errorMsg = data.error || data.message || "Unknown error";
-              term.write(`\x1b[31mError: ${formatForTerminal(String(errorMsg))}\x1b[0m\r\n`);
+              term.write(`\x1b[31mError: ${formatForTerminal(stripAnsi(String(errorMsg)))}\x1b[0m\r\n`);
             }
             else if (data.type === "tool-input-error") {
               const errorMsg = data.error || "Tool input error";
-              term.write(`\x1b[31m[Tool Error] ${formatForTerminal(String(errorMsg))}\x1b[0m\r\n`);
+              term.write(`\x1b[31m[Tool Error] ${formatForTerminal(stripAnsi(String(errorMsg)))}\x1b[0m\r\n`);
             }
             else if (data.type === "tool-output-error") {
               const errorMsg = data.error || "Tool execution error";
-              term.write(`\x1b[31m[Tool Error] ${formatForTerminal(String(errorMsg))}\x1b[0m\r\n`);
+              term.write(`\x1b[31m[Tool Error] ${formatForTerminal(stripAnsi(String(errorMsg)))}\x1b[0m\r\n`);
             }
             else if (data.type === "tool-output-denied") {
               term.write(`\x1b[33m[Tool Denied]\x1b[0m\r\n`);

--- a/examples/website/app/components/terminal-parts/input-handler.ts
+++ b/examples/website/app/components/terminal-parts/input-handler.ts
@@ -11,6 +11,27 @@ type Terminal = {
 };
 
 
+// Strip ANSI escape sequences from text destined for term.write so OSC
+// 8 hyperlink XSS can't sneak in via user-supplied or URL-supplied
+// command echoes. Defense in depth — callers that forget to sanitize
+// still get protected here.
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const STRIP_OSC = /\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const STRIP_CSI = /\x1b\[[\d;?]*[A-Za-z@~]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const STRIP_ESC_OTHER = /\x1b[@-_]/g;
+// biome-ignore lint/suspicious/noControlCharactersInRegex: deliberately matching control chars
+const STRIP_C0 = /[\x00-\x08\x0B-\x1F\x7F]/g;
+
+function stripDisplayAnsi(text: string): string {
+  return text
+    .replace(STRIP_OSC, "")
+    .replace(STRIP_CSI, "")
+    .replace(STRIP_ESC_OTHER, "")
+    .replace(STRIP_C0, "");
+}
+
 // Find the start of the previous word
 function findPrevWordBoundary(str: string, pos: number): number {
   if (pos <= 0) return 0;
@@ -475,10 +496,14 @@ export function createInputHandler(term: Terminal, bash: Bash) {
     setInitialCommand: (initialCmd: string) => {
       cmd = initialCmd;
       cursorPos = initialCmd.length;
-      term.write(initialCmd);
+      // Strip ANSI before echoing — defense in depth in case any caller
+      // forgets to sanitize. The bash parser still sees the original
+      // string from the cmd variable above (set on the same line),
+      // so we just protect the visual echo.
+      term.write(stripDisplayAnsi(initialCmd));
     },
     executeCommand: async (command: string) => {
-      term.write(command);
+      term.write(stripDisplayAnsi(command));
       term.writeln("");
       await executeCommand(command);
     },

--- a/packages/just-bash/src/commands/rg/rg-parser-threads.test.ts
+++ b/packages/just-bash/src/commands/rg/rg-parser-threads.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression tests for the HIGH_BUG `-j`/`--threads` finding.
+ *
+ * The compatibility flag was wired with `target: "maxDepth"` and
+ * `parse: () => Infinity`, intending to be a no-op. In practice every
+ * `-j N` invocation silently overwrote the user's max-depth setting
+ * to Infinity — disabling the safe default of 256 and any explicit
+ * `--max-depth` set earlier on the command line. With unbounded depth,
+ * `walkDirectory` could recurse the full filesystem (only bounded by
+ * gitignore), which is a security-adjacent DoS when paths are
+ * user-controlled.
+ *
+ * The fix introduces an `ignored: true` flag on ValueOptDef that
+ * consumes the value but does not write to RgOptions.
+ */
+import { describe, expect, it } from "vitest";
+import { createDefaultOptions } from "./rg-options.js";
+import { parseArgs } from "./rg-parser.js";
+
+const DEFAULT_MAX_DEPTH = createDefaultOptions().maxDepth;
+
+function expectOk(result: ReturnType<typeof parseArgs>) {
+  if (!("options" in result)) {
+    throw new Error(`Expected ok parse, got error: ${JSON.stringify(result)}`);
+  }
+  return result;
+}
+
+describe("rg -j/--threads compatibility flag", () => {
+  it("does not clobber the default maxDepth", () => {
+    const result = expectOk(parseArgs(["-j", "4", "foo"]));
+    expect(result.options.maxDepth).toBe(DEFAULT_MAX_DEPTH);
+  });
+
+  it("does not clobber an explicit --max-depth set BEFORE -j", () => {
+    const result = expectOk(parseArgs(["--max-depth", "1", "-j", "4", "foo"]));
+    expect(result.options.maxDepth).toBe(1);
+  });
+
+  it("does not clobber an explicit --max-depth set AFTER -j", () => {
+    const result = expectOk(parseArgs(["-j", "4", "--max-depth", "2", "foo"]));
+    expect(result.options.maxDepth).toBe(2);
+  });
+
+  it("--threads behaves like -j (long form)", () => {
+    const result = expectOk(parseArgs(["--threads", "8", "foo"]));
+    expect(result.options.maxDepth).toBe(DEFAULT_MAX_DEPTH);
+  });
+
+  it("combined-form -Iij <n> still does not clobber maxDepth", () => {
+    // The bug also reaches via `findValueOptByShort('j')` when -j is
+    // bundled into a combined-flag form like `-Iij 4`.
+    const result = expectOk(parseArgs(["-Iij", "4", "foo"]));
+    expect(result.options.maxDepth).toBe(DEFAULT_MAX_DEPTH);
+  });
+
+  it("the default maxDepth is a finite, sane value", () => {
+    // Sanity floor: regression test against any future attempt to
+    // restore Infinity as the default. The recursion guard at
+    // walkDirectory uses `if (depth >= options.maxDepth) return;` —
+    // Infinity disables it and opens unbounded traversal.
+    expect(Number.isFinite(DEFAULT_MAX_DEPTH)).toBe(true);
+    expect(DEFAULT_MAX_DEPTH).toBeGreaterThan(0);
+  });
+});

--- a/packages/just-bash/src/commands/rg/rg-parser.ts
+++ b/packages/just-bash/src/commands/rg/rg-parser.ts
@@ -71,10 +71,19 @@ function validateType(_typeName: string): ExecResult | null {
 interface ValueOptDef {
   short?: string;
   long: string;
-  target: keyof RgOptions;
+  /** Where to store the parsed value. Required unless `ignored` is true. */
+  target?: keyof RgOptions;
   multi?: boolean;
   parse?: (val: string) => number;
   validate?: (val: string) => ExecResult | null;
+  /**
+   * When true, consume the option's value but do NOT write it anywhere.
+   * Used for compatibility-only flags like `-j`/`--threads` that have
+   * no effect in this single-threaded environment. Previously these
+   * reused `target: "maxDepth"` as dummy storage, which silently
+   * clobbered the user's max-depth setting (HIGH_BUG finding).
+   */
+  ignored?: boolean;
 }
 
 const VALUE_OPTS: ValueOptDef[] = [
@@ -108,8 +117,11 @@ const VALUE_OPTS: ValueOptDef[] = [
     validate: validateFilesize,
   },
   { long: "context-separator", target: "contextSeparator" },
-  // Thread count (no-op in single-threaded environment, but accept the option)
-  { short: "j", long: "threads", target: "maxDepth", parse: () => Infinity }, // Use maxDepth as dummy target (value ignored)
+  // Thread count (no-op in single-threaded environment). Must NOT be
+  // wired to a real RgOptions field — earlier versions used
+  // `target: "maxDepth"` as a dummy and silently overrode the user's
+  // max-depth setting to Infinity, disabling the safe default of 256.
+  { short: "j", long: "threads", ignored: true },
   // Custom ignore file
   { long: "ignore-file", target: "ignoreFiles", multi: true },
   // Preprocessing
@@ -568,6 +580,11 @@ function applyValueOpt(
   if (def.validate) {
     const error = def.validate(value);
     if (error) return error;
+  }
+
+  // Compatibility-only flags consume their value but don't store it.
+  if (def.ignored || !def.target) {
+    return undefined;
   }
 
   const parsed = def.parse ? def.parse(value) : value;

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.writeback-edge-cases.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.writeback-edge-cases.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Regression tests for the HIGH_BUG sqlite3 writeback finding.
+ *
+ * Previously the worker classified statements as "writes" with a
+ * `startsWith` allowlist on INSERT/UPDATE/DELETE/CREATE/DROP/ALTER/
+ * REPLACE/VACUUM. Statements that mutated the database but did NOT
+ * begin with one of those tokens — CTE-prefixed writes (`WITH ...
+ * INSERT/UPDATE/DELETE`), mutating PRAGMAs (`PRAGMA user_version=N`),
+ * and comment-led writes — silently skipped the writeback to disk.
+ *
+ * Each test executes a mutating statement, then RE-OPENS the database
+ * file in a fresh Bash environment to confirm the change persisted.
+ * If the writeback gate misses the mutation, the second invocation
+ * sees an unmutated database and the assertion fails.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+async function setupDb(env: Bash, schema: string): Promise<void> {
+  const result = await env.exec(`sqlite3 /tmp/db.sqlite "${schema}"`);
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr).toBe("");
+}
+
+describe("sqlite3 writeback covers non-prefixed mutations", () => {
+  it("persists a CTE-prefixed INSERT (WITH ... INSERT)", async () => {
+    const env = new Bash();
+    await setupDb(env, "CREATE TABLE t(x INT); INSERT INTO t VALUES(1)");
+
+    // Mutating WITH-prefixed write — startsWith allowlist would miss this.
+    const write = await env.exec(
+      `sqlite3 /tmp/db.sqlite "WITH cte AS (SELECT 2 AS v) INSERT INTO t SELECT v FROM cte"`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    // Re-open the persisted file and confirm the row is there.
+    const read = await env.exec(
+      `sqlite3 /tmp/db.sqlite "SELECT x FROM t ORDER BY x"`,
+    );
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("1\n2\n");
+  });
+
+  it("persists a CTE-prefixed UPDATE", async () => {
+    const env = new Bash();
+    await setupDb(
+      env,
+      "CREATE TABLE t(id INT, val TEXT); INSERT INTO t VALUES(1,'a'),(2,'b')",
+    );
+
+    const write = await env.exec(
+      `sqlite3 /tmp/db.sqlite "WITH ids AS (SELECT 1 AS id) UPDATE t SET val='changed' WHERE id IN (SELECT id FROM ids)"`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    const read = await env.exec(
+      `sqlite3 /tmp/db.sqlite "SELECT id, val FROM t ORDER BY id"`,
+    );
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("1|changed\n2|b\n");
+  });
+
+  it("persists a CTE-prefixed DELETE", async () => {
+    const env = new Bash();
+    await setupDb(
+      env,
+      "CREATE TABLE t(x INT); INSERT INTO t VALUES(1),(2),(3)",
+    );
+
+    const write = await env.exec(
+      `sqlite3 /tmp/db.sqlite "WITH ids AS (SELECT 2 AS x) DELETE FROM t WHERE x IN (SELECT x FROM ids)"`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    const read = await env.exec(
+      `sqlite3 /tmp/db.sqlite "SELECT x FROM t ORDER BY x"`,
+    );
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("1\n3\n");
+  });
+
+  it("persists a mutating PRAGMA (user_version)", async () => {
+    const env = new Bash();
+    await setupDb(env, "CREATE TABLE t(x INT)");
+
+    const write = await env.exec(
+      `sqlite3 /tmp/db.sqlite "PRAGMA user_version = 42"`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    const read = await env.exec(`sqlite3 /tmp/db.sqlite "PRAGMA user_version"`);
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("42\n");
+  });
+
+  it("persists a comment-led INSERT (line comment)", async () => {
+    const env = new Bash();
+    await setupDb(env, "CREATE TABLE t(x INT)");
+
+    // -- comment then INSERT. startsWith allowlist would miss this.
+    // Pipe via stdin to preserve the embedded newline cleanly.
+    const write = await env.exec(
+      `printf '%s\\n%s' '-- adding a row' 'INSERT INTO t VALUES(7);' | sqlite3 /tmp/db.sqlite`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    const read = await env.exec(`sqlite3 /tmp/db.sqlite "SELECT x FROM t"`);
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("7\n");
+  });
+
+  it("persists a comment-led UPDATE (block comment)", async () => {
+    const env = new Bash();
+    await setupDb(
+      env,
+      "CREATE TABLE t(id INT, val TEXT); INSERT INTO t VALUES(1,'a')",
+    );
+
+    const write = await env.exec(
+      `sqlite3 /tmp/db.sqlite "/* note */ UPDATE t SET val='b' WHERE id=1"`,
+    );
+    expect(write.exitCode).toBe(0);
+    expect(write.stderr).toBe("");
+
+    const read = await env.exec(
+      `sqlite3 /tmp/db.sqlite "SELECT id, val FROM t"`,
+    );
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("1|b\n");
+  });
+
+  it("does not mark a plain SELECT as modified (no needless writeback)", async () => {
+    // Negative control: a pure SELECT must remain classified read-only,
+    // otherwise we'd write back unnecessarily on every read.
+    const env = new Bash();
+    await setupDb(env, "CREATE TABLE t(x INT); INSERT INTO t VALUES(5)");
+
+    const read = await env.exec(`sqlite3 /tmp/db.sqlite "SELECT x FROM t"`);
+    expect(read.exitCode).toBe(0);
+    expect(read.stdout).toBe("5\n");
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/worker.ts
+++ b/packages/just-bash/src/commands/sqlite3/worker.ts
@@ -130,8 +130,50 @@ export interface WorkerError {
 
 export type WorkerOutput = WorkerSuccess | WorkerError;
 
+/**
+ * Strip leading SQL comments and whitespace so that classification is
+ * not fooled by `-- comment\nINSERT ...` or `/* x *\/ UPDATE ...`.
+ */
+function stripLeadingNoise(sql: string): string {
+  let s = sql;
+  for (;;) {
+    const before = s;
+    s = s.replace(/^\s+/, "");
+    if (s.startsWith("--")) {
+      const nl = s.indexOf("\n");
+      s = nl === -1 ? "" : s.slice(nl + 1);
+    } else if (s.startsWith("/*")) {
+      const end = s.indexOf("*/");
+      s = end === -1 ? "" : s.slice(end + 2);
+    }
+    if (s === before) return s;
+  }
+}
+
+/**
+ * Conservative classifier: returns true ONLY if the statement is
+ * provably read-only. Anything else — CTE-prefixed writes (`WITH ...
+ * INSERT/UPDATE/DELETE`), mutating PRAGMAs (`PRAGMA user_version=N`),
+ * comment-led writes — is treated as potentially mutating so the DB
+ * is written back. Bias: false positives cost an extra writeback;
+ * false negatives cause silent data loss (the original bug).
+ */
+function isReadOnlyStatement(sql: string): boolean {
+  const s = stripLeadingNoise(sql).toUpperCase();
+  if (s.startsWith("SELECT")) return true;
+  if (s.startsWith("EXPLAIN")) return true;
+  if (s.startsWith("VALUES")) return true;
+  if (s.startsWith("PRAGMA")) {
+    // `PRAGMA name` is a read; `PRAGMA name = value` and
+    // `PRAGMA name(value)` mutate state.
+    const rest = s.slice("PRAGMA".length);
+    return !/[=(]/.test(rest);
+  }
+  return false;
+}
+
 function isWriteStatement(sql: string): boolean {
-  const trimmed = sql.trim().toUpperCase();
+  const trimmed = stripLeadingNoise(sql).toUpperCase();
   return (
     trimmed.startsWith("INSERT") ||
     trimmed.startsWith("UPDATE") ||
@@ -225,6 +267,14 @@ async function executeQuery(data: WorkerInput): Promise<WorkerOutput> {
 
           prepared.free();
           results.push({ type: "data", columns, rows });
+
+          // Anything that is not provably read-only must trigger writeback.
+          // Catches CTE-prefixed writes (WITH ... INSERT), mutating PRAGMAs
+          // (PRAGMA user_version=N), and comment-led writes that the
+          // startsWith allowlist in isWriteStatement misses.
+          if (!isReadOnlyStatement(stmt)) {
+            hasModifications = true;
+          }
         }
       } catch (e) {
         const error = (e as Error).message;

--- a/packages/just-bash/src/commands/xan/moonblade-parser.test.ts
+++ b/packages/just-bash/src/commands/xan/moonblade-parser.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for the HIGH_BUG moonblade parser finding.
+ *
+ * The `(` case in `parsePrefix` had broken backtracking when the body
+ * was `(ident)` or `(ident, ident, ...)` NOT followed by `=>`. The
+ * ad-hoc `pos -= params.length * 2` correction mis-counted comma
+ * tokens and re-entered the same `(` case at the same pos, causing
+ * infinite recursion until JS stack overflow.
+ *
+ * These inputs reach the parser via `xan filter '(x)' data.csv`, so
+ * an attacker can crash filter from untrusted CSV options.
+ */
+import { describe, expect, it } from "vitest";
+import { parseMoonblade } from "./moonblade-parser.js";
+
+describe("moonblade parser parenthesized expressions", () => {
+  it("parses (ident) as a grouped identifier expression", () => {
+    const ast = parseMoonblade("(x)");
+    expect(ast).toMatchObject({ type: "identifier", name: "x" });
+  });
+
+  it("parses (ident op value) as a grouped expression (not a lambda)", () => {
+    const ast = parseMoonblade("(x > 5)");
+    // Either binary node or func-call node depending on AST flavor —
+    // the only requirement is "not a lambda" and "no infinite recursion".
+    expect(ast).toMatchObject({});
+    expect((ast as { type: string }).type).not.toBe("lambda");
+  });
+
+  it("parses (ident, ident) as a grouped tuple-ish expression and does not stack-overflow", () => {
+    // Without `=>`, the parser must not commit to lambda parsing.
+    // Comma at the top level isn't a binary operator in moonblade, so
+    // either this becomes a single expression (first ident only) or
+    // throws a clean parse error. What it must NOT do is infinite recurse.
+    expect(() => parseMoonblade("(x, y)")).not.toThrow(RangeError);
+  });
+
+  it("parses (ident) => body as a single-arg lambda", () => {
+    const ast = parseMoonblade("(x) => x + 1");
+    expect(ast).toMatchObject({
+      type: "lambda",
+      params: ["x"],
+    });
+  });
+
+  it("parses (a, b) => body as a multi-arg lambda", () => {
+    const ast = parseMoonblade("(a, b) => a + b");
+    expect(ast).toMatchObject({
+      type: "lambda",
+      params: ["a", "b"],
+    });
+  });
+
+  it("parses (ident).method() — paren around a method-call receiver", () => {
+    // Ensures the backtracked grouped expression continues to combine
+    // with following operators correctly.
+    expect(() => parseMoonblade("(x).len()")).not.toThrow(RangeError);
+  });
+});

--- a/packages/just-bash/src/commands/xan/moonblade-parser.ts
+++ b/packages/just-bash/src/commands/xan/moonblade-parser.ts
@@ -156,74 +156,62 @@ class Parser {
       case "(": {
         this.advance();
 
-        // Could be grouping or lambda params
-        // Check if this looks like lambda params
-        const params: string[] = [];
+        // Could be grouping or lambda params. Save pos so we can
+        // cleanly backtrack if the lambda guess is wrong — the prior
+        // implementation used `pos -= params.length * 2` which
+        // mis-counted comma tokens and infinite-recursed on `(ident)`.
+        const startPos = this.pos;
 
         if (this.peek().type === ")") {
-          // Empty parens - likely lambda with no args
+          // Empty parens - either an empty-arg lambda or invalid.
           this.advance();
           if (this.peek().type === "=>") {
             this.advance();
             const body = this.parseExpr(0);
             return { type: "lambda", params: [], body };
           }
-          // Empty parens as expression? Treat as empty list?
           throw new Error("Empty parentheses not allowed");
         }
 
-        // Parse first expression/identifier
+        // Speculatively try `(ident, ident, ...) =>`. If it doesn't
+        // hold, restore pos and parse as a grouped expression instead.
         if (this.peek().type === "ident") {
-          const firstIdent = this.peek().value;
+          const params: string[] = [this.peek().value];
           this.advance();
 
-          if (this.peek().type === "," || this.peek().type === ")") {
-            // Could be lambda params
-            params.push(firstIdent);
-
-            while (this.peek().type === ",") {
+          let looksLikeParamList = true;
+          while (this.peek().type === ",") {
+            this.advance();
+            if (this.peek().type === "ident") {
+              params.push(this.peek().value);
               this.advance();
-              if (this.peek().type === "ident") {
-                params.push(this.peek().value);
-                this.advance();
-              } else {
-                break;
-              }
-            }
-
-            if (this.peek().type === ")") {
-              this.advance();
-              if (this.peek().type === "=>") {
-                this.advance();
-                const body = this.parseExpr(0);
-                return this.bindLambdaArgs(
-                  { type: "lambda", params, body },
-                  params,
-                );
-              }
-            }
-
-            // Not a lambda, treat as expression
-            // Put token back and re-parse
-            this.pos -= params.length * 2; // rough approximation
-            if (params.length > 1) {
-              this.pos = this.pos; // Can't easily backtrack
+            } else {
+              looksLikeParamList = false;
+              break;
             }
           }
 
-          // Rewind - we need to parse as expression
-          this.pos--;
+          if (
+            looksLikeParamList &&
+            this.peek().type === ")" &&
+            this.peekAt(1).type === "=>"
+          ) {
+            this.advance(); // ')'
+            this.advance(); // '=>'
+            const body = this.parseExpr(0);
+            return this.bindLambdaArgs(
+              { type: "lambda", params, body },
+              params,
+            );
+          }
+
+          // Not a lambda. Restore and fall through to grouped-expression parse.
+          this.pos = startPos;
         }
 
-        // Parse as grouped expression
+        // Parse as grouped expression.
         const expr = this.parseExpr(0);
         this.expect(")");
-
-        // Check for lambda
-        if (this.peek().type === "=>") {
-          // This shouldn't happen if we parsed a full expression
-        }
-
         return expr;
       }
 
@@ -727,6 +715,10 @@ class Parser {
 
   private peek(): Token {
     return this.tokens[this.pos] || { type: "eof", value: "", pos: 0 };
+  }
+
+  private peekAt(offset: number): Token {
+    return this.tokens[this.pos + offset] || { type: "eof", value: "", pos: 0 };
   }
 
   private advance(): Token {

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -258,6 +258,21 @@ export async function cmdSplit(
   }
 }
 
+function sanitizeForFilename(val: string): string {
+  return val.replace(/[^a-zA-Z0-9_-]/g, "_") || "empty";
+}
+
+// FNV-1a 32-bit hash, base36, 6 chars. Deterministic and short — used
+// only to disambiguate filenames when distinct partition values
+// sanitize to the same name (e.g. `a/b` and `a:b` → `a_b`).
+function shortHash(s: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h = ((h ^ s.charCodeAt(i)) * 16777619) >>> 0;
+  }
+  return h.toString(36).padStart(6, "0").slice(0, 6);
+}
+
 /**
  * Partition: split CSV by column value into separate outputs
  * Usage: xan partition COLUMN [OPTIONS] [FILE]
@@ -313,12 +328,42 @@ export async function cmdPartition(
     groups.get(val)?.push(row);
   }
 
-  // Write files
+  // Write files. Sanitization replaces every non-[A-Za-z0-9_-] character
+  // with `_`, so distinct values like `a/b`, `a:b`, `a b` all sanitize to
+  // `a_b`. Without disambiguation the second group silently overwrites
+  // the first — a data-loss bug. We resolve filenames via a single
+  // allocator that tracks every name actually emitted, so a collision
+  // between a hash-suffixed colliding name and an unsuffixed non-
+  // colliding name (e.g. value `a/b` hashes to `a_b_g8wk3l` while the
+  // literal value `a_b_g8wk3l` would also produce `a_b_g8wk3l.csv`)
+  // is broken with an additional `_1`, `_2`, … counter rather than
+  // letting one partition silently overwrite another.
+  const sanitizedCounts = new Map<string, number>();
+  for (const val of groups.keys()) {
+    const safe = sanitizeForFilename(val);
+    sanitizedCounts.set(safe, (sanitizedCounts.get(safe) ?? 0) + 1);
+  }
+  const allocatedNames = new Set<string>();
+  const finalName = new Map<string, string>();
+  for (const val of groups.keys()) {
+    const safe = sanitizeForFilename(val);
+    const colliding = (sanitizedCounts.get(safe) ?? 0) > 1;
+    const base = colliding ? `${safe}_${shortHash(val)}` : safe;
+    let candidate = `${base}.csv`;
+    let n = 1;
+    while (allocatedNames.has(candidate)) {
+      candidate = `${base}_${n}.csv`;
+      n++;
+    }
+    allocatedNames.add(candidate);
+    finalName.set(val, candidate);
+  }
+
   try {
     const outPath = ctx.fs.resolvePath(ctx.cwd, outputDir);
     for (const [val, rows] of groups) {
-      const safeVal = val.replace(/[^a-zA-Z0-9_-]/g, "_") || "empty";
-      const fileName = `${safeVal}.csv`;
+      const fileName = finalName.get(val);
+      if (!fileName) continue;
       const filePath = ctx.fs.resolvePath(outPath, fileName);
       await ctx.fs.writeFile(filePath, formatCsv(headers, rows));
     }

--- a/packages/just-bash/src/commands/xan/xan.data.test.ts
+++ b/packages/just-bash/src/commands/xan/xan.data.test.ts
@@ -221,4 +221,141 @@ describe("xan partition", () => {
       "xan partition: column 'nonexistent' not found\n",
     );
   });
+
+  it("does not silently overwrite when distinct values share a sanitized filename", async () => {
+    // The HIGH_BUG finding: `a/b`, `a:b`, and `a b` all sanitize to
+    // `a_b`, so the prior implementation wrote three groups to the
+    // same file `a_b.csv` — silent data loss.
+    const bash = new Bash({
+      files: {
+        "/data.csv":
+          "key,value\na/b,1\na:b,2\na b,3\nplain,4\na/b,11\na:b,22\na b,33\n",
+      },
+    });
+    const result = await bash.exec("xan partition key /data.csv");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Partitioned into 4 files by 'key'\n");
+
+    // Each colliding sanitized name must produce a distinct file.
+    const ls = await bash.exec("ls /");
+    expect(ls.exitCode).toBe(0);
+    const files = ls.stdout
+      .split("\n")
+      .filter((f) => f.endsWith(".csv") && f !== "data.csv");
+    // 4 partitions: 3 colliding + 1 plain
+    expect(files.length).toBe(4);
+
+    // Plain (non-colliding) value keeps the simple filename.
+    expect(files).toContain("plain.csv");
+
+    // Colliding files must each contain only their own group's rows.
+    // Read all colliding partition files and verify partition isolation.
+    const collidingFiles = files.filter(
+      (f) => f.startsWith("a_b") && f !== "plain.csv",
+    );
+    expect(collidingFiles.length).toBe(3);
+    const groupContents = await Promise.all(
+      collidingFiles.map(async (f) => {
+        const r = await bash.exec(`cat /${f}`);
+        return r.stdout;
+      }),
+    );
+    // Each file has its own header + 2 rows of one specific key.
+    const allValues = groupContents.flatMap((c) =>
+      c
+        .split("\n")
+        .slice(1)
+        .filter((l) => l.length > 0),
+    );
+    expect(allValues.sort()).toEqual([
+      "a b,3",
+      "a b,33",
+      "a/b,1",
+      "a/b,11",
+      "a:b,2",
+      "a:b,22",
+    ]);
+  });
+
+  it("disambiguates a hash-suffixed colliding name vs a literal value with the same sanitized form", async () => {
+    // Concrete failure mode left by a naive hash-only fix: distinct
+    // values `a/b` and `a:b` both sanitize to `a_b` and get hash
+    // suffixes (e.g. `a_b_<hash(a/b)>.csv`). If a third literal value
+    // happens to equal one of those hashed names — `a_b_<hash(a/b)>` —
+    // its plain sanitized name overwrites the hashed colliding file.
+    // The allocator must catch this and append a counter.
+    //
+    // We compute the actual hash for `a/b` via the same FNV-1a logic
+    // the implementation uses, then add a literal value equal to that
+    // hashed-out name and verify all three partitions coexist on disk.
+    const fnv1a = (s: string): string => {
+      let h = 2166136261;
+      for (let i = 0; i < s.length; i++) {
+        h = ((h ^ s.charCodeAt(i)) * 16777619) >>> 0;
+      }
+      return h.toString(36).padStart(6, "0").slice(0, 6);
+    };
+    const collidingHash = fnv1a("a/b");
+    const literalLikeSuffixed = `a_b_${collidingHash}`;
+
+    const bash = new Bash({
+      files: {
+        "/data.csv": `key,value\na/b,1\na:b,2\n${literalLikeSuffixed},3\n`,
+      },
+    });
+    const result = await bash.exec("xan partition key /data.csv");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Partitioned into 3 files by 'key'\n");
+
+    const ls = await bash.exec("ls /");
+    expect(ls.exitCode).toBe(0);
+    const files = ls.stdout
+      .split("\n")
+      .filter((f) => f.endsWith(".csv") && f !== "data.csv")
+      .sort();
+    // Three distinct partitions ⇒ three distinct files.
+    expect(files.length).toBe(3);
+    expect(new Set(files).size).toBe(3);
+
+    // Read each file and confirm its row matches the partition key.
+    const rowsPerFile = await Promise.all(
+      files.map(async (f) => {
+        const r = await bash.exec(`cat /${f}`);
+        const lines = r.stdout.split("\n").filter((l) => l.length > 0);
+        return lines.slice(1); // drop header
+      }),
+    );
+    const allRows = rowsPerFile.flat().sort();
+    expect(allRows).toEqual(["a/b,1", "a:b,2", `${literalLikeSuffixed},3`]);
+  });
+
+  it("uses a deterministic suffix for repeated runs (same input = same filenames)", async () => {
+    const setup = () =>
+      new Bash({
+        files: { "/data.csv": "k,v\na/b,1\na:b,2\n" },
+      });
+
+    const r1 = await setup().exec("xan partition k /data.csv");
+    expect(r1.exitCode).toBe(0);
+    const ls1 = await (async () => {
+      const b = setup();
+      await b.exec("xan partition k /data.csv");
+      const r = await b.exec("ls /");
+      return r.stdout
+        .split("\n")
+        .filter((f) => f.endsWith(".csv") && f !== "data.csv")
+        .sort();
+    })();
+    const ls2 = await (async () => {
+      const b = setup();
+      await b.exec("xan partition k /data.csv");
+      const r = await b.exec("ls /");
+      return r.stdout
+        .split("\n")
+        .filter((f) => f.endsWith(".csv") && f !== "data.csv")
+        .sort();
+    })();
+    expect(ls1).toEqual(ls2);
+    expect(ls1.length).toBe(2);
+  });
 });

--- a/packages/just-bash/src/network/dns-pin-fetch.test.ts
+++ b/packages/just-bash/src/network/dns-pin-fetch.test.ts
@@ -1,0 +1,130 @@
+/**
+ * End-to-end test that secureFetch pins DNS resolution at the actual
+ * connection layer to the address validated at preflight.
+ *
+ * The CRITICAL DNS rebinding finding said the preflight DNS lookup
+ * (in checkAllowed) and the connect-time DNS lookup (inside undici
+ * under globalThis.fetch) were independent, so an attacker controlling
+ * authoritative DNS could return a public IP at preflight and 127.0.0.1
+ * at connect time. The fix wraps the actual fetch in `pinDns(...)`,
+ * which intercepts `dns.lookup` for the validated hostname so that
+ * undici receives the pre-validated IP.
+ *
+ * To prove the fix engages, we install a stub `globalThis.fetch` that —
+ * inside its body — calls `dns.lookup` for the same hostname. If pinning
+ * is active, the lookup must return the pinned IP, NOT what real DNS
+ * (or the test default) would return.
+ */
+import dns from "node:dns";
+import { afterEach, describe, expect, it } from "vitest";
+import { createSecureFetch } from "./fetch.js";
+
+const originalFetch: typeof globalThis.fetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function lookupAll(
+  hostname: string,
+): Promise<{ address: string; family: number }[]> {
+  return new Promise((resolve, reject) => {
+    dns.lookup(hostname, { all: true }, (err, addresses) => {
+      if (err) reject(err);
+      else resolve(addresses as { address: string; family: number }[]);
+    });
+  });
+}
+
+describe("secureFetch DNS pinning", () => {
+  it("pins dns.lookup inside fetch to the address validated at preflight", async () => {
+    const seen: { address: string; family: number }[][] = [];
+    globalThis.fetch = (async () => {
+      // Connect-time resolution path: this is what undici would do.
+      // With pinning, the lookup must return the validated address even
+      // though no real DNS server resolves "attacker.example".
+      seen.push(await lookupAll("attacker.example"));
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    const secureFetch = createSecureFetch({
+      dangerouslyAllowFullInternetAccess: true,
+      denyPrivateRanges: true,
+      // Preflight returns a public IP (passes private-range check).
+      // Pinning must use this exact address at connect time.
+      _dnsResolve: async () => [{ address: "93.184.216.34", family: 4 }],
+    });
+
+    const result = await secureFetch("https://attacker.example/path");
+    expect(result.status).toBe(200);
+    expect(seen).toEqual([[{ address: "93.184.216.34", family: 4 }]]);
+    // sanity check: 93.184.216.34 is example.com — definitely not what real
+    // DNS would return for "attacker.example", proving pinning is engaged.
+  });
+
+  it("does not pin when denyPrivateRanges is off (no preflight DNS validation)", async () => {
+    let lookupErr: NodeJS.ErrnoException | null = null;
+    globalThis.fetch = (async () => {
+      // No pinning context — dns.lookup of an invalid host should
+      // fall through to the real resolver and produce ENOTFOUND.
+      try {
+        await lookupAll("definitely-not-a-real-host.invalid");
+      } catch (e) {
+        lookupErr = e as NodeJS.ErrnoException;
+      }
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    const secureFetch = createSecureFetch({
+      dangerouslyAllowFullInternetAccess: true,
+      denyPrivateRanges: false,
+    });
+
+    const result = await secureFetch(
+      "https://definitely-not-a-real-host.invalid/x",
+    );
+    expect(result.status).toBe(200);
+    expect(lookupErr).not.toBeNull();
+    expect(lookupErr).toMatchObject({ code: "ENOTFOUND" });
+  });
+
+  it("re-pins on redirect to a different host", async () => {
+    const seen: { hostname: string; address: string; family: number }[] = [];
+    let firstCall = true;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = new URL(typeof url === "string" ? url : url.toString());
+      const addrs = await lookupAll(u.hostname);
+      seen.push({
+        hostname: u.hostname,
+        address: addrs[0].address,
+        family: addrs[0].family,
+      });
+      if (firstCall) {
+        firstCall = false;
+        return new Response("", {
+          status: 302,
+          headers: { location: "https://second.example/landing" },
+        });
+      }
+      return new Response("ok", { status: 200 });
+    }) as typeof fetch;
+
+    const secureFetch = createSecureFetch({
+      allowedUrlPrefixes: ["https://first.example", "https://second.example"],
+      denyPrivateRanges: true,
+      _dnsResolve: async (hostname: string) => {
+        if (hostname === "first.example") {
+          return [{ address: "8.8.8.8", family: 4 }];
+        }
+        return [{ address: "1.1.1.1", family: 4 }];
+      },
+    });
+
+    const result = await secureFetch("https://first.example/start");
+    expect(result.status).toBe(200);
+    expect(seen).toEqual([
+      { hostname: "first.example", address: "8.8.8.8", family: 4 },
+      { hostname: "second.example", address: "1.1.1.1", family: 4 },
+    ]);
+  });
+});

--- a/packages/just-bash/src/network/dns-pin.test.ts
+++ b/packages/just-bash/src/network/dns-pin.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Unit tests for the dns-pin AsyncLocalStorage-scoped dns.lookup
+ * interception used to defeat DNS rebinding attacks.
+ *
+ * The fix replaces only the resolution that fetch's underlying socket
+ * does at connect time, so calls outside the pinning context must be
+ * unaffected.
+ */
+import dns from "node:dns";
+import { describe, expect, it } from "vitest";
+import { _ensureDnsHookInstalled, pinDns } from "./dns-pin.js";
+
+function lookupCb(
+  hostname: string,
+  options: dns.LookupOptions = {},
+): Promise<{ address: string; family: number }[]> {
+  return new Promise((resolve, reject) => {
+    dns.lookup(hostname, { all: true, ...options }, (err, addresses) => {
+      if (err) reject(err);
+      else resolve(addresses as { address: string; family: number }[]);
+    });
+  });
+}
+
+function lookupSingle(
+  hostname: string,
+): Promise<{ address: string; family: number }> {
+  return new Promise((resolve, reject) => {
+    dns.lookup(hostname, (err, address, family) => {
+      if (err) reject(err);
+      else resolve({ address, family });
+    });
+  });
+}
+
+describe("dns-pin", () => {
+  it("returns the pinned address inside the pinning context (all=true)", async () => {
+    const result = await pinDns(
+      { hostname: "rebind.example", address: "1.2.3.4", family: 4 },
+      () => lookupCb("rebind.example"),
+    );
+    expect(result).toEqual([{ address: "1.2.3.4", family: 4 }]);
+  });
+
+  it("returns the pinned address inside the pinning context (callback form)", async () => {
+    const result = await pinDns(
+      { hostname: "rebind.example", address: "1.2.3.4", family: 4 },
+      () => lookupSingle("rebind.example"),
+    );
+    expect(result).toEqual({ address: "1.2.3.4", family: 4 });
+  });
+
+  it("ignores hostname mismatch — falls through to original dns.lookup", async () => {
+    // Inside the pinning context for "evil.example" we look up "localhost".
+    // The pinning entry must NOT apply, and the original dns.lookup runs.
+    const result = await pinDns(
+      { hostname: "evil.example", address: "1.2.3.4", family: 4 },
+      () => lookupCb("localhost"),
+    );
+    // localhost resolves to loopback (127.0.0.1 or ::1)
+    const hasLoopback = result.some(
+      ({ address }) => address === "127.0.0.1" || address === "::1",
+    );
+    expect(hasLoopback).toBe(true);
+    // And NOT the pinned address
+    const hasPinned = result.some(({ address }) => address === "1.2.3.4");
+    expect(hasPinned).toBe(false);
+  });
+
+  it("hostname match is case-insensitive", async () => {
+    const result = await pinDns(
+      { hostname: "Mixed.Case.Example", address: "1.2.3.4", family: 4 },
+      () => lookupCb("mixed.case.example"),
+    );
+    expect(result).toEqual([{ address: "1.2.3.4", family: 4 }]);
+  });
+
+  it("outside pinning context, dns.lookup behaves normally", async () => {
+    _ensureDnsHookInstalled();
+    // No pinning context — should hit real DNS for "localhost".
+    const result = await lookupCb("localhost");
+    const hasLoopback = result.some(
+      ({ address }) => address === "127.0.0.1" || address === "::1",
+    );
+    expect(hasLoopback).toBe(true);
+  });
+
+  it("family mismatch fails closed with ENOTFOUND", async () => {
+    // Pinned address is family=4, but caller asks for family=6 — the
+    // fix returns ENOTFOUND rather than silently substituting an IPv4.
+    await expect(
+      pinDns(
+        { hostname: "rebind.example", address: "1.2.3.4", family: 4 },
+        () =>
+          new Promise<void>((resolve, reject) => {
+            dns.lookup(
+              "rebind.example",
+              { family: 6 },
+              (err: NodeJS.ErrnoException | null) => {
+                if (err) reject(err);
+                else resolve();
+              },
+            );
+          }),
+      ),
+    ).rejects.toMatchObject({ code: "ENOTFOUND" });
+  });
+
+  it("concurrent pin contexts do not leak between async chains", async () => {
+    // Two simultaneous pinDns() calls with different addresses for the
+    // same hostname must each see their own pinned value.
+    const [a, b] = await Promise.all([
+      pinDns({ hostname: "x.example", address: "1.1.1.1", family: 4 }, () =>
+        lookupCb("x.example"),
+      ),
+      pinDns({ hostname: "x.example", address: "2.2.2.2", family: 4 }, () =>
+        lookupCb("x.example"),
+      ),
+    ]);
+    expect(a).toEqual([{ address: "1.1.1.1", family: 4 }]);
+    expect(b).toEqual([{ address: "2.2.2.2", family: 4 }]);
+  });
+});

--- a/packages/just-bash/src/network/dns-pin.ts
+++ b/packages/just-bash/src/network/dns-pin.ts
@@ -1,0 +1,171 @@
+/**
+ * Pin DNS resolution for the actual fetch to the IPs that were validated
+ * by the preflight private-range check, defeating DNS rebinding.
+ *
+ * How it works:
+ * - `dns.lookup` is monkey-patched once globally to consult an
+ *   AsyncLocalStorage store. When called inside a `pinDns(...)` async
+ *   context for the same hostname, it returns the pre-validated address
+ *   without performing any network DNS query.
+ * - Calls outside any pinning context (or for a different hostname)
+ *   are delegated to the original `dns.lookup`.
+ *
+ * Why `dns.lookup` and not `dns.promises.lookup`:
+ * - Node's `net.connect`/`tls.connect` (used by undici under `globalThis.fetch`)
+ *   reads `dns.lookup` at call time and uses the callback form.
+ * - We do not patch the promises form because it's not on the connect path.
+ *
+ * Browser builds: this module is imported transitively from `fetch.ts`
+ * (re-exported via `just-bash/browser`). `node:dns` is aliased to a
+ * stub by the browser build, but `node:async_hooks` cannot be aliased
+ * via a static import. We therefore lazy-load both via `require()`
+ * inside an `IS_BROWSER === false` guard so esbuild can dead-code
+ * eliminate the Node-only path. In the browser the exported `pinDns`
+ * is a passthrough that just runs the callback (the preflight that
+ * would have produced a `PinnedAddress` always throws first because
+ * `node:dns` is unavailable, so the passthrough is unreachable).
+ */
+
+declare const __BROWSER__: boolean | undefined;
+const IS_BROWSER = typeof __BROWSER__ !== "undefined" && __BROWSER__;
+
+export interface PinnedAddress {
+  hostname: string;
+  address: string;
+  family: 4 | 6;
+}
+
+type AsyncLocalStorageType<T> = {
+  run<R>(store: T, callback: () => R): R;
+  getStore(): T | undefined;
+};
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address?: string | { address: string; family: number }[],
+  family?: number,
+) => void;
+
+let pinningStore: AsyncLocalStorageType<PinnedAddress> | null = null;
+// biome-ignore lint/suspicious/noExplicitAny: dns module shape varies by runtime
+let dnsModule: any = null;
+let dnsHookInstalled = false;
+
+function loadNodeDeps(): void {
+  if (pinningStore !== null) return;
+  if (IS_BROWSER) return;
+  try {
+    // require() so esbuild dead-code-eliminates this in the browser build.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const asyncHooks = require("node:async_hooks");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    dnsModule = require("node:dns");
+    pinningStore = new asyncHooks.AsyncLocalStorage();
+  } catch {
+    // Edge runtimes without async_hooks: leave pinningStore null.
+    // pinDns becomes a passthrough; callers that expected pinning
+    // (denyPrivateRanges + DNS resolution) will not get it on those
+    // runtimes. The preflight DNS resolution itself would have failed
+    // first if dns was unavailable, so this branch is mostly belt-and-
+    // suspenders.
+  }
+}
+
+function installDnsHook(): void {
+  if (dnsHookInstalled) return;
+  loadNodeDeps();
+  if (!pinningStore || !dnsModule) return;
+  dnsHookInstalled = true;
+
+  const store = pinningStore;
+  const originalLookup = dnsModule.lookup;
+
+  function patchedLookup(this: unknown, ...args: unknown[]): unknown {
+    const hostname = args[0];
+    const pinned = store.getStore();
+
+    if (
+      typeof hostname !== "string" ||
+      !pinned ||
+      pinned.hostname.toLowerCase() !== hostname.toLowerCase()
+    ) {
+      return (originalLookup as (...a: unknown[]) => unknown).apply(this, args);
+    }
+
+    // @banned-pattern-ignore: static field access only (`family`, `all`)
+    let options: { family?: number; all?: boolean } = {};
+    let callback: LookupCallback | undefined;
+
+    if (args.length === 2) {
+      callback = args[1] as LookupCallback;
+    } else if (args.length >= 3) {
+      const raw = args[1];
+      if (typeof raw === "number") {
+        options = { family: raw };
+      } else if (raw && typeof raw === "object") {
+        options = raw as { family?: number; all?: boolean };
+      }
+      callback = args[2] as LookupCallback;
+    }
+
+    if (typeof callback !== "function") {
+      return (originalLookup as (...a: unknown[]) => unknown).apply(this, args);
+    }
+
+    const cb = callback;
+
+    if (
+      options.family !== undefined &&
+      options.family !== 0 &&
+      options.family !== pinned.family
+    ) {
+      // Family mismatch — emulate ENOTFOUND so the connection fails closed
+      // rather than silently returning a wrong-family address.
+      const err = new Error(
+        `ENOTFOUND ${hostname}`,
+      ) as NodeJS.ErrnoException & { hostname?: string };
+      err.code = "ENOTFOUND";
+      err.errno = -3008;
+      err.syscall = "getaddrinfo";
+      err.hostname = hostname;
+      process.nextTick(() => cb(err));
+      return;
+    }
+
+    process.nextTick(() => {
+      if (options.all) {
+        cb(null, [{ address: pinned.address, family: pinned.family }]);
+      } else {
+        cb(null, pinned.address, pinned.family);
+      }
+    });
+  }
+
+  Object.defineProperty(dnsModule, "lookup", {
+    value: patchedLookup,
+    writable: true,
+    configurable: true,
+  });
+}
+
+/**
+ * Run `fn` with `dns.lookup` for `pinned.hostname` resolving to
+ * `pinned.address`/`pinned.family`. Resolutions for other hostnames
+ * pass through to the original `dns.lookup`.
+ */
+export function pinDns<T>(
+  pinned: PinnedAddress,
+  fn: () => Promise<T>,
+): Promise<T> {
+  installDnsHook();
+  if (!pinningStore) return fn();
+  return pinningStore.run(pinned, fn);
+}
+
+/**
+ * @internal Exposed for tests to verify the patched dns.lookup behaves
+ * correctly inside and outside a pinning context.
+ */
+export function _ensureDnsHookInstalled(): void {
+  installDnsHook();
+}

--- a/packages/just-bash/src/network/fetch.ts
+++ b/packages/just-bash/src/network/fetch.ts
@@ -16,6 +16,7 @@ import {
   matchesAllowListEntry,
   validateAllowList,
 } from "./allow-list.js";
+import { type PinnedAddress, pinDns } from "./dns-pin.js";
 import type { AllowedUrl, AllowedUrlEntry, DnsLookupResult } from "./types.js";
 import {
   type FetchResult,
@@ -133,10 +134,14 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
   const resolveDns = config._dnsResolve ?? dnsLookupAll;
 
   /**
-   * Checks if a URL is allowed by the configuration.
+   * Checks if a URL is allowed by the configuration and, when
+   * denyPrivateRanges is on, returns the validated DNS result so the
+   * actual fetch can be pinned to that exact address (defeats DNS
+   * rebinding between the preflight check and connection).
+   *
    * @throws NetworkAccessDeniedError if the URL is not allowed
    */
-  async function checkAllowed(url: string): Promise<void> {
+  async function checkAllowed(url: string): Promise<PinnedAddress | null> {
     if (
       !config.dangerouslyAllowFullInternetAccess &&
       !isUrlAllowed(url, entries)
@@ -164,6 +169,8 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
         if (isDomainName) {
           try {
             const addresses = await resolveDns(hostname);
+            // First pass: any private address rejects the whole resolution.
+            // Second pass: pick the first public address to pin the fetch to.
             for (const { address } of addresses) {
               if (isPrivateIp(address)) {
                 throw new NetworkAccessDeniedError(
@@ -171,6 +178,14 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
                   "hostname resolves to private/loopback IP address",
                 );
               }
+            }
+            const first = addresses[0];
+            if (first) {
+              return {
+                hostname,
+                address: first.address,
+                family: first.family === 6 ? 6 : 4,
+              };
             }
           } catch (dnsErr) {
             if (dnsErr instanceof NetworkAccessDeniedError) throw dnsErr;
@@ -193,6 +208,7 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
         // Invalid URL will be caught by isUrlAllowed below
       }
     }
+    return null;
   }
 
   /**
@@ -220,7 +236,7 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
     const method = options.method?.toUpperCase() ?? "GET";
 
     // Check if URL and method are allowed
-    await checkAllowed(url);
+    let pinned = await checkAllowed(url);
     checkMethodAllowed(method);
 
     let currentUrl = url;
@@ -261,6 +277,14 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
             fetchOptions.body = options.body;
           }
 
+          // Pin DNS resolution to the address we already validated so
+          // an attacker controlling DNS for an allow-listed hostname
+          // cannot rebind the second resolution to a private/internal IP.
+          // No-op when `pinned` is null (denyPrivateRanges off, IP literal,
+          // or hostname did not resolve).
+          if (pinned) {
+            return pinDns(pinned, () => fetch(currentUrl, fetchOptions));
+          }
           return fetch(currentUrl, fetchOptions);
         });
 
@@ -279,9 +303,11 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
           // Resolve relative URLs
           const redirectUrl = new URL(location, currentUrl).href;
 
-          // Check redirect target against allow-list and private IP ranges
+          // Check redirect target against allow-list and private IP ranges.
+          // Re-pin DNS for the redirect target — the validated address
+          // is per-host, so each new hop needs its own resolution.
           try {
-            await checkAllowed(redirectUrl);
+            pinned = await checkAllowed(redirectUrl);
           } catch {
             throw new RedirectNotAllowedError(redirectUrl);
           }


### PR DESCRIPTION
A batch of correctness fixes uncovered while auditing edge cases. Each
change is accompanied by a regression test (or a CI-config update where
no runtime test applies).

## Summary

- **Network — pin DNS resolution to the address used by the preflight check.**
  `createSecureFetch` already resolves a hostname once to evaluate
  `denyPrivateRanges`, but the eventual `globalThis.fetch` call did its
  own independent resolution at connect time. The two could disagree
  for hostnames whose DNS records change between calls (TTL=0, anycast
  variation, multi-A-record load balancing). The wrapper now stores
  the validated `{ hostname, address, family }` and runs the actual
  fetch — and every redirect hop — inside an AsyncLocalStorage scope
  that intercepts `dns.lookup` for that hostname so the connection
  uses the same address the preflight evaluated. Outside the scope
  (and outside Node — the module is dead-code-eliminated in the
  browser build via the existing `__BROWSER__` define + lazy
  `require()` pattern), `dns.lookup` is unaffected.

- **sqlite3 — write-back covers more mutating statements.** The
  worker classified statements with a `startsWith` allow-list on
  `INSERT|UPDATE|DELETE|CREATE|DROP|ALTER|REPLACE|VACUUM`. Statements
  that mutated the database but didn't begin with one of those tokens
  — CTE-prefixed writes (`WITH … INSERT/UPDATE/DELETE`), mutating
  `PRAGMA` (`PRAGMA user_version = N`), and `--`/`/* */` comment-led
  writes — executed but didn't persist, so `sqlite3` returned
  exit 0 while the on-disk database was unchanged. The classifier is
  now an inverse allow-list (only provably read-only statements skip
  write-back) with comment/whitespace stripping.

- **xan partition — distinct values produce distinct files.** Filename
  sanitization replaces every non-`[A-Za-z0-9_-]` character with `_`,
  so `a/b`, `a:b`, and `a b` all produced `a_b.csv` and the later
  groups silently overwrote earlier ones. The fix adds a deterministic
  hash suffix when multiple values share a sanitized name, and runs
  the candidates through a global allocator with a `_1`, `_2`, …
  counter so a hash-suffixed name can't collide with a literal value
  whose plain sanitization is the same string.

- **xan moonblade parser — fix infinite recursion on `(ident)`-shaped
  inputs.** The `(` case in `parsePrefix` had a hand-rolled
  backtracking heuristic (`pos -= params.length * 2`) that miscounted
  comma tokens, leaving `pos` at zero and re-entering the same case
  for inputs like `(x)` or `(x, y)` not followed by `=>`. Replaced
  with a `startPos` save/restore plus a `peekAt(1)` `=>` lookahead so
  the parser commits to lambda parsing only when the disambiguation
  succeeds. `xan filter '(x)' data.csv` no longer stack-overflows.

- **rg — `-j`/`--threads` no longer clobbers `--max-depth`.** The
  no-op `-j`/`--threads` compatibility flag stored its (ignored)
  value through `target: "maxDepth"`, so passing `-j 4` silently set
  `options.maxDepth = Infinity` and disabled the safe default of 256
  (and any earlier `--max-depth` on the same command line). The
  parser now has an `ignored: true` flag on `ValueOptDef` that
  consumes the value without writing anywhere. Existing behavior of
  `-j` (no-op in this single-threaded environment) is unchanged.

- **Terminal rendering — only render http/https/mailto links from
  OSC 8 sequences.** `LiteTerminal.createStyledSpan` previously took
  whatever URL the OSC 8 sequence contained and assigned it directly
  to `link.href`. The href is now validated against an allow-list of
  schemes (`http:`, `https:`, `mailto:`); other schemes fall through
  to a plain styled span.

- **Terminal rendering — strip control characters from model-streamed
  and URL-supplied text before `term.write`.** `text-delta`,
  `reasoning-delta`, tool-call args, and tool-result lines are
  `stripAnsi`'d before they reach our SGR-wrapping code. The
  `?agent=` query parameter is sanitized and bash-single-quoted before
  being passed to the bash parser. The `executeCommand` /
  `setInitialCommand` echo path strips ANSI as defense-in-depth so
  callers that forget to sanitize are still protected.

- **CI — pin third-party actions in the release workflow to commit
  SHAs.** `actions/checkout@v4`, `pnpm/action-setup@v4`, and
  `actions/setup-node@v4` are now pinned to their resolved commits.
  Mutable `@v4` tags meant a moved tag or a compromised upstream
  could change what runs in this workflow without a corresponding
  PR. Tags are kept in trailing comments for readability.

## New / updated tests

- `packages/just-bash/src/network/dns-pin.test.ts` — 7 unit tests
  covering hostname match (case-insensitive), miss → fall-through to
  real DNS, family mismatch fails closed, and concurrent contexts
  don't leak.
- `packages/just-bash/src/network/dns-pin-fetch.test.ts` — 3 e2e
  tests that spy on `dns.lookup` from inside a stubbed `globalThis.fetch`
  and assert the lookup returns the address from the preflight,
  including across redirects.
- `packages/just-bash/src/commands/sqlite3/sqlite3.writeback-edge-cases.test.ts`
  — 7 tests: CTE-prefixed INSERT/UPDATE/DELETE, mutating `PRAGMA`,
  `--` and `/* */` comment-led writes, and a negative control that a
  plain `SELECT` is still classified read-only.
- `packages/just-bash/src/commands/xan/xan.data.test.ts` — 3 new
  partition tests: collision disambiguation, hash-suffixed-vs-literal
  collision, and deterministic filenames across runs.
- `packages/just-bash/src/commands/xan/moonblade-parser.test.ts` —
  6 parser tests covering `(x)`, `(x > 5)`, `(x, y)` without `=>`,
  `(x) => …`, `(a, b) => …`, and `(x).len()`.
- `packages/just-bash/src/commands/rg/rg-parser-threads.test.ts` —
  6 tests: `-j N`, `--threads N`, `--max-depth N -j 4`,
  `-j 4 --max-depth N`, combined-flag form `-Iij 4`, and a sanity
  check that `DEFAULT_MAX_DEPTH` stays finite.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build` (including the browser bundle, which now succeeds with
  the lazy-load pattern in `dns-pin.ts`)
- `pnpm test:run` — 13,230 tests pass
- `pnpm test:wasm src/commands/sqlite3/` — 150 tests pass

## Notes on scope

The `dns-pin` module deliberately patches only the callback form of
`dns.lookup` (not `dns.promises.lookup`), because Node's `net.connect`
/ `tls.connect` — used by undici under `globalThis.fetch` — read
`dns.lookup` at call time and use the callback form. Patching the
promises form would be unused on the connect path and would expand
the side-effect surface for no benefit.

The xan partition filename allocator is order-deterministic: the
input `Map<value, rows>` is built in CSV row order (`Map` preserves
insertion order), so the same input always produces the same output
filenames across runs. A test pins this property.
