### PR TITLE
Implement readdirWithFileTypes in MountableFs

### DIFF
--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -232,6 +232,78 @@ describe("MountableFs", () => {
     });
   });
 
+  describe("readdirWithFileTypes", () => {
+    it("should list mount points as directories with types", async () => {
+      const fs = new MountableFs();
+      fs.mount("/mnt/data", new InMemoryFs());
+      fs.mount("/mnt/logs", new InMemoryFs());
+
+      const entries = await fs.readdirWithFileTypes("/mnt");
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0].name).toBe("data");
+      expect(entries[0].isDirectory).toBe(true);
+      expect(entries[0].isFile).toBe(false);
+
+      expect(entries[1].name).toBe("logs");
+      expect(entries[1].isDirectory).toBe(true);
+      expect(entries[1].isFile).toBe(false);
+    });
+
+    it("should merge mount points with base fs entries and preserve types", async () => {
+      const base = new InMemoryFs({
+        "/mnt/readme.txt": "docs",
+        "/mnt/other_dir/file": "content",
+      });
+
+      const fs = new MountableFs({ base });
+      fs.mount("/mnt/data", new InMemoryFs());
+
+      const entries = await fs.readdirWithFileTypes("/mnt");
+
+      expect(entries).toHaveLength(3);
+      // entries are sorted
+      expect(entries[0].name).toBe("data");
+      expect(entries[0].isDirectory).toBe(true);
+
+      expect(entries[1].name).toBe("other_dir");
+      expect(entries[1].isDirectory).toBe(true);
+
+      expect(entries[2].name).toBe("readme.txt");
+      expect(entries[2].isFile).toBe(true);
+    });
+
+    it("should throw ENOENT for non-existent paths", async () => {
+      const fs = new MountableFs();
+      await expect(fs.readdirWithFileTypes("/non-existent")).rejects.toThrow("ENOENT");
+    });
+
+    it("should fallback to readdir + lstat if underlying fs doesn't support readdirWithFileTypes", async () => {
+      // Create a mock fs that doesn't have readdirWithFileTypes
+      // and explicitly provide a simple readdir implementation so it doesn't call the deleted readdirWithFileTypes
+      const mockFs: any = new InMemoryFs({
+        "/file.txt": "content",
+        "/dir/subdir": "content",
+      });
+      mockFs.readdirWithFileTypes = undefined;
+      // Override readdir so it doesn't use the original InMemoryFs logic which calls readdirWithFileTypes
+      mockFs.readdir = async (path: string) => {
+        if (path === "/" || path === "") return ["file.txt", "dir"];
+        if (path === "/dir") return ["subdir"];
+        return [];
+      };
+
+      const fs = new MountableFs({ base: mockFs });
+      const entries = await fs.readdirWithFileTypes("/");
+
+      expect(entries).toHaveLength(2);
+      expect(entries[0].name).toBe("dir");
+      expect(entries[0].isDirectory).toBe(true);
+      expect(entries[1].name).toBe("file.txt");
+      expect(entries[1].isFile).toBe(true);
+    });
+  });
+
   describe("rm operations", () => {
     it("should remove files from mounted filesystem", async () => {
       const mounted = new InMemoryFs({ "/test.txt": "content" });

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -2,6 +2,7 @@ import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
 import type {
   BufferEncoding,
   CpOptions,
+  DirentEntry,
   FileContent,
   FsStat,
   IFileSystem,
@@ -442,6 +443,70 @@ export class MountableFs implements IFileSystem {
     }
 
     return Array.from(entries).sort();
+  }
+
+  async readdirWithFileTypes(path: string): Promise<DirentEntry[]> {
+    const normalized = normalizePath(path);
+    const entries = new Map<string, DirentEntry>();
+    let readdirError: Error | null = null;
+
+    // Get entries from the owning filesystem
+    const { fs, relativePath } = this.routePath(path);
+    try {
+      if (fs.readdirWithFileTypes) {
+        const fsEntries = await fs.readdirWithFileTypes(relativePath);
+        for (const entry of fsEntries) {
+          entries.set(entry.name, entry);
+        }
+      } else {
+        // Fallback if underlying fs doesn't support readdirWithFileTypes
+        const names = await fs.readdir(relativePath);
+        for (const name of names) {
+          const entryPath = joinPath(relativePath, name);
+          try {
+            const stats = await fs.lstat(entryPath);
+            entries.set(name, {
+              name,
+              isFile: stats.isFile,
+              isDirectory: stats.isDirectory,
+              isSymbolicLink: stats.isSymbolicLink,
+            });
+          } catch {
+            // Ignore stat errors for individual entries
+          }
+        }
+      }
+    } catch (err) {
+      // Path might not exist in base FS if only mount points are there
+      const code = (err as { code?: string }).code;
+      const message = (err as { message?: string }).message || "";
+
+      if (code !== "ENOENT" && !message.includes("ENOENT")) {
+        throw err;
+      }
+      // Save error to throw later if no mount points provide entries
+      readdirError = err as Error;
+    }
+
+    // Add mount points that are immediate children
+    const childMounts = this.getChildMountPoints(normalized);
+    for (const child of childMounts) {
+      entries.set(child, {
+        name: child,
+        isFile: false,
+        isDirectory: true,
+        isSymbolicLink: false,
+      });
+    }
+
+    // If no entries found and we had an error, throw the original error
+    if (entries.size === 0 && readdirError && !this.mounts.has(normalized)) {
+      throw readdirError;
+    }
+
+    return Array.from(entries.values()).sort((a, b) =>
+      a.name < b.name ? -1 : a.name > b.name ? 1 : 0
+    );
   }
 
   async rm(path: string, options?: RmOptions): Promise<void> {


### PR DESCRIPTION
## Summary
- Implemented the `readdirWithFileTypes` method in `MountableFs`.
- Added logic to inject mount points accurately as directories with correct file types.
- Implemented a fallback strategy using `readdir` followed by `lstat` for file systems lacking native support.
- Fixed type-check errors by correctly importing the `DirentEntry` interface.
- Standardized sorting logic to ensure parity with the native `readdir` method.

## What Changed
- `packages/just-bash/src/fs/mountable-fs/mountable-fs.ts`: Added the `readdirWithFileTypes` implementation, fixed missing type imports, and applied consistent UTF-16 sorting.
- `packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts`: Added test cases, safely mocked properties to avoid test runner crashes, and included an explicit `ENOENT` test case.

## Verification
- Evaluated the implementation via `bun test packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts`, confirming all 62 tests pass.
- Validated type safety locally by running `tsc --noEmit`.
- Ran manual sorting tests to confirm identical sorting behavior between `readdir` and `readdirWithFileTypes`.

## Publish Notes
- Target repository: vercel-labs/just-bash
- Publishing through a fork (sashimikun/just-bash -> vercel-labs/just-bash).