### PR TITLE
sqlite3: add dot-commands and -init/-batch invocation flags

### DIFF
--- a/packages/just-bash/docs/sqlite3-invocation-shapes.md
+++ b/packages/just-bash/docs/sqlite3-invocation-shapes.md
@@ -1,0 +1,150 @@
+# sqlite3 invocation shapes — agent parity catalogue
+
+This index tracks how reasoning agents actually invoke `sqlite3` in production
+(via the `bash` tool) and our parity status. Source: a Braintrust review of
+~924 spans across the four `flowglad-pay-agent*` projects in 2026-04.
+
+Each shape maps to one or more pinning tests under
+`src/commands/sqlite3/sqlite3.{invocation-shapes,sql-features,dot-commands,flags}.test.ts`.
+If a test in this directory regresses, an agent in production has hit (or will
+hit) the same failure.
+
+This file is the **triage list** — the GitHub issue tracker is disabled on
+this fork, so deferred work lives here. Update the **Status** column when
+patches land.
+
+## Shell invocation shapes
+
+| ID  | Shape                                                       | Status        | Test |
+| --- | ----------------------------------------------------------- | ------------- | ---- |
+| S1  | `sqlite3 :memory: "SELECT sqlite_version();"`               | Supported     | invocation-shapes / S1 |
+| S2  | `which sqlite3 && file $(which sqlite3)` (capability probe) | **Partial**: `file` builtin missing | — |
+| S3  | `sqlite3 <db> "<single SQL>"`                               | Supported     | invocation-shapes / S3 |
+| S4  | `sqlite3 <db> "stmt1; stmt2; stmt3"`                        | Supported     | invocation-shapes / S4 |
+| S5  | `sqlite3 <db> < /workspace/file.sql` (script redirect)      | Supported     | invocation-shapes / S5 |
+| S6  | `echo "<SQL>" \| sqlite3 <db>` (stdin pipe)                 | Supported     | invocation-shapes / S6 |
+| S7  | `sqlite3 <db> "$(cat file.sql)"` (command substitution)     | Supported     | invocation-shapes / S7 |
+| S8  | `sqlite3 -header -separator $'\t' <db> "..."` (TSV+header)  | Supported     | invocation-shapes / S8 |
+| S9  | `sqlite3 -separator $'\t' <db> "..."` (TSV no header)       | Supported     | invocation-shapes / S9 |
+| S10 | `sqlite3 <db> "..." > /workspace/out.tsv`                   | Supported     | invocation-shapes / S10 |
+| S11 | Per-statement loop (sequential calls)                       | Supported     | invocation-shapes / S11 |
+
+## SQL features
+
+| ID  | Feature                                                  | Status    | Test |
+| --- | -------------------------------------------------------- | --------- | ---- |
+| F1  | `CREATE TABLE … AS SELECT …`                             | Supported | sql-features / F1 |
+| F2  | Bulk `INSERT` blocks from script-redirected `.sql`       | Supported | sql-features / F2 |
+| F3  | Window functions (`SUM(...) OVER (PARTITION BY ...)`)    | Supported | sql-features / F3 |
+| F4  | CTEs (`WITH x AS …`) including `WITH RECURSIVE`          | Supported | sql-features / F4 |
+| F5  | `strftime('%Y-%m', …)`, `strftime('%Y-W%W', …)`          | Supported | sql-features / F5 |
+| F6  | `sqlite_master` introspection                            | Supported | sql-features / F6 |
+| F7  | `CASE WHEN`, scalar subqueries                           | Supported | sql-features / F7 |
+| X4  | `PRAGMA table_info(t)` and friends                       | Supported | sql-features / X4 |
+
+## Dot-commands
+
+| ID  | Command                              | Status                 | Test |
+| --- | ------------------------------------ | ---------------------- | ---- |
+| D1  | `.tables [pat]`                      | Supported (one-name-per-line, not multi-column) | dot-commands / D1 |
+| D2  | `.schema [pat]`                      | Supported              | dot-commands / D2 |
+| D3  | `.headers on/off` (alias `.header`)  | Supported              | dot-commands / D3 |
+| D4  | `.mode <list\|csv\|json\|line\|column\|table\|markdown\|tabs\|box\|quote\|html\|ascii>` | Supported (last-mode-wins limitation) | dot-commands / D4 |
+| D5  | `.separator <col> [<row>]`           | Supported              | dot-commands / D5 |
+| D6  | `.nullvalue <text>`                  | Supported              | dot-commands / D6 |
+| D7  | `.read <file>` (recursive)           | Supported              | dot-commands / D7 |
+| D8  | `.import <file> <table>`             | **Deferred — see Open work / D8** | dot-commands / D8 (todo) |
+| D9  | `.dump`                              | **Deferred — see Open work / D9** | dot-commands / D9 (todo) |
+| —   | `.help .show .timer .changes .bail .echo .eqp .width .prompt .print .explain` | Accepted as no-op | — |
+| —   | `.import .dump .clone .save .restore .backup .open .shell .system .iotrace .log .cd .load .excel` | Rejected with explicit error | dot-commands / "explicitly unsupported" |
+
+## Flags
+
+| ID  | Flag                                  | Status    | Test |
+| --- | ------------------------------------- | --------- | ---- |
+| —   | `-list -csv -json -line -column -table -markdown -tabs -box -quote -html -ascii` | Supported | options / output-modes |
+| —   | `-header / -noheader / -separator / -newline / -nullvalue / -readonly / -bail / -echo / -cmd / -version / --` | Supported | options |
+| X1  | `-init <file>`                        | Supported | flags / X1 |
+| X2  | `-batch`                              | Supported (no-op) | flags / X2 |
+
+## Limitations
+
+- **Float precision**: `ROUND(x, 2)` does not emit clean two-decimal output.
+  just-bash mirrors real sqlite3's full IEEE-754 precision (`999.99` →
+  `999.99000000000001`). Agents who need clean cents should compute in
+  integer cents. Pinned in invocation-shapes / S8.
+- **Last-mode-wins**: dot-commands that mutate formatter state (`.mode`,
+  `.headers`, `.separator`, `.nullvalue`) apply globally to the entire
+  invocation, not incrementally. Real sqlite3 applies them statement by
+  statement. Pinned in dot-commands / "interleaved mode + query".
+- **`.tables` format**: one name per line, not real sqlite3's 3-column
+  space-padded format. Easier to parse, but a divergence.
+
+## Open work (deferred)
+
+### D8: `.import <file> <table>` — load CSV/TSV into a table
+
+Real sqlite3 uses `.import` to ingest CSV/TSV. Agents currently work around
+this by translating CSV → `INSERT` statements via `awk`, which is slow and
+brittle. Trace evidence: ~22 invocations of the awk-then-script pattern in
+the sample of 200 spans.
+
+**Suggested approach**: implement in `dot-commands.ts`. Parse
+`.import [--csv|--ascii] [--skip N] FILE TABLE`. Read FILE via `ctx.fs`,
+parse with the existing papaparse dep, translate to `INSERT INTO TABLE
+VALUES (...)` statements appended to the SQL stream.
+
+**Test pin**: `sqlite3.dot-commands.test.ts` has `it.todo` under
+`describe("D8: .import")`. Flip to `it(...)` once implemented.
+
+### D9: `.dump` — emit schema + INSERTs reproducing the database
+
+Walk `sqlite_master`, emit every `CREATE TABLE/INDEX/VIEW/TRIGGER` with a
+trailing `;`, then `SELECT *` from each table to generate `INSERT INTO ...
+VALUES (...)` lines. Wrap in `BEGIN; ... COMMIT;`.
+
+**Test pin**: `sqlite3.dot-commands.test.ts` has `it.todo` under
+`describe("D9: .dump")`.
+
+### X3: `ATTACH DATABASE 'other.db' AS o` to real-FS file paths
+
+sql.js is a sandboxed WASM build with no real-FS access. `ATTACH` to a path
+opens an empty in-memory database, not the file the agent expects.
+
+**Suggested approach**: pre-process `ATTACH DATABASE 'path' AS alias` —
+read `path` via `ctx.fs`, load it into sql.js as an in-memory DB, register
+under `alias`. Write back on exit if modifications detected. Non-trivial:
+need a multi-buffer worker protocol.
+
+**No test pin yet** — file under
+`sqlite3.invocation-shapes.test.ts` if/when added.
+
+### S2: `file` builtin missing
+
+`which sqlite3 && file $(which sqlite3)` — `file` is not a just-bash builtin.
+This isn't strictly a sqlite3 issue; it's a gap in the command set. Agents
+use it to verify the binary type during capability probes.
+
+**Suggested approach**: add `file` as a stub in `src/commands/file/` that
+inspects the magic bytes of the target file and reports an extension-based
+type. Doesn't need full libmagic — just enough to identify ELF, Mach-O,
+PE, ASCII text, JSON, gzip, zip, sqlite, etc.
+
+## When this catalogue should be re-run
+
+Pull a fresh sample any time:
+
+- A `flowglad-pay-agent*` project's prompt set materially changes.
+- We bump `sql.js` (regression risk for SQL features).
+- An agent reports a new failure mode involving `sqlite3`.
+
+Re-run via the Braintrust SQL-query MCP:
+
+```sql
+-- across the four flowglad-pay-agent* projects
+WHERE output::text ILIKE '%sqlite3%'
+ORDER BY created DESC
+LIMIT 200
+```
+
+Then update the tables above and add new pinning tests.

--- a/packages/just-bash/src/commands/sqlite3/dot-commands.ts
+++ b/packages/just-bash/src/commands/sqlite3/dot-commands.ts
@@ -1,0 +1,357 @@
+/**
+ * Dot-command preprocessor for sqlite3.
+ *
+ * Real sqlite3's CLI accepts dot-commands (`.tables`, `.schema`, `.mode csv`,
+ * `.read script.sql`, etc.) interleaved with SQL. The sql.js engine doesn't
+ * implement these — they're a feature of the CLI, not the library — so we
+ * translate them to equivalent SQL or to formatter mutations before handing
+ * the script to the worker.
+ *
+ * Supported:
+ *   .tables [pattern]           -> SELECT name FROM sqlite_master ...
+ *   .schema [pattern]           -> SELECT sql FROM sqlite_master ...
+ *   .indexes [pattern]          -> SELECT name FROM sqlite_master WHERE type='index' ...
+ *   .databases                  -> emits a synthetic "main" row (sql.js has no ATTACH-to-file)
+ *   .headers on|off             -> formatter mutation
+ *   .header  on|off             -> alias of .headers
+ *   .mode <mode>                -> formatter mutation (list|csv|json|line|column|table|markdown|tabs|box|quote|html|ascii)
+ *   .separator <col> [<row>]    -> formatter mutation
+ *   .nullvalue <text>           -> formatter mutation
+ *   .read <file>                -> inline file contents (recursive, max depth 8)
+ *   .quit / .exit               -> stop processing further input (best-effort)
+ *
+ * Not supported (returns an error so an agent sees a clear signal):
+ *   .import .dump .clone .save .restore .backup .open .shell .system .iotrace
+ *
+ * Limitation: formatter mutations are global within a single sqlite3
+ * invocation. The LAST seen `.mode` / `.headers` / `.separator` wins.
+ * Real sqlite3 applies them incrementally; we approximate. This matches
+ * the most common agent use case (`.mode csv` followed by SELECTs).
+ */
+
+import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
+import type { CommandContext } from "../../types.js";
+import type { OutputMode } from "./formatters.js";
+
+const VALID_MODES: ReadonlySet<string> = new Set([
+  "list",
+  "csv",
+  "json",
+  "line",
+  "column",
+  "table",
+  "markdown",
+  "tabs",
+  "box",
+  "quote",
+  "html",
+  "ascii",
+]);
+
+const UNSUPPORTED_DOT_COMMANDS: ReadonlySet<string> = new Set([
+  ".import",
+  ".dump",
+  ".clone",
+  ".save",
+  ".restore",
+  ".backup",
+  ".open",
+  ".shell",
+  ".system",
+  ".iotrace",
+  ".log",
+  ".cd",
+  ".load",
+  ".excel",
+]);
+
+const MAX_READ_DEPTH = 8;
+
+export interface FormatterMutation {
+  mode?: OutputMode;
+  header?: boolean;
+  separator?: string;
+  newline?: string;
+  nullValue?: string;
+}
+
+export interface PreprocessResult {
+  /** SQL with dot-commands replaced by their SQL equivalents. */
+  sql: string;
+  /** Accumulated formatter mutation (last-write-wins). */
+  formatterMutation: FormatterMutation;
+  /** First error encountered, if any. */
+  error?: string;
+  /** Set when .quit/.exit was encountered; everything after is dropped. */
+  quit?: true;
+}
+
+interface PreprocessCtx {
+  fs: CommandContext["fs"];
+  cwd: string;
+  /** Recursion depth tracker for .read. */
+  depth: number;
+}
+
+/**
+ * Tokenize a dot-command line into [name, ...args]. Single- and double-quoted
+ * args are honored; everything else is whitespace-separated. Backslash escapes
+ * are not honored — bash already processed them by the time we see this.
+ */
+function tokenizeDotCommand(line: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote: '"' | "'" | null = null;
+
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+    } else if (ch === " " || ch === "\t") {
+      if (current.length > 0) {
+        tokens.push(current);
+        current = "";
+      }
+    } else {
+      current += ch;
+    }
+  }
+  if (current.length > 0) tokens.push(current);
+  return tokens;
+}
+
+function escapeSqlLiteral(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+/**
+ * Translate a single dot-command to SQL or a formatter mutation.
+ * Returns the SQL replacement (may be empty string for pure mutations),
+ * a quit signal (.quit/.exit, possibly with trailing SQL from .read),
+ * or an error.
+ */
+async function translateDotCommand(
+  tokens: string[],
+  mutation: FormatterMutation,
+  ctx: PreprocessCtx,
+): Promise<{ sql: string; quit?: true } | { error: string }> {
+  const [head, ...rest] = tokens;
+
+  // The caller's guard (`/^\.[a-zA-Z]/`) ensures non-empty tokens in
+  // practice, but make the assumption explicit so a future caller change
+  // can't produce confusing "unknown command: undefined" errors.
+  if (!head) {
+    return { error: "Error: empty dot-command" };
+  }
+
+  if (UNSUPPORTED_DOT_COMMANDS.has(head)) {
+    return {
+      error: `Error: ${head} is not supported by just-bash sqlite3`,
+    };
+  }
+
+  switch (head) {
+    case ".tables": {
+      const pat = rest[0];
+      // Use '~' as ESCAPE char to avoid the JS-template-literal -> SQL
+      // double-escape ambiguity that '\\' creates.
+      const where = pat
+        ? `type='table' AND name NOT LIKE 'sqlite~_%' ESCAPE '~' AND name LIKE '${escapeSqlLiteral(pat)}'`
+        : `type='table' AND name NOT LIKE 'sqlite~_%' ESCAPE '~'`;
+      return {
+        sql: `SELECT name FROM sqlite_master WHERE ${where} ORDER BY name`,
+      };
+    }
+    case ".indexes":
+    case ".indices": {
+      const pat = rest[0];
+      const where = pat
+        ? `type='index' AND tbl_name LIKE '${escapeSqlLiteral(pat)}'`
+        : `type='index'`;
+      return {
+        sql: `SELECT name FROM sqlite_master WHERE ${where} ORDER BY name`,
+      };
+    }
+    case ".schema": {
+      const pat = rest[0];
+      const where = pat
+        ? `type IN ('table','index','view','trigger') AND sql IS NOT NULL AND name LIKE '${escapeSqlLiteral(pat)}'`
+        : `type IN ('table','index','view','trigger') AND sql IS NOT NULL`;
+      // Append ';' so output mirrors real sqlite3 .schema (each CREATE ends with ;)
+      return {
+        sql: `SELECT sql || ';' FROM sqlite_master WHERE ${where} ORDER BY name`,
+      };
+    }
+    case ".databases": {
+      // sql.js sandbox: only "main" is meaningful. Emit a synthetic single row.
+      return {
+        sql: `SELECT 'main' AS name, '' AS file`,
+      };
+    }
+    case ".headers":
+    case ".header": {
+      const v = rest[0]?.toLowerCase();
+      if (v === "on" || v === "true" || v === "1") {
+        mutation.header = true;
+      } else if (v === "off" || v === "false" || v === "0") {
+        mutation.header = false;
+      } else {
+        return {
+          error: `Error: unknown argument to ${head}: ${rest[0] ?? ""}`,
+        };
+      }
+      return { sql: "" };
+    }
+    case ".mode": {
+      const m = rest[0];
+      if (!m || !VALID_MODES.has(m)) {
+        return { error: `Error: unknown mode: ${m ?? ""}` };
+      }
+      mutation.mode = m as OutputMode;
+      // Do NOT touch mutation.separator here — real sqlite3 keeps .separator
+      // independent of .mode (csv/tabs hardcode their separators in the
+      // formatter; list reads from options.separator). Mutating separator
+      // here would clobber an explicit .separator that ran earlier.
+      return { sql: "" };
+    }
+    case ".separator": {
+      if (rest.length === 0) {
+        return { error: "Error: .separator requires an argument" };
+      }
+      mutation.separator = rest[0];
+      if (rest.length > 1) mutation.newline = rest[1];
+      return { sql: "" };
+    }
+    case ".nullvalue": {
+      mutation.nullValue = rest[0] ?? "";
+      return { sql: "" };
+    }
+    case ".read": {
+      const file = rest[0];
+      if (!file) return { error: "Error: .read requires a filename" };
+      if (ctx.depth >= MAX_READ_DEPTH) {
+        return { error: "Error: .read depth limit exceeded" };
+      }
+      let contents: string;
+      try {
+        const path = ctx.fs.resolvePath(ctx.cwd, file);
+        contents = await ctx.fs.readFile(path);
+      } catch (e) {
+        return {
+          error: `Error: cannot open ${file}: ${sanitizeErrorMessage((e as Error).message)}`,
+        };
+      }
+      // Recurse so .read inside the file is also expanded
+      const sub = await preprocessDotCommandsInternal(contents, mutation, {
+        fs: ctx.fs,
+        cwd: ctx.cwd,
+        depth: ctx.depth + 1,
+      });
+      if (sub.error) return { error: sub.error };
+      // Propagate the quit signal: a .quit inside the read'd file should
+      // stop the parent from processing anything that came after .read.
+      return sub.quit ? { sql: sub.sql, quit: true } : { sql: sub.sql };
+    }
+    case ".quit":
+    case ".exit": {
+      // Stop processing further input. Real sqlite3 exits immediately on
+      // .quit; we approximate by dropping everything that follows from
+      // the SQL we emit to the worker.
+      return { sql: "", quit: true };
+    }
+    case ".help":
+    case ".show":
+    case ".timer":
+    case ".changes":
+    case ".bail":
+    case ".echo":
+    case ".eqp":
+    case ".width":
+    case ".prompt":
+    case ".print":
+    case ".explain":
+      // Accept silently; not implemented but harmless to ignore for agent use.
+      return { sql: "" };
+    default:
+      return {
+        error: `Error: unknown command or invalid arguments: "${head.replace(/^\./, "")}". Enter ".help" for help`,
+      };
+  }
+}
+
+async function preprocessDotCommandsInternal(
+  input: string,
+  mutation: FormatterMutation,
+  ctx: PreprocessCtx,
+): Promise<PreprocessResult> {
+  const lines = input.split("\n");
+  const outLines: string[] = [];
+
+  for (const rawLine of lines) {
+    const trimmed = rawLine.trim();
+    // Only treat lines starting with `.` followed by a letter as
+    // dot-commands. SQL line comments (`-- ...`) and SQL fragments that
+    // happen to start with `.` followed by a digit (e.g. a numeric
+    // continuation `.5`) are passed through unchanged.
+    if (
+      trimmed.startsWith("--") ||
+      !trimmed.startsWith(".") ||
+      !/^\.[a-zA-Z]/.test(trimmed)
+    ) {
+      outLines.push(rawLine);
+      continue;
+    }
+    const tokens = tokenizeDotCommand(trimmed);
+    const result = await translateDotCommand(tokens, mutation, ctx);
+    if ("error" in result) {
+      return {
+        sql: outLines.join("\n"),
+        formatterMutation: mutation,
+        error: result.error,
+      };
+    }
+    if (result.sql.length > 0) {
+      // Ensure dot-translated SQL is its own statement. .read produces
+      // multi-line output; split so each line becomes its own outLines
+      // entry rather than a single multi-line element (keeps the
+      // outLines.join("\n") at the end behaving uniformly).
+      const stmt = result.sql.trim();
+      const withSemi = stmt.endsWith(";") ? stmt : `${stmt};`;
+      for (const line of withSemi.split("\n")) {
+        outLines.push(line);
+      }
+    }
+    if (result.quit) {
+      return {
+        sql: outLines.join("\n"),
+        formatterMutation: mutation,
+        quit: true,
+      };
+    }
+  }
+
+  return { sql: outLines.join("\n"), formatterMutation: mutation };
+}
+
+/**
+ * Public entry point. Walks the SQL line by line, replacing dot-commands
+ * with equivalent SQL or formatter mutations. Returns the rewritten SQL
+ * plus the accumulated mutation to apply to FormatOptions.
+ */
+export async function preprocessDotCommands(
+  sql: string,
+  ctx: { fs: CommandContext["fs"]; cwd: string },
+): Promise<PreprocessResult> {
+  const mutation: FormatterMutation = Object.create(null);
+  return preprocessDotCommandsInternal(sql, mutation, {
+    fs: ctx.fs,
+    cwd: ctx.cwd,
+    depth: 0,
+  });
+}

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.dot-commands.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.dot-commands.test.ts
@@ -1,0 +1,328 @@
+/**
+ * Dot-command tests for sqlite3.
+ *
+ * Real sqlite3 supports CLI dot-commands (`.tables`, `.schema`, `.mode csv`,
+ * `.read script.sql`, ...). The Braintrust trace catalogue showed agents
+ * never used them — but as we add them as a parity feature, we pin behavior
+ * here. D-numbers map to docs/sqlite3-invocation-shapes.md.
+ *
+ * Limitations encoded in the tests below:
+ *   - Formatter mutations (`.mode`, `.headers`, `.separator`) are global
+ *     within a single sqlite3 invocation. Last write wins. Real sqlite3
+ *     applies them incrementally.
+ *   - `.tables` output is one-name-per-line, not real sqlite3's 3-column
+ *     space-padded format.
+ *   - `.import` and `.dump` are intentionally unsupported (separate issues).
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 dot-commands", () => {
+  describe("D1: .tables", () => {
+    it("lists user tables, excludes sqlite_*", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE orders(id INT); CREATE TABLE refunds(id INT)'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".tables"');
+      expect(result.stdout).toBe("orders\nrefunds\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("filters by LIKE pattern", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE orders(id INT); CREATE TABLE order_items(id INT); CREATE TABLE refunds(id INT)'",
+      );
+      const result = await env.exec("sqlite3 /db.sqlite \".tables 'order%'\"");
+      expect(result.stdout).toBe("order_items\norders\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("returns empty for empty database", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".tables"');
+      expect(result.stdout).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D2: .schema", () => {
+    it("emits CREATE statements with trailing semicolons", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL)'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".schema users"');
+      expect(result.stdout).toBe(
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL);\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("with no pattern dumps all schema", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE a(x); CREATE TABLE b(y); CREATE INDEX idx_b ON b(y);'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".schema"');
+      expect(result.stdout).toBe(
+        "CREATE TABLE a(x);\nCREATE TABLE b(y);\nCREATE INDEX idx_b ON b(y);\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D3: .headers on/off", () => {
+    it(".headers on shows header before the SELECT", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(id INT, name TEXT); INSERT INTO t VALUES (1, 'a')\"",
+      );
+      const script = `.headers on\nSELECT id, name FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("id|name\n1|a\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".header (singular) is an alias", async () => {
+      const env = new Bash();
+      await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE t(x INT); INSERT INTO t VALUES (42)"',
+      );
+      const script = `.header on\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("x\n42\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D4: .mode", () => {
+    it(".mode csv produces comma-separated output", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'hello'), (2, 'world')"`,
+      );
+      const script = `.mode csv\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1,hello\n2,world\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".mode tabs produces TSV", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'x')"`,
+      );
+      const script = `.mode tabs\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1\tx\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".mode json produces JSON array", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(id INT); INSERT INTO t VALUES (7)"`,
+      );
+      const script = `.mode json\nSELECT id FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe('[{"id":7}]\n');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects unknown mode", async () => {
+      const env = new Bash();
+      const script = `.mode parquet\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stderr).toBe("Error: unknown mode: parquet\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D5: .separator", () => {
+    it(".separator , overrides the column separator", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b INT); INSERT INTO t VALUES (1, 2)"`,
+      );
+      const script = `.separator ,\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1,2\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("requires an argument", async () => {
+      const env = new Bash();
+      const script = `.separator\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stderr).toBe("Error: .separator requires an argument\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D6: .nullvalue", () => {
+    it(".nullvalue NULL substitutes for NULL fields", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x); INSERT INTO t VALUES (NULL), (1)'",
+      );
+      const script = `.nullvalue NULL\nSELECT * FROM t ORDER BY x`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("NULL\n1\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D7: .read", () => {
+    it("inlines a script file", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/setup.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (10);
+INSERT INTO t VALUES (20);
+EOF`,
+      );
+      const script = `.read /workspace/setup.sql\nSELECT SUM(x) FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("30\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("nested .read works (recursive expansion)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/inner.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (5);
+EOF`,
+      );
+      await env.exec(
+        `cat > /workspace/outer.sql <<'EOF'
+.read /workspace/inner.sql
+INSERT INTO t VALUES (15);
+EOF`,
+      );
+      const script = `.read /workspace/outer.sql\nSELECT SUM(x) FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("20\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("errors on missing file", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: ".read /workspace/does_not_exist.sql"',
+      );
+      expect(result.stderr).toContain("Error: cannot open");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D8: .import (unsupported)", () => {
+    it.todo("loads CSV into a table — see github issue: not yet implemented");
+  });
+
+  describe("D9: .dump (unsupported)", () => {
+    it.todo(
+      "dumps schema + INSERT statements — see github issue: not yet implemented",
+    );
+  });
+
+  describe("explicitly unsupported dot-commands surface a clear error", () => {
+    for (const cmd of [
+      ".import",
+      ".dump",
+      ".clone",
+      ".save",
+      ".restore",
+      ".backup",
+      ".open",
+      ".shell",
+      ".system",
+    ]) {
+      it(`${cmd} is rejected with "not supported by just-bash sqlite3"`, async () => {
+        const env = new Bash();
+        const result = await env.exec(`sqlite3 :memory: '${cmd} foo bar'`);
+        expect(result.stderr).toBe(
+          `Error: ${cmd} is not supported by just-bash sqlite3\n`,
+        );
+        expect(result.exitCode).toBe(1);
+      });
+    }
+  });
+
+  describe("unknown dot-command", () => {
+    it("returns sqlite3-shaped error", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".bogus arg1 arg2"');
+      expect(result.stderr).toBe(
+        'Error: unknown command or invalid arguments: "bogus". Enter ".help" for help\n',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("interleaved mode + query", () => {
+    it("`.mode csv` followed by SELECT then `.mode list` — last mode wins (documented limitation)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b INT); INSERT INTO t VALUES (1, 2)"`,
+      );
+      const script = `.mode csv\nSELECT * FROM t;\n.mode list\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1|2\n1|2\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe(".quit / .exit", () => {
+    it(".quit stops processing — SQL after it is dropped", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x INT); INSERT INTO t VALUES (1)'",
+      );
+      const script = `SELECT * FROM t;\n.quit\nDROP TABLE t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1\n");
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(after.stdout).toBe("t\n");
+    });
+
+    it(".exit behaves the same as .quit", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      const script = `.exit\nDROP TABLE t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(after.stdout).toBe("t\n");
+    });
+
+    it(".quit inside a .read'd file stops the outer script too", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      await env.exec(
+        `cat > /workspace/mid.sql <<'EOF'
+INSERT INTO t VALUES (1);
+.quit
+INSERT INTO t VALUES (2);
+EOF`,
+      );
+      const script = `.read /workspace/mid.sql\nINSERT INTO t VALUES (3)`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        'sqlite3 /db.sqlite "SELECT x FROM t ORDER BY x"',
+      );
+      expect(after.stdout).toBe("1\n");
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.flags.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.flags.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Flag tests for sqlite3 — pins the X-numbered flags from the trace catalogue
+ * (-init, -batch). The other flags (-header, -separator, -bail, -echo, -cmd,
+ * etc.) are covered in sqlite3.options.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 flags", () => {
+  describe("X1: -init <file>", () => {
+    it("runs the init script before the main SQL", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (10), (20), (30);
+EOF`,
+      );
+      const result = await env.exec(
+        'sqlite3 -init /workspace/init.sql /db.sqlite "SELECT SUM(x) FROM t"',
+      );
+      expect(result.stdout).toBe("60\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("init runs even with stdin SQL", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (1), (2);
+EOF`,
+      );
+      const result = await env.exec(
+        `echo "SELECT COUNT(*) FROM t" | sqlite3 -init /workspace/init.sql /db.sqlite`,
+      );
+      expect(result.stdout).toBe("2\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("missing init file errors with exit 1", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 -init /workspace/nope.sql :memory: "SELECT 1"',
+      );
+      expect(result.stderr).toContain("cannot open -init file");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("missing argument errors", async () => {
+      const env = new Bash();
+      const result = await env.exec("sqlite3 -init");
+      expect(result.stderr).toBe("sqlite3: Error: missing argument to -init\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("X2: -batch", () => {
+    it("is accepted as a no-op (just-bash is always non-interactive)", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 -batch :memory: "SELECT 1"');
+      expect(result.stdout).toBe("1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("can be combined with other flags", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 -batch -header :memory: \"CREATE TABLE t(name TEXT); INSERT INTO t VALUES ('a'); SELECT * FROM t\"",
+      );
+      expect(result.stdout).toBe("name\na\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("interplay: -init + .read + dot-commands", () => {
+    it("init.sql can itself contain dot-commands", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/sub.sql <<'EOF'
+CREATE TABLE sub(x INT);
+INSERT INTO sub VALUES (100);
+EOF`,
+      );
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+.read /workspace/sub.sql
+.headers on
+EOF`,
+      );
+      const result = await env.exec(
+        'sqlite3 -init /workspace/init.sql /db.sqlite "SELECT x FROM sub"',
+      );
+      expect(result.stdout).toBe("x\n100\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.invocation-shapes.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.invocation-shapes.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Invocation-shape tests for sqlite3.
+ *
+ * Each test mirrors a shape catalogued from a Braintrust review of ~924
+ * reasoning-agent spans across the four flowglad-pay-agent* projects.
+ * The S-numbers (S1..S11) match docs/sqlite3-invocation-shapes.md.
+ *
+ * If a test here fails, an agent in production has hit (or will hit) the
+ * same failure. Either patch the wrapper or open a triage issue.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 invocation shapes", () => {
+  describe("S1: version smoke test", () => {
+    it("sqlite3 :memory: with SELECT sqlite_version()", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "SELECT sqlite_version();"',
+      );
+      expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("-version flag", async () => {
+      const env = new Bash();
+      const result = await env.exec("sqlite3 -version");
+      expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S3: one-liner sqlite3 <db> '<SQL>'", () => {
+    it("simple SELECT against :memory:", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "CREATE TABLE t(x INT); INSERT INTO t VALUES(1),(2),(3); SELECT COUNT(*) FROM t;"',
+      );
+      expect(result.stdout).toBe("3\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("introspection via sqlite_master", async () => {
+      const env = new Bash();
+      const setup = await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE orders(id INT); CREATE TABLE refunds(id INT)"',
+      );
+      expect(setup.exitCode).toBe(0);
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;\"",
+      );
+      expect(result.stdout).toBe("orders\nrefunds\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S4: multi-statement single positional arg", () => {
+    it("CREATE + INSERT + SELECT in one quoted arg", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(x TEXT); INSERT INTO t VALUES('hello'); SELECT * FROM t;\"",
+      );
+      expect(result.stdout).toBe("hello\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S5: script redirect sqlite3 <db> < script.sql", () => {
+    it("schema + INSERTs piped from a workspace .sql file", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        'printf \'CREATE TABLE vendor_spend (vendor TEXT, amount_cents INTEGER);\\nINSERT INTO vendor_spend VALUES ("acme", 1000);\\nINSERT INTO vendor_spend VALUES ("globex", 2500);\\n\' > /workspace/load.sql',
+      );
+      expect(write.exitCode).toBe(0);
+
+      const load = await env.exec(
+        "sqlite3 /out/report.db < /workspace/load.sql",
+      );
+      expect(load.stdout).toBe("");
+      expect(load.stderr).toBe("");
+      expect(load.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /out/report.db "SELECT vendor, amount_cents FROM vendor_spend ORDER BY vendor"',
+      );
+      expect(verify.stdout).toBe("acme|1000\nglobex|2500\n");
+      expect(verify.stderr).toBe("");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("S6: stdin pipe echo '<SQL>' | sqlite3 <db>", () => {
+    it("echoed CREATE through pipe persists to db", async () => {
+      const env = new Bash();
+      const create = await env.exec(
+        'echo "CREATE TABLE vendor_spend (vendor TEXT, amount_cents INTEGER, date TEXT, category TEXT);" | sqlite3 /report.db',
+      );
+      expect(create.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        "sqlite3 /report.db \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(verify.stdout).toBe("vendor_spend\n");
+      expect(verify.exitCode).toBe(0);
+    });
+
+    it("smoke test: SELECT 1; via pipe", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'echo "SELECT 1;" | sqlite3 :memory: && echo "sqlite3 works"',
+      );
+      expect(result.stdout).toBe("1\nsqlite3 works\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('S7: command substitution sqlite3 <db> "$(cat file.sql)"', () => {
+    it("reads SQL via $(cat ...) and runs it", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        "printf 'CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (7); SELECT x FROM t;' > /workspace/load_all_v2.sql",
+      );
+      expect(write.exitCode).toBe(0);
+
+      const result = await env.exec(
+        'sqlite3 /out/report.db "$(cat /workspace/load_all_v2.sql)" && echo "SUCCESS"',
+      );
+      expect(result.stdout).toBe("7\nSUCCESS\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S8: TSV with headers via -header -separator $'\\t'", () => {
+    // Note: just-bash mirrors real sqlite3's full IEEE-754 float precision
+    // (see sqlite3.fixtures.test.ts, products.db where 999.99 -> 999.99000000000001).
+    // ROUND(...,2) does not produce clean two-decimal output here.
+    it("dumps header row + tab-separated data, integer aggregates clean", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE refunds(note TEXT, amount_cents INT); INSERT INTO refunds VALUES('damaged', 1250), ('damaged', 725), ('lost', 9999)\"",
+      );
+
+      const result = await env.exec(
+        "sqlite3 -header -separator $'\\t' /db.sqlite \"SELECT note, COUNT(*) AS count, SUM(amount_cents) AS total_cents FROM refunds GROUP BY note ORDER BY count DESC;\"",
+      );
+      expect(result.stdout).toBe(
+        "note\tcount\ttotal_cents\ndamaged\t2\t1975\nlost\t1\t9999\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S9: TSV without headers via -separator $'\\t'", () => {
+    it("dumps tab-separated data, no header", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'one'), (2, 'two')\"",
+      );
+
+      const result = await env.exec(
+        "sqlite3 -separator $'\\t' /db.sqlite \"SELECT a, b FROM t ORDER BY a\"",
+      );
+      expect(result.stdout).toBe("1\tone\n2\ttwo\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S10: redirect output to .tsv file", () => {
+    it("writes query result to /workspace/flavor_picks.tsv", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT, picks INT); INSERT INTO picks VALUES ('mint', 12), ('vanilla', 8)\"",
+      );
+
+      const dump = await env.exec(
+        "sqlite3 -header -separator $'\\t' /db.sqlite \"SELECT flavor, picks FROM picks ORDER BY picks DESC\" > /workspace/flavor_picks.tsv",
+      );
+      expect(dump.stdout).toBe("");
+      expect(dump.stderr).toBe("");
+      expect(dump.exitCode).toBe(0);
+
+      const cat = await env.exec("cat /workspace/flavor_picks.tsv");
+      expect(cat.stdout).toBe("flavor\tpicks\nmint\t12\nvanilla\t8\n");
+      expect(cat.exitCode).toBe(0);
+    });
+  });
+
+  describe("S11: per-statement loop (sequential invocations)", () => {
+    it("multiple sqlite3 calls accumulate against the same db", async () => {
+      const env = new Bash();
+      const stmts = [
+        "CREATE TABLE t(x INT)",
+        "INSERT INTO t VALUES (1)",
+        "INSERT INTO t VALUES (2)",
+        "INSERT INTO t VALUES (3)",
+      ];
+      for (const stmt of stmts) {
+        const r = await env.exec(`sqlite3 /loop.db "${stmt}"`);
+        expect(r.stderr).toBe("");
+        expect(r.exitCode).toBe(0);
+      }
+      const result = await env.exec('sqlite3 /loop.db "SELECT SUM(x) FROM t"');
+      expect(result.stdout).toBe("6\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("relative-path database (out/report.db)", () => {
+    it("works with a relative db path from cwd", async () => {
+      const env = new Bash({ cwd: "/work" });
+      await env.exec("mkdir -p /work/out");
+      const create = await env.exec(
+        'sqlite3 out/report.db "CREATE TABLE t(x); INSERT INTO t VALUES(11); SELECT * FROM t"',
+      );
+      expect(create.stdout).toBe("11\n");
+      expect(create.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.sql-features.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.sql-features.test.ts
@@ -1,0 +1,256 @@
+/**
+ * SQL feature tests for sqlite3 — pin the language features actual agents
+ * use against this wrapper. F-numbers map to docs/sqlite3-invocation-shapes.md.
+ *
+ * If a future sql.js bump silently drops one of these, agents in production
+ * will start producing wrong output. These tests catch that.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 SQL features", () => {
+  describe("F1: CREATE TABLE … AS SELECT (materialized reports)", () => {
+    it("materializes monthly revenue rollup", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE orders(id INT, created_at TEXT, financial_status TEXT, total_cents INT);
+         INSERT INTO orders VALUES
+           (1,'2026-01-15','paid',1000),
+           (2,'2026-01-20','paid',2000),
+           (3,'2026-02-05','paid',1500),
+           (4,'2026-02-10','refunded',500);"`,
+      );
+
+      const create = await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE monthly_revenue AS SELECT strftime('%Y-%m', created_at) AS month, COUNT(*) AS orders, SUM(total_cents) AS revenue_cents FROM orders WHERE financial_status='paid' GROUP BY month ORDER BY month;\"",
+      );
+      expect(create.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /db.sqlite "SELECT month, orders, revenue_cents FROM monthly_revenue ORDER BY month"',
+      );
+      expect(verify.stdout).toBe("2026-01|2|3000\n2026-02|1|1500\n");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("F2: bulk INSERT in a script-redirected .sql file", () => {
+    it("loads a multi-row INSERT block via < script.sql (heredoc)", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        `cat > /workspace/load_customers.sql <<'EOF'
+CREATE TABLE customers(id INT, email TEXT);
+INSERT INTO customers VALUES (1, 'a@x.com');
+INSERT INTO customers VALUES (2, 'b@x.com');
+INSERT INTO customers VALUES (3, 'c@x.com');
+EOF`,
+      );
+      expect(write.exitCode).toBe(0);
+
+      const load = await env.exec(
+        "sqlite3 /db.sqlite < /workspace/load_customers.sql",
+      );
+      expect(load.stderr).toBe("");
+      expect(load.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /db.sqlite "SELECT COUNT(*) FROM customers"',
+      );
+      expect(verify.stdout).toBe("3\n");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("F3: window functions", () => {
+    it("SUM(...) OVER (PARTITION BY ...)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE sales(region TEXT, amount INT); INSERT INTO sales VALUES ('NA',100),('NA',200),('EU',300),('EU',400);"`,
+      );
+
+      const result = await env.exec(
+        'sqlite3 -header /db.sqlite "SELECT region, amount, SUM(amount) OVER (PARTITION BY region) AS region_total FROM sales ORDER BY region, amount"',
+      );
+      expect(result.stdout).toBe(
+        "region|amount|region_total\nEU|300|700\nEU|400|700\nNA|100|300\nNA|200|300\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("ROW_NUMBER() OVER (ORDER BY ...)", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(name TEXT); INSERT INTO t VALUES ('c'),('a'),('b');\"",
+      );
+
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT ROW_NUMBER() OVER (ORDER BY name) AS rn, name FROM t"',
+      );
+      expect(result.stdout).toBe("1|a\n2|b\n3|c\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F4: common table expressions (CTE)", () => {
+    it("simple WITH ... SELECT", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT); INSERT INTO picks VALUES ('mint'),('mint'),('vanilla');\"",
+      );
+
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "WITH flavor_demand AS (SELECT flavor, COUNT(*) AS n FROM picks GROUP BY flavor) SELECT flavor, n FROM flavor_demand ORDER BY n DESC, flavor"',
+      );
+      expect(result.stdout).toBe("mint|2\nvanilla|1\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("recursive WITH RECURSIVE for fibonacci", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "WITH RECURSIVE fib(n, a, b) AS (SELECT 1, 0, 1 UNION ALL SELECT n+1, b, a+b FROM fib WHERE n < 8) SELECT a FROM fib"',
+      );
+      expect(result.stdout).toBe("0\n1\n1\n2\n3\n5\n8\n13\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F5: strftime() date arithmetic", () => {
+    it("%Y-%m grouping", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 :memory: \"SELECT strftime('%Y-%m', '2026-04-30 12:00:00')\"",
+      );
+      expect(result.stdout).toBe("2026-04\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("%Y-W%W weekly grouping", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 :memory: \"SELECT strftime('%Y-W%W', '2026-04-30')\"",
+      );
+      expect(result.stdout).toBe("2026-W17\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F6: sqlite_master introspection", () => {
+    it("lists tables ordered by name", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE z(x); CREATE TABLE a(x); CREATE TABLE m(x);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\"",
+      );
+      expect(result.stdout).toBe("a\nm\nz\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("returns CREATE TABLE DDL via sqlite_master.sql", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT sql FROM sqlite_master WHERE type='table' AND name='users'\"",
+      );
+      expect(result.stdout).toBe(
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL)\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F7: aggregations and scalar subqueries", () => {
+    it("CASE WHEN aggregate", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE orders(status TEXT, amount INT); INSERT INTO orders VALUES ('paid', 100), ('refunded', 50), ('paid', 200);\"",
+      );
+      const result = await env.exec(
+        "sqlite3 -header /db.sqlite \"SELECT SUM(CASE WHEN status='paid' THEN amount ELSE 0 END) AS revenue, SUM(CASE WHEN status='refunded' THEN amount ELSE 0 END) AS refunds FROM orders\"",
+      );
+      expect(result.stdout).toBe("revenue|refunds\n300|50\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("scalar subquery for percent-of-total", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT); INSERT INTO picks VALUES ('mint'),('mint'),('mint'),('vanilla');\"",
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT flavor, COUNT(*) * 100 / (SELECT COUNT(*) FROM picks) AS pct FROM picks GROUP BY flavor ORDER BY pct DESC"',
+      );
+      expect(result.stdout).toBe("mint|75\nvanilla|25\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("X4: PRAGMA statements", () => {
+    it("PRAGMA table_info(t)", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);'",
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "PRAGMA table_info(t)"',
+      );
+      expect(result.stdout).toBe("0|id|INTEGER|0||1\n1|name|TEXT|0||0\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("PRAGMA foreign_keys=ON; SELECT", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "PRAGMA foreign_keys=ON; PRAGMA foreign_keys"',
+      );
+      expect(result.stdout).toBe("1\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("indices, views, triggers", () => {
+    it("CREATE INDEX is queryable via sqlite_master", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x INT); CREATE INDEX idx_t_x ON t(x);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name, type FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'\"",
+      );
+      expect(result.stdout).toBe("idx_t_x|index\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("CREATE VIEW + SELECT through it", async () => {
+      const env = new Bash();
+      await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE t(x INT); INSERT INTO t VALUES (1),(2),(3); CREATE VIEW v AS SELECT x*x AS sq FROM t"',
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT sq FROM v ORDER BY sq"',
+      );
+      expect(result.stdout).toBe("1\n4\n9\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("transactions", () => {
+    it("BEGIN; INSERT; COMMIT; round-trips", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      const txn = await env.exec(
+        "sqlite3 /db.sqlite 'BEGIN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); COMMIT;'",
+      );
+      expect(txn.exitCode).toBe(0);
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT SUM(x) FROM t"',
+      );
+      expect(result.stdout).toBe("3\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
+import { coerceDbBuffer } from "./worker.js";
 
 describe("sqlite3", () => {
   describe("basic operations", () => {
@@ -132,6 +133,50 @@ describe("sqlite3", () => {
       // Full IEEE 754 precision like real sqlite3
       expect(result.stdout).toBe('[{"i":42,"f":3.1400000000000001}]\n');
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // Regression: Bun's worker_threads structured-clone (notably the build
+  // shipped in Trigger.dev's container) surfaces a host-side `null` dbBuffer
+  // as a zero-length ArrayBuffer at the worker. The pre-fix code used
+  // `if (data.dbBuffer) new SQL.Database(data.dbBuffer)`, which let the empty
+  // ArrayBuffer through and threw "Expected ArrayBuffer for the first
+  // argument" from sql.js (sql.js wants Uint8Array, not bare ArrayBuffer).
+  // coerceDbBuffer must collapse those cases to null so the executeQuery call
+  // site falls back to `new SQL.Database()` (fresh in-memory db).
+  describe("coerceDbBuffer (Bun structured-clone regression)", () => {
+    it("returns null for null", () => {
+      expect(coerceDbBuffer(null)).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(coerceDbBuffer(undefined)).toBeNull();
+    });
+
+    it("returns null for a zero-length ArrayBuffer (Bun structured-clone case)", () => {
+      expect(coerceDbBuffer(new ArrayBuffer(0))).toBeNull();
+    });
+
+    it("wraps a non-empty ArrayBuffer into a Uint8Array view", () => {
+      const ab = new ArrayBuffer(4);
+      new Uint8Array(ab).set([1, 2, 3, 4]);
+
+      const result = coerceDbBuffer(ab);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(Array.from(result as Uint8Array)).toEqual([1, 2, 3, 4]);
+    });
+
+    it("returns the same Uint8Array when given a Uint8Array", () => {
+      const u8 = new Uint8Array([10, 20, 30]);
+      expect(coerceDbBuffer(u8)).toBe(u8);
+    });
+
+    it("returns the same buffer when given a Node Buffer", () => {
+      const buf = Buffer.from([5, 6, 7]);
+      const result = coerceDbBuffer(buf);
+      expect(result).toBe(buf);
+      expect(result).toBeInstanceOf(Uint8Array);
     });
   });
 });

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -27,6 +27,7 @@ import { _clearTimeout, _setTimeout } from "../../timers.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
 
+import { preprocessDotCommands } from "./dot-commands.js";
 import {
   type FormatOptions,
   formatOutput,
@@ -68,6 +69,8 @@ const sqlite3Help = {
     "-bail           stop on first error",
     "-echo           print SQL before execution",
     "-cmd COMMAND    run SQL command before main SQL",
+    "-init FILENAME  read/process named file before main SQL",
+    "-batch          accept-and-ignore (just-bash is always non-interactive)",
     "-version        show SQLite version",
     "--              end of options",
     "--help          show this help",
@@ -90,6 +93,7 @@ interface SqliteOptions {
   bail: boolean;
   echo: boolean;
   cmd: string | null;
+  init: string | null;
 }
 
 function parseArgs(args: string[]):
@@ -110,6 +114,7 @@ function parseArgs(args: string[]):
     bail: false,
     echo: false,
     cmd: null,
+    init: null,
   };
 
   let database: string | null = null;
@@ -187,6 +192,17 @@ function parseArgs(args: string[]):
         };
       }
       options.cmd = args[++i];
+    } else if (arg === "-init") {
+      if (i + 1 >= args.length) {
+        return {
+          stdout: "",
+          stderr: "sqlite3: Error: missing argument to -init\n",
+          exitCode: 1,
+        };
+      }
+      options.init = args[++i];
+    } else if (arg === "-batch") {
+      // No-op: just-bash is never interactive, so -batch is implied.
     } else if (arg.startsWith("-")) {
       // Real sqlite3 treats --xyz as -xyz and says "unknown option: -xyz"
       const optName = arg.startsWith("--") ? arg.slice(1) : arg;
@@ -539,17 +555,76 @@ export const sqlite3Command: Command = {
       };
     }
 
-    // Get SQL from argument or stdin, prepend -cmd if provided
+    // Get SQL from argument or stdin. Prepend -cmd first, then -init on top,
+    // so the final execution order is: init content -> cmd -> main SQL.
     let sql = sqlArg || ctx.stdin.trim();
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }
-    if (!sql) {
+    // `options.init` is `string | null`. Use `!== null` (not falsiness) so
+    // `-init ""` attempts the read and surfaces a clear error, instead of
+    // silently skipping. This matches the no-SQL guard below, which also
+    // treats an explicit empty string as "provided".
+    if (options.init !== null) {
+      try {
+        const initPath = ctx.fs.resolvePath(ctx.cwd, options.init);
+        const initContent = await ctx.fs.readFile(initPath);
+        sql = initContent + (sql ? `\n${sql}` : "");
+      } catch (e) {
+        const message = sanitizeErrorMessage((e as Error).message);
+        return {
+          stdout: "",
+          stderr: `sqlite3: cannot open -init file "${options.init}": ${message}\n`,
+          exitCode: 1,
+        };
+      }
+    }
+    // Only error when no SQL source was provided at all. An empty -init
+    // file (or explicitly empty stdin/sqlArg) with nothing else is a clean
+    // exit 0, matching real sqlite3. sqlArg/options.init are typed as
+    // `string | null`, so test for absence with `=== null` rather than
+    // falsiness (an explicit empty string is "provided but empty").
+    if (!sql && options.init === null && sqlArg === null && !ctx.stdin.trim()) {
       return {
         stdout: "",
         stderr: "sqlite3: no SQL provided\n",
         exitCode: 1,
       };
+    }
+
+    // Preprocess dot-commands (.tables, .schema, .mode, .read, ...)
+    let dotError: string | undefined;
+    {
+      const pre = await preprocessDotCommands(sql, {
+        fs: ctx.fs,
+        cwd: ctx.cwd,
+      });
+      sql = pre.sql.trim();
+      if (pre.formatterMutation.mode !== undefined)
+        options.mode = pre.formatterMutation.mode;
+      if (pre.formatterMutation.header !== undefined)
+        options.header = pre.formatterMutation.header;
+      if (pre.formatterMutation.separator !== undefined)
+        options.separator = pre.formatterMutation.separator;
+      if (pre.formatterMutation.newline !== undefined)
+        options.newline = pre.formatterMutation.newline;
+      if (pre.formatterMutation.nullValue !== undefined)
+        options.nullValue = pre.formatterMutation.nullValue;
+      dotError = pre.error;
+      if (dotError && options.bail) {
+        return { stdout: "", stderr: `${dotError}\n`, exitCode: 1 };
+      }
+      // Pure formatter mutations / dot-commands with no SQL: short-circuit
+      // instead of sending whitespace to the worker. Real sqlite3 emits
+      // nothing in this case.
+      if (!sql) {
+        const stderr = dotError ? `${dotError}\n` : "";
+        return {
+          stdout: "",
+          stderr,
+          exitCode: dotError !== undefined ? 1 : 0,
+        };
+      }
     }
 
     // Load database buffer
@@ -630,7 +705,6 @@ export const sqlite3Command: Command = {
     }
 
     // Process results
-    let hadError = false;
     for (const stmtResult of result.results) {
       if (stmtResult.type === "error") {
         if (options.bail) {
@@ -641,7 +715,6 @@ export const sqlite3Command: Command = {
           };
         }
         stdout += `Error: ${stmtResult.error}\n`;
-        hadError = true;
       } else if (stmtResult.columns && stmtResult.rows) {
         if (stmtResult.rows.length > 0 || options.header) {
           stdout += formatOutput(
@@ -673,7 +746,12 @@ export const sqlite3Command: Command = {
       }
     }
 
-    return { stdout, stderr: "", exitCode: hadError && options.bail ? 1 : 0 };
+    const stderr = dotError ? `${dotError}\n` : "";
+    // dotError always causes exit 1 (matches real sqlite3).
+    // hadError without -bail doesn't (pre-existing behaviour preserved);
+    // hadError with -bail already returned early in the loop above.
+    const exitCode = dotError !== undefined ? 1 : 0;
+    return { stdout, stderr, exitCode };
   },
 };
 

--- a/packages/just-bash/src/commands/sqlite3/worker.ts
+++ b/packages/just-bash/src/commands/sqlite3/worker.ts
@@ -28,6 +28,32 @@ import {
 // Cached SQL.js module (initialized once)
 let cachedSQL: SqlJsStatic | null = null;
 
+/**
+ * Coerce a host-supplied dbBuffer into the form sql.js expects.
+ *
+ * Why: Bun's worker_threads structured-clone has regressed across versions
+ * (notably the build shipped in Trigger.dev's container) and surfaces a
+ * host-side `null` dbBuffer as a zero-length ArrayBuffer here. A truthy
+ * empty ArrayBuffer would slip past `if (data.dbBuffer)` and reach
+ * `new SQL.Database(arrayBuffer)`, which throws "Expected ArrayBuffer for
+ * the first argument" (sql.js wants Uint8Array, not bare ArrayBuffer).
+ * Treat empty/non-Uint8Array values as "no buffer" → fresh in-memory db,
+ * matching the host's intent for :memory: databases.
+ */
+export function coerceDbBuffer(raw: unknown): Uint8Array | null {
+  if (raw instanceof Uint8Array) {
+    return raw;
+  }
+  if (
+    raw &&
+    typeof (raw as { byteLength?: unknown }).byteLength === "number" &&
+    (raw as ArrayBuffer).byteLength > 0
+  ) {
+    return new Uint8Array(raw as ArrayBufferLike);
+  }
+  return null;
+}
+
 // Defense instance (activated after sql.js init)
 let defense: WorkerDefenseInDepth | null = null;
 
@@ -186,6 +212,215 @@ function isWriteStatement(sql: string): boolean {
   );
 }
 
+function quoteSqlString(s: string): string {
+  return `'${s.replace(/'/g, "''")}'`;
+}
+
+const DOT_SKIP = Symbol("dot-skip");
+
+function preprocessDotCommands(sql: string): string {
+  if (!/(^|;|\n)\s*\./.test(sql)) {
+    return sql;
+  }
+
+  let out = "";
+  let i = 0;
+  let atBoundary = true;
+  let buffered = "";
+
+  while (i < sql.length) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+
+    if (ch === "'") {
+      out += buffered;
+      buffered = "";
+      out += ch;
+      i++;
+      while (i < sql.length) {
+        const c = sql[i];
+        out += c;
+        i++;
+        if (c === "'") {
+          if (sql[i] === "'") {
+            out += sql[i];
+            i++;
+            continue;
+          }
+          break;
+        }
+      }
+      atBoundary = false;
+      continue;
+    }
+
+    if (ch === '"') {
+      out += buffered;
+      buffered = "";
+      out += ch;
+      i++;
+      while (i < sql.length) {
+        const c = sql[i];
+        out += c;
+        i++;
+        if (c === '"') {
+          if (sql[i] === '"') {
+            out += sql[i];
+            i++;
+            continue;
+          }
+          break;
+        }
+      }
+      atBoundary = false;
+      continue;
+    }
+
+    if (ch === "-" && next === "-") {
+      out += buffered;
+      buffered = "";
+      while (i < sql.length && sql[i] !== "\n") {
+        out += sql[i];
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === "/" && next === "*") {
+      out += buffered;
+      buffered = "";
+      out += "/*";
+      i += 2;
+      while (i < sql.length) {
+        if (sql[i] === "*" && sql[i + 1] === "/") {
+          out += "*/";
+          i += 2;
+          break;
+        }
+        out += sql[i];
+        i++;
+      }
+      continue;
+    }
+
+    if (ch === ";" || ch === "\n") {
+      out += buffered;
+      buffered = "";
+      out += ch;
+      atBoundary = true;
+      i++;
+      continue;
+    }
+
+    if (ch === " " || ch === "\t" || ch === "\r") {
+      buffered += ch;
+      i++;
+      continue;
+    }
+
+    if (atBoundary && ch === ".") {
+      let j = i + 1;
+      const cmdStart = j;
+      while (j < sql.length && /[a-zA-Z_0-9]/.test(sql[j] ?? "")) j++;
+      const cmd = sql.slice(cmdStart, j).toLowerCase();
+      const argsStart = j;
+      while (j < sql.length && sql[j] !== ";" && sql[j] !== "\n") j++;
+      const args = sql.slice(argsStart, j).trim();
+
+      const translated = translateDotCommand(cmd, args);
+      if (translated === DOT_SKIP) {
+        buffered = "";
+      } else if (translated === null) {
+        out += buffered;
+        out += sql.slice(i, j);
+        buffered = "";
+      } else {
+        out += buffered;
+        out += translated;
+        buffered = "";
+      }
+      i = j;
+      atBoundary = false;
+      continue;
+    }
+
+    out += buffered;
+    buffered = "";
+    out += ch;
+    atBoundary = false;
+    i++;
+  }
+
+  out += buffered;
+  return out;
+}
+
+function translateDotCommand(
+  cmd: string,
+  args: string,
+): string | null | typeof DOT_SKIP {
+  switch (cmd) {
+    case "tables": {
+      const where = args
+        ? `AND name LIKE ${quoteSqlString(args.replace(/\*/g, "%"))}`
+        : "";
+      return `SELECT name FROM sqlite_master WHERE type IN ('table','view') ${where} ORDER BY name;`;
+    }
+    case "schema": {
+      const where = args ? `AND name = ${quoteSqlString(args)}` : "";
+      return `SELECT sql FROM sqlite_master WHERE type IN ('table','view','index','trigger') ${where} AND sql IS NOT NULL ORDER BY name;`;
+    }
+    case "indexes":
+    case "indices": {
+      const where = args ? `AND tbl_name = ${quoteSqlString(args)}` : "";
+      return `SELECT name FROM sqlite_master WHERE type='index' ${where} ORDER BY name;`;
+    }
+    case "databases":
+      return "PRAGMA database_list;";
+
+    case "headers":
+    case "mode":
+    case "separator":
+    case "nullvalue":
+    case "echo":
+    case "timer":
+    case "changes":
+    case "bail":
+    case "show":
+    case "width":
+      return DOT_SKIP;
+
+    case "quit":
+    case "exit":
+      return null;
+
+    case "read":
+      return `SELECT ${quoteSqlString(`sqlite3: .read is not supported in this sandbox - use: cat ${args || "FILE"} | sqlite3 DB`)} AS error;`;
+    case "save":
+    case "backup":
+      return `SELECT ${quoteSqlString(`sqlite3: .${cmd} is not supported in this sandbox - emit a SELECT and redirect with shell instead`)} AS error;`;
+    case "dump":
+      return `SELECT ${quoteSqlString("sqlite3: .dump is not supported in this sandbox - query sqlite_master for schema, then emit per-table SELECTs")} AS error;`;
+    case "import":
+      return `SELECT ${quoteSqlString("sqlite3: .import is not supported in this sandbox - read the source file with cat and run INSERTs from a SQL script")} AS error;`;
+    case "load":
+    case "restore":
+    case "open":
+    case "output":
+    case "log":
+    case "shell":
+    case "system":
+    case "cd":
+      return `SELECT ${quoteSqlString(`sqlite3: .${cmd} is not supported in this sandbox`)} AS error;`;
+
+    case "help":
+      return `SELECT ${quoteSqlString("Supported dot commands: .tables [pattern], .schema [name], .indexes [table], .databases. Use SQL for everything else; .read/.save/.dump/.import are not available in this sandbox.")} AS help;`;
+
+    default:
+      return null;
+  }
+}
+
 function splitStatements(sql: string): string[] {
   const statements: string[] = [];
   let current = "";
@@ -229,11 +464,8 @@ async function executeQuery(data: WorkerInput): Promise<WorkerOutput> {
   try {
     const SQL = await initializeWithDefense(data.protocolToken);
 
-    if (data.dbBuffer) {
-      db = new SQL.Database(data.dbBuffer);
-    } else {
-      db = new SQL.Database();
-    }
+    const buf = coerceDbBuffer(data.dbBuffer);
+    db = buf ? new SQL.Database(buf) : new SQL.Database();
   } catch (e) {
     const message = sanitizeHostErrorMessage((e as Error).message);
     return {
@@ -247,7 +479,8 @@ async function executeQuery(data: WorkerInput): Promise<WorkerOutput> {
   let hasModifications = false;
 
   try {
-    const statements = splitStatements(data.sql);
+    const processedSql = preprocessDotCommands(data.sql);
+    const statements = splitStatements(processedSql);
 
     for (const stmt of statements) {
       try {


### PR DESCRIPTION
## Summary
Real `sqlite3` accepts a number of invocation shapes that just-bash's `sqlite3` didn't model. Agents and scripts shelling out to `sqlite3` regularly emit them, so getting an opaque misparse for them surfaces as a confusing failure rather than expected output.

Adds:
- **Dot-commands**: `.tables`, `.schema`, `.mode`, `.separator`, `.quit` / `.exit`. `.tables` and `.schema` are translated into `SELECT … FROM sqlite_master` queries; `.mode list|column|csv|…` toggles formatter state; `.separator` updates the column separator independently of `.mode` (matching real sqlite3); `.quit` / `.exit` short-circuit further input.
- **`-init <file>`** to run a SQL file before the inline command.
- **`-batch`** to run non-interactively.
- **Empty `ArrayBuffer` dbBuffer is coerced to `null`** so an empty file isn't treated as a corrupt database.
- **No-SQL guard** distinguishes absent vs. empty SQL so an empty heredoc doesn't print usage.

Coverage lives in four new test files plus extensions to `sqlite3.test.ts`:
- `sqlite3.dot-commands.test.ts` — dot-command parsing + execution
- `sqlite3.invocation-shapes.test.ts` — argv permutations agents pin against
- `sqlite3.flags.test.ts` — `-init` / `-batch` combinations
- `sqlite3.sql-features.test.ts` — SQL feature parity touched by the writeback worker changes

`docs/sqlite3-invocation-shapes.md` documents the supported shapes for downstream consumers.

## Test plan
- [x] `pnpm --filter just-bash typecheck` — clean
- [x] `pnpm --filter just-bash exec vitest run src/commands/sqlite3/` — 15 files / 225 tests pass + 2 todo
- [x] `pnpm lint:fix` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)