### PR TITLE
fix(yq): preserve UTF-8 bytes during YAML parsing

### DIFF
--- a/.changeset/yq-utf8-fix.md
+++ b/.changeset/yq-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+fix yq UTF-8 mojibake by decoding binary stdin/file input before YAML parsing.

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -35,6 +35,32 @@ import {
   parseInput,
 } from "./formats.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 const yqHelp = {
   name: "yq",
   summary: "command-line YAML/XML/INI/CSV/TOML processor",
@@ -287,14 +313,14 @@ export const yqCommand: Command = {
     if (options.nullInput) {
       input = "";
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = ctx.stdin;
+      input = decodeBinaryToUtf8IfNeeded(ctx.stdin);
     } else {
       try {
         const resolvedFilePath = ctx.fs.resolvePath(ctx.cwd, files[0]);
         filePath = resolvedFilePath;
-        input = await withDefenseContext("file read", () =>
+        input = decodeBinaryToUtf8IfNeeded(await withDefenseContext("file read", () =>
           ctx.fs.readFile(resolvedFilePath),
-        );
+        ));
       } catch (e) {
         if (e instanceof SecurityViolationError) {
           throw e;

--- a/packages/just-bash/src/commands/yq/yq.utf8.test.ts
+++ b/packages/just-bash/src/commands/yq/yq.utf8.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("yq utf8 path assignment", () => {
+  const KOREAN = "한글 테스트 문구입니다.";
+  const ACCENTED = "café déjà vu";
+  const CJK = "漢字テスト";
+
+  it("preserves UTF-8 string bytes for file input during path assignment", async () => {
+    const env = new Bash({
+      files: {
+        "/workflow.yaml": `nodes:\n  - id: target\n    type: llm\n    max_tokens: 8192\n    system_prompt: \"<g>${KOREAN} / ${ACCENTED} / ${CJK}</g>\"\n`,
+      },
+    });
+
+    const result = await env.exec(
+      "yq '(.nodes[] | select(.id == \"target\")).max_tokens = 16384' /workflow.yaml > /out.yaml && mv /out.yaml /workflow.yaml",
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const after = await env.fs.readFile("/workflow.yaml", "utf8");
+    expect(after).toContain(KOREAN);
+    expect(after).toContain(ACCENTED);
+    expect(after).toContain(CJK);
+  });
+
+  it("preserves UTF-8 string bytes for stdin input during path assignment", async () => {
+    const env = new Bash({
+      files: {
+        "/workflow.yaml": `nodes:\n  - id: target\n    type: llm\n    max_tokens: 8192\n    system_prompt: \"<g>${KOREAN} / ${ACCENTED} / ${CJK}</g>\"\n`,
+      },
+    });
+
+    const result = await env.exec(
+      "cat /workflow.yaml | yq '(.nodes[] | select(.id == \"target\")).max_tokens = 16384' > /out.yaml",
+    );
+
+    expect(result.exitCode).toBe(0);
+
+    const after = await env.fs.readFile("/out.yaml", "utf8");
+    expect(after).toContain(KOREAN);
+    expect(after).toContain(ACCENTED);
+    expect(after).toContain(CJK);
+  });
+});


### PR DESCRIPTION
## Summary

Same root cause as #219 (jq), applied to yq.

`yq` reads `ctx.stdin` and file content as latin1 binary strings (each char's charCode = one byte). When the YAML parser/serializer re-encodes the data, multi-byte UTF-8 sequences get double-encoded (e.g. `한` → `í•œ`).

## Fix

Apply `decodeBinaryToUtf8IfNeeded` at every `ctx.stdin` and file-content site, using the exact helper from the jq fix.

## Test

New regression test at `packages/just-bash/src/commands/yq/yq.utf8.test.ts` covering Korean / accented / CJK text via stdin and files.