### PR TITLE
perf(grep): 5–123× speedup via RE2 matcher reuse and literal pre-filter

### DIFF
--- a/.changeset/tasty-papers-love.md
+++ b/.changeset/tasty-papers-love.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+grep: 5-123x faster pattern matching via RE2 matcher reuse and literal pre-filter

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -237,6 +237,7 @@ export const grepCommand: Command = {
         afterContext,
         maxCount,
         kResetGroup,
+        preFilter,
       });
       if (quietMode) {
         return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -206,6 +206,7 @@ export const grepCommand: Command = {
 
     let regex: UserRegex;
     let kResetGroup: number | undefined;
+    let preFilter: import("../search-engine/regex.js").PreFilter | undefined;
     try {
       const regexResult = buildRegex(pattern, {
         mode: regexMode,
@@ -215,6 +216,7 @@ export const grepCommand: Command = {
       });
       regex = regexResult.regex;
       kResetGroup = regexResult.kResetGroup;
+      preFilter = regexResult.preFilter;
     } catch {
       return {
         stdout: "",
@@ -361,6 +363,7 @@ export const grepCommand: Command = {
               afterContext,
               maxCount,
               kResetGroup,
+              preFilter,
             });
 
             return { file, result };

--- a/packages/just-bash/src/commands/search-engine/matcher.ts
+++ b/packages/just-bash/src/commands/search-engine/matcher.ts
@@ -225,7 +225,11 @@ export function searchContent(
         if (onlyMatching) {
           // firstMatch is the first iteration of the all-matches loop.
           // exec()'s side effect already advanced lastIndex past it.
-          for (let match = firstMatch; match !== null; match = regex.exec(line)) {
+          for (
+            let match = firstMatch;
+            match !== null;
+            match = regex.exec(line)
+          ) {
             // If \K was used, extract from the capture group instead of full match
             const rawMatch =
               kResetGroup !== undefined ? (match[kResetGroup] ?? "") : match[0];
@@ -240,7 +244,11 @@ export function searchContent(
           }
         } else if (vimgrep) {
           // Vimgrep mode: output each match separately with full line
-          for (let match = firstMatch; match !== null; match = regex.exec(line)) {
+          for (
+            let match = firstMatch;
+            match !== null;
+            match = regex.exec(line)
+          ) {
             let prefix = filename ? `${filename}:` : "";
             if (showByteOffset) prefix += `${byteOffset + match.index}:`;
             if (showLineNumbers) prefix += `${i + 1}:`;

--- a/packages/just-bash/src/commands/search-engine/matcher.ts
+++ b/packages/just-bash/src/commands/search-engine/matcher.ts
@@ -3,6 +3,23 @@
  */
 
 import type { UserRegex } from "../../regex/index.js";
+import type { PreFilter } from "./regex.js";
+
+/**
+ * Substring fast-path check: returns true if at least one needle is present
+ * in the line, meaning the regex *might* match. False means provably no match.
+ *
+ * For case-insensitive filters, the line is lowercased once per call. Both the
+ * needles and the line are compared in lowercase.
+ */
+function preFilterMatches(preFilter: PreFilter, line: string): boolean {
+  const haystack = preFilter.ignoreCase ? line.toLowerCase() : line;
+  const needles = preFilter.needles;
+  for (let i = 0; i < needles.length; i++) {
+    if (haystack.indexOf(needles[i]) !== -1) return true;
+  }
+  return false;
+}
 
 /**
  * Apply a replacement pattern using capture groups from a regex match
@@ -61,6 +78,11 @@ export interface SearchOptions {
   multiline?: boolean;
   /** If \K was used, this is the capture group index containing the "real" match */
   kResetGroup?: number;
+  /**
+   * Optional substring fast-path: skip RE2 entirely for lines where no needle
+   * is present. Pre-computed by buildRegex from the source pattern.
+   */
+  preFilter?: PreFilter | null;
 }
 
 export interface SearchResult {
@@ -106,6 +128,7 @@ export function searchContent(
     passthru = false,
     multiline = false,
     kResetGroup,
+    preFilter,
   } = options;
 
   // Multiline mode: search entire content as one string
@@ -140,20 +163,27 @@ export function searchContent(
     // --count --only-matching behaves like --count-matches
     const shouldCountMatches = (countMatches || onlyMatching) && !invertMatch;
     for (let i = 0; i < lastIdx; i++) {
+      const line = lines[i];
+      // Pre-filter: skip lines that can't contain any required literal.
+      // For invertMatch=true (-vc), a no-match line still counts, so we
+      // can't skip it — only short-circuit when not inverting.
+      if (preFilter && !invertMatch && !preFilterMatches(preFilter, line)) {
+        continue;
+      }
       regex.lastIndex = 0;
       if (shouldCountMatches) {
         // Count individual matches on the line
         for (
-          let match = regex.exec(lines[i]);
+          let match = regex.exec(line);
           match !== null;
-          match = regex.exec(lines[i])
+          match = regex.exec(line)
         ) {
           matchCount++;
           if (match[0].length === 0) regex.lastIndex++;
         }
       } else {
         // Count lines (with matches, or without matches if inverted)
-        if (regex.test(lines[i]) !== invertMatch) {
+        if (regex.test(line) !== invertMatch) {
           matchCount++;
         }
       }
@@ -176,19 +206,26 @@ export function searchContent(
       if (maxCount > 0 && matchCount >= maxCount) break;
 
       const line = lines[i];
-      regex.lastIndex = 0;
-      const matches = regex.test(line);
+      // Substring pre-filter: when no extracted needle is present, the
+      // regex provably cannot match. String.indexOf is ~50x faster than
+      // RE2.find() for short inputs, so we skip the regex for the bulk
+      // of unmatching lines.
+      let firstMatch: RegExpExecArray | null = null;
+      if (preFilter && !preFilterMatches(preFilter, line)) {
+        // firstMatch stays null → matches stays false
+      } else {
+        regex.lastIndex = 0;
+        firstMatch = regex.exec(line);
+      }
+      const matches = firstMatch !== null;
 
       if (matches !== invertMatch) {
         hasMatch = true;
         matchCount++;
         if (onlyMatching) {
-          regex.lastIndex = 0;
-          for (
-            let match = regex.exec(line);
-            match !== null;
-            match = regex.exec(line)
-          ) {
+          // firstMatch is the first iteration of the all-matches loop.
+          // exec()'s side effect already advanced lastIndex past it.
+          for (let match = firstMatch; match !== null; match = regex.exec(line)) {
             // If \K was used, extract from the capture group instead of full match
             const rawMatch =
               kResetGroup !== undefined ? (match[kResetGroup] ?? "") : match[0];
@@ -203,12 +240,7 @@ export function searchContent(
           }
         } else if (vimgrep) {
           // Vimgrep mode: output each match separately with full line
-          regex.lastIndex = 0;
-          for (
-            let match = regex.exec(line);
-            match !== null;
-            match = regex.exec(line)
-          ) {
+          for (let match = firstMatch; match !== null; match = regex.exec(line)) {
             let prefix = filename ? `${filename}:` : "";
             if (showByteOffset) prefix += `${byteOffset + match.index}:`;
             if (showLineNumbers) prefix += `${i + 1}:`;
@@ -217,9 +249,7 @@ export function searchContent(
             if (match[0].length === 0) regex.lastIndex++;
           }
         } else {
-          // Get first match position for column
-          regex.lastIndex = 0;
-          const firstMatch = regex.exec(line);
+          // First match position already known from the exec() above.
           const column = firstMatch ? firstMatch.index + 1 : 1;
 
           // Apply replacement if specified
@@ -278,8 +308,13 @@ export function searchContent(
 
     for (let i = 0; i < lastIdx; i++) {
       const line = lines[i];
-      regex.lastIndex = 0;
-      const matches = regex.test(line);
+      let matches: boolean;
+      if (preFilter && !preFilterMatches(preFilter, line)) {
+        matches = false;
+      } else {
+        regex.lastIndex = 0;
+        matches = regex.test(line);
+      }
       const isMatch = matches !== invertMatch;
 
       if (isMatch) {
@@ -313,8 +348,15 @@ export function searchContent(
   for (let i = 0; i < lastIdx; i++) {
     // Check if we've reached maxCount
     if (maxCount > 0 && matchCount >= maxCount) break;
-    regex.lastIndex = 0;
-    if (regex.test(lines[i]) !== invertMatch) {
+    const line = lines[i];
+    let matches: boolean;
+    if (preFilter && !preFilterMatches(preFilter, line)) {
+      matches = false;
+    } else {
+      regex.lastIndex = 0;
+      matches = regex.test(line);
+    }
+    if (matches !== invertMatch) {
       matchingLineNumbers.push(i);
       matchCount++;
     }

--- a/packages/just-bash/src/commands/search-engine/regex.test.ts
+++ b/packages/just-bash/src/commands/search-engine/regex.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { buildRegex } from "./regex.js";
+
+/**
+ * Direct tests for the preFilter extractor inside buildRegex.
+ *
+ * The extractor is the safety-critical part of the perf/grep optimisation:
+ * a false-positive needle (extracting a literal that isn't actually required
+ * by the regex) causes searchContent to skip lines the regex would have
+ * matched — a silent correctness bug. These tests cover the happy paths
+ * (extraction must succeed) and the safety paths (extraction must return
+ * `undefined`, falling back to the unfiltered regex scan).
+ */
+
+describe("buildRegex preFilter — happy path", () => {
+  it("extracts bare literal in basic mode", () => {
+    expect(buildRegex("interface", { mode: "basic" }).preFilter).toEqual({
+      needles: ["interface"],
+      ignoreCase: false,
+    });
+  });
+
+  it("strips -w wrapper for single literal", () => {
+    expect(
+      buildRegex("type", { mode: "basic", wholeWord: true }).preFilter,
+    ).toEqual({ needles: ["type"], ignoreCase: false });
+  });
+
+  it("strips -w wrapper around alternation", () => {
+    expect(
+      buildRegex("foo|bar", { mode: "extended", wholeWord: true }).preFilter,
+    ).toEqual({ needles: ["foo", "bar"], ignoreCase: false });
+  });
+
+  it("splits top-level alternation in extended mode", () => {
+    expect(buildRegex("interface|type", { mode: "extended" }).preFilter).toEqual(
+      { needles: ["interface", "type"], ignoreCase: false },
+    );
+  });
+
+  it("lowercases needles when -i is set", () => {
+    expect(
+      buildRegex("Async", { mode: "basic", ignoreCase: true }).preFilter,
+    ).toEqual({ needles: ["async"], ignoreCase: true });
+  });
+
+  it("treats -F fixed strings as literal needles", () => {
+    // < and > are not regex meta, so -F leaves them untouched
+    expect(buildRegex("Promise<T>", { mode: "fixed" }).preFilter).toEqual({
+      needles: ["Promise<T>"],
+      ignoreCase: false,
+    });
+  });
+
+  it("decodes regex meta escaped by -F back to literal text", () => {
+    // -F escapes "." to "\\." inside the regex. The needle should be ".", not "\\."
+    expect(buildRegex("a.b", { mode: "fixed" }).preFilter).toEqual({
+      needles: ["a.b"],
+      ignoreCase: false,
+    });
+  });
+
+  it("decodes \\n / \\t / \\r escapes to their literal characters", () => {
+    expect(buildRegex("foo\\nbar", { mode: "extended" }).preFilter).toEqual({
+      needles: ["foo\nbar"],
+      ignoreCase: false,
+    });
+  });
+});
+
+describe("buildRegex preFilter — safety (must NOT extract)", () => {
+  it("rejects quantifier +", () => {
+    expect(buildRegex("a+", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects quantifier *", () => {
+    expect(buildRegex("a*", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects quantifier ?", () => {
+    expect(buildRegex("a?", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects quantifier {n,m}", () => {
+    expect(buildRegex("a{2,4}", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects character class", () => {
+    expect(buildRegex("[abc]", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects start anchor ^", () => {
+    expect(buildRegex("^foo", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects end anchor $", () => {
+    expect(buildRegex("foo$", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects . (matches any char)", () => {
+    // basic mode: . is the dot meta in BRE, not escaped
+    expect(buildRegex("a.b", { mode: "basic" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects \\d (digit class)", () => {
+    expect(buildRegex("\\d", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects \\w (word class)", () => {
+    expect(buildRegex("\\w+", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects \\s (whitespace class)", () => {
+    expect(buildRegex("\\s", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects bare \\b word boundary", () => {
+    // Distinct from the -w wrapper case: \b is the *content*, not a frame
+    expect(buildRegex("\\bfoo", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects capturing group (foo)", () => {
+    expect(buildRegex("(foo)", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects non-capturing group (?:foo) without \\b\\b frame", () => {
+    expect(
+      buildRegex("(?:foo)", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
+  });
+
+  it("rejects alternation when one branch contains meta", () => {
+    // "foo" alone would be safe, but "bar+" disqualifies the whole alternation
+    // (any matching line might satisfy "bar+" without containing "foo" or "bar")
+    expect(
+      buildRegex("foo|bar+", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
+  });
+
+  it("rejects nested alternation inside a capturing group", () => {
+    expect(
+      buildRegex("foo(bar|baz)", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
+  });
+});
+
+describe("buildRegex preFilter — structural correctness", () => {
+  it("does not split | inside non-capturing group", () => {
+    // (?:a|b)c has no top-level alternation; it must NOT be split into ["(?:a", "b)c"]
+    // Pattern is rejected (group is meta), but the failure mode we're guarding
+    // against here is misclassification, not rejection.
+    expect(
+      buildRegex("(?:a|b)c", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
+  });
+
+  it("does not split | inside character class", () => {
+    expect(buildRegex("[a|b]", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("preserves needle ordering for alternation", () => {
+    expect(
+      buildRegex("alpha|beta|gamma", { mode: "extended" }).preFilter,
+    ).toEqual({ needles: ["alpha", "beta", "gamma"], ignoreCase: false });
+  });
+
+  it("does not over-strip when pattern just starts with \\b", () => {
+    // "\bfoo" (no closing \b) should NOT be treated as a -w wrap
+    expect(buildRegex("\\bfoo", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("returns undefined for empty pattern", () => {
+    expect(buildRegex("", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+});

--- a/packages/just-bash/src/commands/search-engine/regex.test.ts
+++ b/packages/just-bash/src/commands/search-engine/regex.test.ts
@@ -33,9 +33,9 @@ describe("buildRegex preFilter — happy path", () => {
   });
 
   it("splits top-level alternation in extended mode", () => {
-    expect(buildRegex("interface|type", { mode: "extended" }).preFilter).toEqual(
-      { needles: ["interface", "type"], ignoreCase: false },
-    );
+    expect(
+      buildRegex("interface|type", { mode: "extended" }).preFilter,
+    ).toEqual({ needles: ["interface", "type"], ignoreCase: false });
   });
 
   it("lowercases needles when -i is set", () => {
@@ -82,7 +82,9 @@ describe("buildRegex preFilter — safety (must NOT extract)", () => {
   });
 
   it("rejects quantifier {n,m}", () => {
-    expect(buildRegex("a{2,4}", { mode: "extended" }).preFilter).toBeUndefined();
+    expect(
+      buildRegex("a{2,4}", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
   });
 
   it("rejects character class", () => {
@@ -116,7 +118,9 @@ describe("buildRegex preFilter — safety (must NOT extract)", () => {
 
   it("rejects bare \\b word boundary", () => {
     // Distinct from the -w wrapper case: \b is the *content*, not a frame
-    expect(buildRegex("\\bfoo", { mode: "extended" }).preFilter).toBeUndefined();
+    expect(
+      buildRegex("\\bfoo", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
   });
 
   it("rejects capturing group (foo)", () => {
@@ -140,6 +144,16 @@ describe("buildRegex preFilter — safety (must NOT extract)", () => {
   it("rejects nested alternation inside a capturing group", () => {
     expect(
       buildRegex("foo(bar|baz)", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
+  });
+
+  it("rejects \\x hex escape (would produce wrong needle, e.g. 'x41' for \\x41)", () => {
+    expect(buildRegex("\\x41", { mode: "extended" }).preFilter).toBeUndefined();
+  });
+
+  it("rejects \\u unicode escape (would produce wrong needle, e.g. 'u2764' for \\u2764)", () => {
+    expect(
+      buildRegex("\\u2764", { mode: "extended" }).preFilter,
     ).toBeUndefined();
   });
 });
@@ -166,7 +180,9 @@ describe("buildRegex preFilter — structural correctness", () => {
 
   it("does not over-strip when pattern just starts with \\b", () => {
     // "\bfoo" (no closing \b) should NOT be treated as a -w wrap
-    expect(buildRegex("\\bfoo", { mode: "extended" }).preFilter).toBeUndefined();
+    expect(
+      buildRegex("\\bfoo", { mode: "extended" }).preFilter,
+    ).toBeUndefined();
   });
 
   it("returns undefined for empty pattern", () => {

--- a/packages/just-bash/src/commands/search-engine/regex.ts
+++ b/packages/just-bash/src/commands/search-engine/regex.ts
@@ -38,6 +38,20 @@ export interface RegexResult {
   regex: UserRegex;
   /** If \K was used, this is the 1-based index of the capture group containing the "real" match */
   kResetGroup?: number;
+  /**
+   * Optional fast-path filter: if every needle is absent from a line via
+   * String.indexOf, the regex is guaranteed not to match and RE2 can be skipped.
+   * Extracted only for patterns where it is provably safe (literal alternatives,
+   * optionally wrapped in \b...\b for -w mode). Null for anything more complex.
+   */
+  preFilter?: PreFilter;
+}
+
+export interface PreFilter {
+  /** Any one of these substrings must appear in a matching line (OR semantics). */
+  needles: string[];
+  /** When true, both needles and the line must be lowercased before indexOf. */
+  ignoreCase: boolean;
 }
 
 /**
@@ -218,7 +232,132 @@ export function buildRegex(
     (options.multiline ? "m" : "") +
     (options.multilineDotall ? "s" : "") +
     (needsUnicode ? "u" : "");
-  return { regex: createUserRegex(regexPattern, flags), kResetGroup };
+  const preFilter = extractPreFilter(
+    regexPattern,
+    options.ignoreCase ?? false,
+  );
+  return {
+    regex: createUserRegex(regexPattern, flags),
+    kResetGroup,
+    preFilter: preFilter ?? undefined,
+  };
+}
+
+/**
+ * Try to extract a set of literal substrings, at least one of which must
+ * appear in any line that matches the pattern. Returns null when no safe
+ * extraction is possible (e.g., the pattern uses quantifiers or character
+ * classes that can match zero or arbitrary text).
+ *
+ * Recognised shapes (covers the bulk of grep usage):
+ *   - bare literal:        "interface"   -> ["interface"]
+ *   - escaped literal:     "Promise\\(" -> ["Promise("]
+ *   - whole-word wrapper:  "\\b(?:type)\\b" or "\\btype\\b" -> ["type"]
+ *   - alternation:         "interface|type" -> ["interface", "type"]
+ *   - whole-word + alt:    "\\b(?:foo|bar)\\b" -> ["foo", "bar"]
+ *
+ * Anchors (^, $) and any quantifier or character class disable extraction.
+ * False positives are fine (we just run the regex anyway); false negatives
+ * would be bugs (skipping a line that the regex would match).
+ */
+function extractPreFilter(
+  jsPattern: string,
+  ignoreCase: boolean,
+): PreFilter | null {
+  let core = jsPattern;
+
+  // Strip -w wrappers produced by buildRegex above.
+  if (core.startsWith("\\b(?:") && core.endsWith(")\\b")) {
+    core = core.slice("\\b(?:".length, core.length - ")\\b".length);
+  } else if (core.startsWith("\\b") && core.endsWith("\\b") && core.length >= 4) {
+    core = core.slice(2, core.length - 2);
+  }
+
+  if (core.length === 0) return null;
+
+  const alternatives = splitTopLevelAlternation(core);
+  if (alternatives === null) return null;
+
+  const needles: string[] = [];
+  for (const alt of alternatives) {
+    const literal = literalFromAlternative(alt);
+    if (literal === null || literal.length === 0) return null;
+    needles.push(literal);
+  }
+
+  if (needles.length === 0) return null;
+
+  return {
+    needles: ignoreCase ? needles.map((n) => n.toLowerCase()) : needles,
+    ignoreCase,
+  };
+}
+
+/**
+ * Split a regex pattern on top-level | (alternation), respecting escapes,
+ * grouping parens, and character classes. Returns null if structure is malformed.
+ */
+function splitTopLevelAlternation(pattern: string): string[] | null {
+  const parts: string[] = [];
+  let depth = 0;
+  let inClass = false;
+  let last = 0;
+  for (let i = 0; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === "\\") {
+      i++; // skip the escaped char
+      continue;
+    }
+    if (inClass) {
+      if (c === "]") inClass = false;
+      continue;
+    }
+    if (c === "[") inClass = true;
+    else if (c === "(") depth++;
+    else if (c === ")") {
+      depth--;
+      if (depth < 0) return null;
+    } else if (c === "|" && depth === 0) {
+      parts.push(pattern.slice(last, i));
+      last = i + 1;
+    }
+  }
+  if (depth !== 0 || inClass) return null;
+  parts.push(pattern.slice(last));
+  return parts;
+}
+
+/**
+ * Return the literal string represented by a regex alternative, or null if
+ * the alternative contains any regex metacharacter that could match
+ * something other than itself (quantifier, anchor, character class, group, dot).
+ */
+function literalFromAlternative(alt: string): string | null {
+  let out = "";
+  for (let i = 0; i < alt.length; i++) {
+    const c = alt[i];
+    if (c === "\\") {
+      const next = alt[i + 1];
+      if (next === undefined) return null;
+      // Reject escapes that aren't simple literal substitutions.
+      // \n, \t, \r are literal whitespace — fine. \d, \w, \s, \b, \B etc.
+      // match character classes or zero-width assertions — reject.
+      if (/[dDwWsSbBAZzGQE0-9ckpPNXR]/.test(next)) return null;
+      // Translate common escape sequences to their literal char.
+      if (next === "n") out += "\n";
+      else if (next === "t") out += "\t";
+      else if (next === "r") out += "\r";
+      else if (next === "f") out += "\f";
+      else if (next === "v") out += "\v";
+      else out += next; // \. \* \+ \? \^ \$ \( \) \[ \] \{ \} \| \\ \/ etc.
+      i++;
+      continue;
+    }
+    // Any unescaped regex metacharacter disqualifies the alternative.
+    if (/[.*+?^${}()|[\]]/.test(c)) return null;
+    out += c;
+  }
+  return out;
 }
 
 /**

--- a/packages/just-bash/src/commands/search-engine/regex.ts
+++ b/packages/just-bash/src/commands/search-engine/regex.ts
@@ -232,10 +232,7 @@ export function buildRegex(
     (options.multiline ? "m" : "") +
     (options.multilineDotall ? "s" : "") +
     (needsUnicode ? "u" : "");
-  const preFilter = extractPreFilter(
-    regexPattern,
-    options.ignoreCase ?? false,
-  );
+  const preFilter = extractPreFilter(regexPattern, options.ignoreCase ?? false);
   return {
     regex: createUserRegex(regexPattern, flags),
     kResetGroup,
@@ -269,7 +266,11 @@ function extractPreFilter(
   // Strip -w wrappers produced by buildRegex above.
   if (core.startsWith("\\b(?:") && core.endsWith(")\\b")) {
     core = core.slice("\\b(?:".length, core.length - ")\\b".length);
-  } else if (core.startsWith("\\b") && core.endsWith("\\b") && core.length >= 4) {
+  } else if (
+    core.startsWith("\\b") &&
+    core.endsWith("\\b") &&
+    core.length >= 4
+  ) {
     core = core.slice(2, core.length - 2);
   }
 
@@ -342,7 +343,7 @@ function literalFromAlternative(alt: string): string | null {
       // Reject escapes that aren't simple literal substitutions.
       // \n, \t, \r are literal whitespace — fine. \d, \w, \s, \b, \B etc.
       // match character classes or zero-width assertions — reject.
-      if (/[dDwWsSbBAZzGQE0-9ckpPNXR]/.test(next)) return null;
+      if (/[dDwWsSbBAZzGQE0-9ckpPNXRxuU]/.test(next)) return null;
       // Translate common escape sequences to their literal char.
       if (next === "n") out += "\n";
       else if (next === "t") out += "\t";

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -82,7 +82,8 @@ export class UserRegex implements RegexLike {
   private _nativeRegex: RegExp | null = null;
   // Reusable RE2 Matcher to avoid per-call allocation in tight grep loops.
   // Matcher allocation dominates regex.test/exec cost when called once per line
-  // across thousands of lines. resetMatcherInput rebinds without re-allocating.
+  // across thousands of lines. We mutate charSequence in-place (not resetMatcherInput,
+  // which is broken in re2js 1.2.1 — see acquireMatcher).
   private _matcher: ReturnType<RE2JS["matcher"]> | null = null;
   private _matcherInput: string | null = null;
 

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -80,6 +80,34 @@ export class UserRegex implements RegexLike {
   private _lastIndex = 0;
   // Cache native RegExp for compatibility - created lazily
   private _nativeRegex: RegExp | null = null;
+  // Reusable RE2 Matcher to avoid per-call allocation in tight grep loops.
+  // Matcher allocation dominates regex.test/exec cost when called once per line
+  // across thousands of lines. resetMatcherInput rebinds without re-allocating.
+  private _matcher: ReturnType<RE2JS["matcher"]> | null = null;
+  private _matcherInput: string | null = null;
+
+  private acquireMatcher(input: string): ReturnType<RE2JS["matcher"]> {
+    if (this._matcher === null) {
+      this._matcher = this._re2.matcher(input);
+      this._matcherInput = input;
+      return this._matcher;
+    }
+    if (this._matcherInput !== input) {
+      // Swap the cached Utf16MatcherInput's charSequence in-place to avoid
+      // allocating a new Matcher per call. RE2JS's resetMatcherInput is not
+      // safe with raw strings (the constructor wraps strings via
+      // MatcherInput.utf16, but resetMatcherInput assigns its argument
+      // directly and then calls .length() as a method, which throws on a
+      // raw string). MatcherInput is not exported, so we mutate the existing
+      // wrapper's charSequence field — Matcher.reset() reads matcherInput.length()
+      // afterwards, so the new length is picked up correctly.
+      // biome-ignore lint/suspicious/noExplicitAny: reaching into re2js internals
+      (this._matcher as any).matcherInput.charSequence = input;
+      this._matcherInput = input;
+    }
+    this._matcher.reset();
+    return this._matcher;
+  }
 
   constructor(pattern: string, flags = "") {
     this._pattern = pattern;
@@ -131,7 +159,7 @@ export class UserRegex implements RegexLike {
     if (this._global) {
       this._lastIndex = 0;
     }
-    const matcher = this._re2.matcher(input);
+    const matcher = this.acquireMatcher(input);
     return matcher.find();
   }
 
@@ -140,7 +168,7 @@ export class UserRegex implements RegexLike {
    * Returns match array with capture groups, or null if no match.
    */
   exec(input: string): RegExpExecArray | null {
-    const matcher = this._re2.matcher(input);
+    const matcher = this.acquireMatcher(input);
 
     // For global regex, start from lastIndex
     const startPos = this._global ? this._lastIndex : 0;


### PR DESCRIPTION
## Summary

Three layered optimisations in the regex engine and grep search loop that together produce a **5–123× speedup** on common grep patterns over a ~25k-line corpus, with all 2,051 directly-relevant tests passing.

## The investigation

Started with a benchmark report: `grep -ri 'async'` over 113 TypeScript files (25,956 lines) on a deployed sandbox API was taking **680 ms server-side**. Other "expensive" grep variants — `-rw`, `-rE` with alternation — were similarly slow at 476 ms and 823 ms. Simple greps (`-r 'interface'`, `-rn 'export'`) were fine (~20–40 ms). The pattern: anything that exercised RE2JS's case-insensitive, word-boundary, or alternation paths was 20–40× slower than expected.

## Issues encountered

### Issue 1 — RE2JS allocates a fresh Matcher per `test()`/`exec()` call

```ts
// before — src/regex/user-regex.ts
test(input: string): boolean {
    const matcher = this._re2.matcher(input);   // new RE2 Matcher every call
    return matcher.find();
}
```

For grep over 25 k lines, that's ~25,000 Matcher allocations per invocation — plus a second one per matched line for the column position (see Issue 3). RE2JS's per-Matcher setup cost dominates the actual matching work for short inputs.

### Issue 2 — `Matcher.resetMatcherInput(string)` is broken in re2js 1.2.1

The natural fix — cache the Matcher and rebind via \`resetMatcherInput(newInput)\` — silently corrupts grep:

```js
// re2js Matcher constructor wraps strings before assigning:
constructor(pattern, input) {
    if (input instanceof MatcherInputBase) this.resetMatcherInput(input);
    else if (Array.isArray(input))         this.resetMatcherInput(MatcherInput.utf8(input));
    else                                   this.resetMatcherInput(MatcherInput.utf16(input));  // ← string wrap
}

// but resetMatcherInput itself does NOT wrap:
resetMatcherInput(input) {
    this.matcherInput = input;        // raw string assigned directly
    this.reset();                     //   → reads this.matcherInput.length() — METHOD CALL
}                                     //   → string has .length (property), not .length() → TypeError
                                      //   → swallowed by grep's try/catch
                                      //   → 0 matches reported, no error surfaces
```

I hit this in the first version of the cache fix — the benchmark sped up but every grep returned 0 matches. The working fix: mutate the cached `Utf16MatcherInput.charSequence` field in place, then call `reset()`.

### Issue 3 — `searchContent` calls `test()` then `exec()` on the same line

```ts
// before — src/commands/search-engine/matcher.ts (default mode)
const matches = regex.test(line);          // RE2 find() #1
if (matches !== invertMatch) {
    regex.lastIndex = 0;
    const firstMatch = regex.exec(line);   // RE2 find() #2 — same line!
    const column = firstMatch.index + 1;
    // ...
}
```

`exec()` already returns null/non-null *and* the match position. Two `find()` calls per matched line is one too many.

### Issue 4 (the big one) — no Boyer-Moore-style literal pre-filter

GNU grep extracts literal substrings from the pattern at compile time and uses `memmem` / Boyer-Moore as a pre-filter. Lines that don't contain the literal are skipped without ever invoking the regex engine. RE2JS doesn't do this, and just-bash's grep didn't either — so for `-ri 'async'`, RE2 was running case-insensitive DFA scans on **all 25 k lines**, even though only ~1.7 k of them contained "async".

`String.indexOf` runs at memory-bandwidth speed in V8. RE2JS, being a JS port, doesn't come close. Skipping the regex entirely on no-needle lines turned out to be the single biggest win — and explains why the cumulative wins compound the way they do (matcher cache alone cut the slow patterns from ~700 ms to ~120 ms; the pre-filter then took them down further to single-digit ms).

## What changed

### `src/regex/user-regex.ts` — Matcher cache

- Added \`acquireMatcher(input)\` that allocates the Matcher once, then mutates \`matcherInput.charSequence\` in place when the input changes. Calls \`reset()\` afterwards to clear match state.
- \`test()\` and \`exec()\` route through it. Other methods (\`replace\`, \`match\`, \`matchAll\`, \`search\`) still allocate per-call — they're not on the grep hot path and \`replace()\` invokes user-supplied callbacks, which makes shared mutable Matcher state risky.

### `src/commands/search-engine/matcher.ts` — combined `test()` + `exec()`

- Replaced the two-call pattern with a single \`regex.exec(line)\`. The result is null / non-null for the boolean *and* provides \`firstMatch.index\` for column info.
- For \`-o\` (only-matching) and vimgrep, the upfront \`exec()\` doubles as the first iteration of the all-matches loop.

### `src/commands/search-engine/regex.ts` — substring pre-filter

- New \`extractPreFilter(jsPattern, ignoreCase)\` returns \`{ needles, ignoreCase }\` when at least one literal substring can be safely required from the pattern, else \`null\`.
- Recognised shapes: bare literal (\`interface\`), \`\b…\b\` and \`\b(?:…)\b\` wrapping (i.e. \`-w\`), top-level alternation of literals (\`a|b|c\`), \`-F\`-mode escapes decoded back to literal text, and \`\n\`/\`\t\`/\`\r\` decoded to actual whitespace.
- Hard-rejects anything with quantifiers, anchors, character classes, character-class escapes (\`\d\` / \`\w\` / \`\s\`), groups, dots, or alternation where any branch contains meta. **False positives are fine; false negatives would silently break grep.**
- Returned alongside \`regex\` from \`buildRegex\`.

### `src/commands/search-engine/matcher.ts` — pre-filter integration

- New \`preFilterMatches(preFilter, line)\` helper.
- Wired into the four per-line loops (default / count / passthru / context). When the pre-filter says "definitely no match", regex is skipped and the boolean result is set to false. The \`-v\` interaction is preserved (a line that the pre-filter rejects still gets emitted by \`-v\` because it's a confirmed non-match).

### `src/commands/search-engine/regex.test.ts` — new test file (29 cases)

- **8 happy-path** — bare literal, \`-w\` wraps (single + alt), top-level alternation, \`-F\` decode, \`-i\` lowercase, \`\n\` decode
- **16 safety negatives** — every quantifier (\`+\`, \`*\`, \`?\`, \`{n,m}\`), char class, anchors (\`^\`, \`$\`), bare \`.\`, char-class escapes (\`\d\`/\`\w\`/\`\s\`), bare \`\b\`, capture group, non-capturing group without \`\b\b\` frame, mixed alternation, nested alternation in group
- **5 structural** — \`|\` correctly *not* split inside \`(?:…)\` or \`[…]\`, alternation order preserved, partial \`\b\` not over-stripped, empty pattern

The negatives are the safety-critical ones — false-positive needles in the extractor would silently cause grep to miss valid matches.

## Benchmark

Setup:  Recursive grep over `/home/user/src` in my private bench— 113 files, 25,956 lines of TypeScript. Server-reported \`duration_ms\`, p50 of 3 measured runs after one warmup run.

| Pattern | matches | **before** | **after** | **speedup** |
|---|---:|---:|---:|---:|
| \`grep -ri 'async'\` | 1655 | 680 ms | **14 ms** | **48×** |
| \`grep -rw 'type'\` | 366 | 476 ms | **5 ms** | **90×** |
| \`grep -rE 'interface\|type'\` | 634 | 823 ms | **7 ms** | **123×** |
| \`grep -r 'interface'\` | 50 | 44 ms | **4 ms** | 11× |
| \`grep -rF 'Promise<'\` | 316 | 26 ms | **3 ms** | 9× |
| \`grep -rn 'export'\` | 141 | 21 ms | **4 ms** | 5× |
| \`grep -rl 'SqlFs'\` | — | 20 ms | **3 ms** | 7× |

Cumulative breakdown for the three slow patterns (each row stacks on the previous):

| Stage | -ri 'async' | -rw 'type' | -rE 'interface\|type' |
|---|---:|---:|---:|
| baseline | 680 ms | 476 ms | 823 ms |
| + Matcher cache | 135 ms | 96 ms | 150 ms |
| + combined test/exec | 120 ms | 85 ms | 138 ms |
| + indexOf pre-filter | **14 ms** | **5 ms** | **7 ms** |

Match counts identical at every stage — verified against the deployed baseline and against system grep via \`src/comparison-tests/grep.comparison.test.ts\`.

## Test plan

- [x] \`pnpm vitest run src/regex\` — 67/67 pass
- [x] \`pnpm vitest run src/commands/grep\` — 212/212 pass (basic, advanced, perl, exclude, binary)
- [x] \`pnpm vitest run src/commands/search-engine\` — 29/29 pass (new test file)
- [x] \`pnpm vitest run src/commands/sed src/commands/awk src/commands/rg\` — 1379/1379 pass (sister commands sharing UserRegex)
- [x] \`pnpm vitest run src/spec-tests/grep\` — 332/332 pass
- [x] \`pnpm test:comparison src/comparison-tests/grep.comparison.test.ts\` — 32/32 pass (validates output against system grep)
- [x] Match counts in the live deployed-vs-local benchmark match exactly (1655, 366, 634, 141, 50, 316, 23)

Total **2,051 / 2,051** directly-relevant tests pass. Eight failures elsewhere in the full unit suite (\`src/cli/just-bash.bundle.test.ts\`, \`src/fs/cross-fs-security.test.ts\`, \`src/security/{attacks,sandbox}/python-*\`) reproduce on clean main without this patch — Python/CPython-Emscripten runtime tests and a filesystem symlink-to-real-dir test, none of which touch files in this diff.