### PR TITLE
fix(jq): preserve UTF-8 in path-assignment output

### DIFF
--- a/.changeset/few-mice-explain.md
+++ b/.changeset/few-mice-explain.md
@@ -1,0 +1,6 @@
+---
+"just-bash": patch
+---
+
+jq: preserve UTF-8 multibyte text when applying nested path assignment filters.
+This prevents mojibake caused by treating JSON file bytes as Latin-1 before serialization.

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -22,6 +22,32 @@ import {
 } from "../query-engine/index.js";
 import { sanitizeParsedData } from "../query-engine/safe-object.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 function escapeControlChar(char: string): string {
   switch (char) {
     case "\b":
@@ -325,7 +351,10 @@ export const jqCommand: Command = {
     if (nullInput) {
       // No input
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      inputs.push({ source: "stdin", content: ctx.stdin });
+      inputs.push({
+        source: "stdin",
+        content: decodeBinaryToUtf8IfNeeded(ctx.stdin),
+      });
     } else {
       // Read all files in parallel using shared utility
       const result = await withDefenseContext("file read", () =>
@@ -343,7 +372,7 @@ export const jqCommand: Command = {
       }
       inputs = result.files.map((f) => ({
         source: f.filename || "stdin",
-        content: f.content,
+        content: decodeBinaryToUtf8IfNeeded(f.content),
       }));
     }
 

--- a/packages/just-bash/src/commands/jq/jq.utf8.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.utf8.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("jq utf8 path assignment", () => {
+  const KOREAN = "한글 테스트 문구입니다.";
+
+  it("preserves UTF-8 string bytes when assigning to nested array path", async () => {
+    const env = new Bash({
+      files: {
+        "/workflow.json": JSON.stringify(
+          {
+            nodes: [
+              {
+                type: "llm",
+                max_tokens: 8192,
+                system_prompt: `<g>${KOREAN}</g>`,
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+      },
+    });
+
+    const result = await env.exec(
+      "jq '.nodes[0].max_tokens = 16384' /workflow.json > /out.json && mv /out.json /workflow.json",
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const after = await env.fs.readFile("/workflow.json", "utf8");
+    expect(after).toContain(KOREAN);
+  });
+
+  it("preserves UTF-8 string bytes when assigning through selected path", async () => {
+    const env = new Bash({
+      files: {
+        "/workflow.json": JSON.stringify(
+          {
+            nodes: [
+              {
+                id: "target",
+                type: "llm",
+                max_tokens: 8192,
+                system_prompt: `<g>${KOREAN}</g>`,
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+      },
+    });
+
+    const result = await env.exec(
+      "jq '(.nodes[] | select(.id == \"target\")).max_tokens = 16384' /workflow.json > /out.json && mv /out.json /workflow.json",
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const after = await env.fs.readFile("/workflow.json", "utf8");
+    expect(after).toContain(KOREAN);
+  });
+});


### PR DESCRIPTION
## Summary
`jq` corrupts UTF-8 multibyte characters (Korean / CJK / any non-ASCII) inside string values when the filter performs a path assignment such as `.foo[0].bar = N` or `(.foo[] | select(.x==Y)).bar = N`. Identity filters and simple top-level edits are unaffected.

## Reproduction
A new test in `packages/just-bash/src/commands/jq/jq.utf8.test.ts` reproduces the bug with a Korean payload. The corruption signature is double-encoding: UTF-8 bytes are interpreted as Latin-1 and then re-encoded as UTF-8 (so `한` 0xED 0x95 0x9C becomes `í`).

## Root cause
`jq` reads file/stdin content through the shared binary path (`readFiles(..., "binary")`), but the jq command parsed those latin1 byte-strings as Unicode text directly. During serialization, those mis-decoded characters were emitted as mojibake.

## Fix
Decode jq inputs from binary byte-strings to UTF-8 before JSON parsing (`decodeBinaryToUtf8IfNeeded` in `packages/just-bash/src/commands/jq/jq.ts`). This is a minimal scoped fix in jq’s input path, with no parser/evaluator refactor.

## Verification
- New regression tests pass (`jq.utf8.test.ts` covers nested assignment and selected-path assignment)
- Full existing `pnpm test:run` suite remains green