### PR TITLE
feat: add declared size support for lazy files

### DIFF
--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -163,6 +163,14 @@ const env = new Bash({
     // Lazy: called on first read, cached. Never called if written before read.
     "/data/large.csv": () => "col1,col2\na,b\n",
     "/data/remote.txt": async () => (await fetch("https://example.com")).text(),
+    // Lazy with declared byte size: `stat`/`ls -l` can avoid loading content.
+    "/data/indexed.bin": {
+      lazy: async () =>
+        new Uint8Array(
+          await (await fetch("https://example.com/indexed.bin")).arrayBuffer(),
+        ),
+      size: 1024,
+    },
   },
 });
 ```

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.test.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.test.ts
@@ -377,6 +377,113 @@ describe("InMemoryFs lazy files", () => {
     expect(stat.size).toBe(5);
   });
 
+  it("should use declared lazy size on stat without materializing", async () => {
+    const provider = vi.fn(() => "hello");
+    const fs = new InMemoryFs({
+      "/lazy.txt": { lazy: provider, size: 5 },
+    });
+
+    const stat = await fs.stat("/lazy.txt");
+
+    expect(stat.isFile).toBe(true);
+    expect(stat.size).toBe(5);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("should use declared lazy size on lstat without materializing", async () => {
+    const provider = vi.fn(() => "hello");
+    const fs = new InMemoryFs({
+      "/lazy.txt": { lazy: provider, size: 5 },
+    });
+
+    const stat = await fs.lstat("/lazy.txt");
+
+    expect(stat.isFile).toBe(true);
+    expect(stat.size).toBe(5);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("should still read declared-size lazy files on demand", async () => {
+    const provider = vi.fn(() => "hello");
+    const fs = new InMemoryFs({
+      "/lazy.txt": { lazy: provider, size: 5 },
+    });
+
+    await fs.stat("/lazy.txt");
+    const result = await fs.readFile("/lazy.txt");
+    await fs.readFile("/lazy.txt");
+
+    expect(result).toBe("hello");
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  it("should report actual size after materializing declared-size lazy files", async () => {
+    const provider = vi.fn(() => "hello");
+    const fs = new InMemoryFs({
+      "/lazy.txt": { lazy: provider, size: 999 },
+    });
+
+    const beforeRead = await fs.stat("/lazy.txt");
+    expect(beforeRead.size).toBe(999);
+    expect(provider).not.toHaveBeenCalled();
+
+    await fs.readFile("/lazy.txt");
+
+    const afterRead = await fs.stat("/lazy.txt");
+    expect(afterRead.size).toBe(5);
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  it("should support declared lazy size via writeFileLazy", async () => {
+    const provider = vi.fn(() => "dynamic content");
+    const fs = new InMemoryFs();
+    fs.writeFileLazy("/dynamic.txt", provider, { size: 15 });
+
+    const stat = await fs.stat("/dynamic.txt");
+
+    expect(stat.size).toBe(15);
+    expect(provider).not.toHaveBeenCalled();
+  });
+
+  it("should materialize lazy files with invalid declared size", async () => {
+    const provider = vi.fn(() => "hello");
+    const fs = new InMemoryFs({
+      "/lazy.txt": { lazy: provider, size: -1 },
+    });
+
+    const stat = await fs.stat("/lazy.txt");
+
+    expect(stat.size).toBe(5);
+    expect(provider).toHaveBeenCalledTimes(1);
+  });
+
+  it("should avoid materializing declared-size lazy files during long listing", async () => {
+    const providers = Array.from({ length: 10 }, (_, i) =>
+      vi.fn(() => `file ${i}`),
+    );
+    const fs = new InMemoryFs(
+      Object.fromEntries(
+        providers.map((provider, i) => [
+          `/dir/file-${i}.txt`,
+          { lazy: provider, size: i + 1 },
+        ]),
+      ),
+    );
+
+    const names = await fs.readdir("/dir");
+    const stats = await Promise.all(
+      names.map((name) => fs.stat(`/dir/${name}`)),
+    );
+
+    expect(names).toHaveLength(10);
+    expect(stats.map((stat) => stat.size)).toEqual([
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+    ]);
+    for (const provider of providers) {
+      expect(provider).not.toHaveBeenCalled();
+    }
+  });
+
   it("should handle appendFile on lazy file", async () => {
     const fs = new InMemoryFs({
       "/lazy.txt": () => "hello",

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -12,6 +12,7 @@ import type {
   IFileSystem,
   InitialFiles,
   LazyFileEntry,
+  LazyFileInit,
   LazyFileProvider,
   MkdirOptions,
   ReadFileOptions,
@@ -56,13 +57,39 @@ const textEncoder = new TextEncoder();
  * Type guard to check if a value is a FileInit object
  */
 function isFileInit(
-  value: FileContent | FileInit | LazyFileProvider,
+  value: FileContent | FileInit | LazyFileProvider | LazyFileInit,
 ): value is FileInit {
   return (
     typeof value === "object" &&
     value !== null &&
     !(value instanceof Uint8Array) &&
     "content" in value
+  );
+}
+
+/**
+ * Type guard to check if a value is a lazy file init object.
+ */
+function isLazyFileInit(
+  value: FileContent | FileInit | LazyFileProvider | LazyFileInit,
+): value is LazyFileInit {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !(value instanceof Uint8Array) &&
+    "lazy" in value &&
+    !("content" in value) &&
+    typeof value.lazy === "function"
+  );
+}
+
+function hasDeclaredSize(entry: LazyFileEntry): entry is LazyFileEntry & {
+  size: number;
+} {
+  return (
+    typeof entry.size === "number" &&
+    Number.isInteger(entry.size) &&
+    entry.size >= 0
   );
 }
 
@@ -82,6 +109,13 @@ export class InMemoryFs implements IFileSystem {
         if (typeof value === "function") {
           // Lazy file - store provider function, called on first read
           this.writeFileLazy(path, value);
+        } else if (isLazyFileInit(value)) {
+          // Lazy file with optional metadata
+          this.writeFileLazy(path, value.lazy, {
+            mode: value.mode,
+            mtime: value.mtime,
+            size: value.size,
+          });
         } else if (isFileInit(value)) {
           // Extended init with metadata
           this.writeFileSync(path, value.content, undefined, {
@@ -140,7 +174,7 @@ export class InMemoryFs implements IFileSystem {
   writeFileLazy(
     path: string,
     lazy: () => string | Uint8Array | Promise<string | Uint8Array>,
-    metadata?: { mode?: number; mtime?: Date },
+    metadata?: { mode?: number; mtime?: Date; size?: number },
   ): void {
     validatePath(path, "write");
     const normalized = normalizePath(path);
@@ -151,6 +185,7 @@ export class InMemoryFs implements IFileSystem {
       lazy,
       mode: metadata?.mode ?? DEFAULT_FILE_MODE,
       mtime: metadata?.mtime ?? new Date(),
+      size: metadata?.size,
     });
   }
 
@@ -296,8 +331,18 @@ export class InMemoryFs implements IFileSystem {
       throw new Error(`ENOENT: no such file or directory, stat '${path}'`);
     }
 
-    // Materialize lazy files to get accurate size
+    // Use declared lazy size when available; otherwise materialize to get size.
     if (entry.type === "file" && "lazy" in entry) {
+      if (hasDeclaredSize(entry)) {
+        return {
+          isFile: true,
+          isDirectory: false,
+          isSymbolicLink: false,
+          mode: entry.mode,
+          size: entry.size,
+          mtime: entry.mtime || new Date(),
+        };
+      }
       entry = await this.materializeLazy(resolvedPath, entry);
     }
 
@@ -344,8 +389,18 @@ export class InMemoryFs implements IFileSystem {
       };
     }
 
-    // Materialize lazy files to get accurate size
+    // Use declared lazy size when available; otherwise materialize to get size.
     if (entry.type === "file" && "lazy" in entry) {
+      if (hasDeclaredSize(entry)) {
+        return {
+          isFile: true,
+          isDirectory: false,
+          isSymbolicLink: false,
+          mode: entry.mode,
+          size: entry.size,
+          mtime: entry.mtime || new Date(),
+        };
+      }
       entry = await this.materializeLazy(resolvedPath, entry);
     }
 

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -57,6 +57,11 @@ export interface LazyFileEntry {
   lazy: () => string | Uint8Array | Promise<string | Uint8Array>;
   mode: number;
   mtime: Date;
+  /**
+   * Optional declared byte length. When present, stat/lstat can report size
+   * without materializing lazy content.
+   */
+  size?: number;
 }
 
 export type FsEntry = FileEntry | LazyFileEntry | DirectoryEntry | SymlinkEntry;
@@ -279,11 +284,24 @@ export type LazyFileProvider = () =>
   | Promise<string | Uint8Array>;
 
 /**
+ * Lazy file initialization options with optional metadata.
+ *
+ * `size` is the declared byte length used by stat/lstat before the file is
+ * materialized. Once read, stat/lstat report the actual materialized size.
+ */
+export interface LazyFileInit {
+  lazy: LazyFileProvider;
+  size?: number;
+  mode?: number;
+  mtime?: Date;
+}
+
+/**
  * Initial files can be simple content, extended options with metadata, or lazy providers
  */
 export type InitialFiles = Record<
   string,
-  FileContent | FileInit | LazyFileProvider
+  FileContent | FileInit | LazyFileProvider | LazyFileInit
 >;
 
 /**


### PR DESCRIPTION
This PR adds support for defining a lazy file with metdaata, including a size.

I've got a use-case using the GitHub tree api where I get the file names, but also the size of the file, see https://api.github.com/repos/vercel-labs/just-bash/git/trees/HEAD

When defining in-memory files, such as:

```ts
const env = new Bash({
  files: { "/data/file.txt": () => fetch('...').then(r => t.text()) },
});
```

When `stat()` (etc) is called on the FS, it performs a fetch request to return metadata (e.g size). So if the user runs a `ls -la` command on a directory with say 100 lazy-loaded files, this would be 100 network requests.

This PR adds support for defining the metadata upfront, so content loading is deferred until the content itself is actually needed, e.g:

```ts
    "/data/indexed.bin": {
      lazy: async () =>
        new Uint8Array(
          await (await fetch("https://example.com/indexed.bin")).arrayBuffer(),
        ),
      size: 1024,
    },
```

With this, the content isn't fetched until it's actually needed since we provide the metadata upfront.

Without this, I basically need to re-implement my own file system instance, re-building all of the complexity which the built in ones provided out of the box.