### PR TITLE
jq: accept literal control chars inside JSON strings

### DIFF
--- a/.changeset/sunny-donuts-matter.md
+++ b/.changeset/sunny-donuts-matter.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+jq: accept control characters inside JSON strings

--- a/packages/just-bash/src/commands/jq/jq.permissive-control-chars.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.permissive-control-chars.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+// Real jq accepts JSON containing literal control characters inside strings,
+// even though RFC 8259 forbids them. Real-world inputs (webhooks, copy-paste
+// from terminals, log lines piped through `jq`) frequently contain unescaped
+// tabs and newlines, so matching jq's permissive behavior here avoids
+// surprising failures when our jq is dropped into existing pipelines.
+describe("jq permissive control chars in JSON strings", () => {
+  it("accepts a literal newline inside a string value", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"body":"first\nsecond"}\n' },
+    });
+
+    const result = await env.exec("jq -r '.body' /payload.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("first\nsecond\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts a literal tab inside a string value", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"body":"col1\tcol2"}\n' },
+    });
+
+    const result = await env.exec("jq -r '.body' /payload.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("col1\tcol2\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts a literal carriage return inside a string value", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"body":"a\rb"}\n' },
+    });
+
+    const result = await env.exec("jq -r '.body' /payload.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("a\rb\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves a real escape sequence next to a literal control char", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"body":"line1\\nline2\nline3"}\n' },
+    });
+
+    const result = await env.exec("jq -r '.body' /payload.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("line1\nline2\nline3\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not rewrite control characters that appear outside strings", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{\n  "a": 1,\n  "b": 2\n}\n' },
+    });
+
+    const result = await env.exec("jq -c '.' /payload.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe('{"a":1,"b":2}\n');
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("handles concatenated JSON values where one contains a literal newline", async () => {
+    const env = new Bash({
+      files: {
+        "/stream.json": '{"a":"x\ny"}{"a":"z"}\n',
+      },
+    });
+
+    const result = await env.exec("jq -r '.a' /stream.json");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("x\ny\nz\n");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -22,6 +22,68 @@ import {
 } from "../query-engine/index.js";
 import { sanitizeParsedData } from "../query-engine/safe-object.js";
 
+function escapeControlChar(char: string): string {
+  switch (char) {
+    case "\b":
+      return "\\b";
+    case "\f":
+      return "\\f";
+    case "\n":
+      return "\\n";
+    case "\r":
+      return "\\r";
+    case "\t":
+      return "\\t";
+    default:
+      return `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`;
+  }
+}
+
+function sanitizeJsonControlChars(input: string): string {
+  let output = "";
+  let inString = false;
+  let isEscaped = false;
+
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+
+    if (isEscaped) {
+      output += char;
+      isEscaped = false;
+      continue;
+    }
+
+    if (char === "\\") {
+      output += char;
+      isEscaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      output += char;
+      inString = !inString;
+      continue;
+    }
+
+    if (inString && char.charCodeAt(0) <= 0x1f) {
+      output += escapeControlChar(char);
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+function parseJsonSlice(
+  input: string,
+  startPos: number,
+  endPos: number,
+): unknown {
+  return JSON.parse(sanitizeJsonControlChars(input.slice(startPos, endPos)));
+}
+
 /**
  * Parse a JSON stream (concatenated JSON values).
  * Real jq can handle `{...}{...}` or `{...}\n{...}` or pretty-printed concatenated JSONs.
@@ -69,7 +131,7 @@ function parseJsonStream(input: string): unknown[] {
         );
       }
 
-      results.push(sanitizeParsedData(JSON.parse(input.slice(startPos, pos))));
+      results.push(sanitizeParsedData(parseJsonSlice(input, startPos, pos)));
     } else if (char === '"') {
       // Parse string
       let isEscaped = false;
@@ -86,11 +148,11 @@ function parseJsonStream(input: string): unknown[] {
         }
         pos++;
       }
-      results.push(sanitizeParsedData(JSON.parse(input.slice(startPos, pos))));
+      results.push(sanitizeParsedData(parseJsonSlice(input, startPos, pos)));
     } else if (char === "-" || (char >= "0" && char <= "9")) {
       // Parse number
       while (pos < len && /[\d.eE+-]/.test(input[pos])) pos++;
-      results.push(sanitizeParsedData(JSON.parse(input.slice(startPos, pos))));
+      results.push(sanitizeParsedData(parseJsonSlice(input, startPos, pos)));
     } else if (input.slice(pos, pos + 4) === "true") {
       results.push(true);
       pos += 4;


### PR DESCRIPTION
## Summary
Real `jq` accepts JSON containing literal control characters inside strings (newlines, tabs, carriage returns, etc.) even though RFC 8259 forbids them. Real-world inputs — webhooks, log lines piped through `jq`, terminal output copy-pasted into a script — frequently carry literal tabs/newlines inside string values, and rejecting those at the `JSON.parse` boundary surprises users who expect parity with `jq`.

This patch pre-processes each JSON slice that `parseJsonStream` is about to hand to `JSON.parse`: it walks the slice tracking quote/escape state and, when a byte ≤ `0x1f` appears **inside** a string, replaces it with the appropriate JSON escape (`\n`, `\t`, `\r`, `\b`, `\f`, or `\uXXXX`). Outside strings the input is left untouched, so structural whitespace keeps its meaning.

Found while running agent-generated pipelines against just-bash where webhook payloads with embedded newlines triggered `Unexpected token` from `jq`, despite the same payload working under real `jq`.

## Test plan
- [x] `pnpm --filter just-bash typecheck` — clean
- [x] `pnpm --filter just-bash exec vitest run src/commands/jq/` — 12 files / 276 tests pass (6 new in `jq.permissive-control-chars.test.ts`)
- [x] `pnpm lint:fix` — clean

New tests cover:
- literal newline / tab / CR inside a string value
- preserved escape sequence (`\\n`) sitting next to a literal control char
- control chars *outside* strings (structural whitespace) leaving compact output unchanged
- concatenated JSON values where one contains a literal newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)