### PR TITLE
fix(html-to-markdown): preserve UTF-8 bytes during conversion

### DIFF
--- a/.changeset/html-to-markdown-utf8-fix.md
+++ b/.changeset/html-to-markdown-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Fix html-to-markdown UTF-8 mojibake by decoding binary-string stdin/file inputs as UTF-8 before Turndown conversion.

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
@@ -8,6 +8,32 @@ import TurndownService from "turndown";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 const htmlToMarkdownHelp = {
   name: "html-to-markdown",
   summary: "convert HTML to Markdown (BashEnv extension)",
@@ -95,11 +121,11 @@ export const htmlToMarkdownCommand: Command = {
     // Get input
     let input: string;
     if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = ctx.stdin;
+      input = decodeBinaryToUtf8IfNeeded(ctx.stdin);
     } else {
       try {
         const filePath = ctx.fs.resolvePath(ctx.cwd, files[0]);
-        input = await ctx.fs.readFile(filePath);
+        input = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(filePath));
       } catch {
         return {
           stdout: "",

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.utf8.test.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.utf8.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+const KOREAN = "한글 테스트 문구입니다.";
+const ACCENTED = "café crème brûlée";
+const CJK = "漢字かな交じり文";
+const EMOJI = "🚀✨";
+
+function toBinaryStringFromUtf8(input: string): string {
+  return Buffer.from(input, "utf8").toString("latin1");
+}
+
+function expectUtf8Preserved(output: string): void {
+  expect(output).toContain(KOREAN);
+  expect(output).toContain(ACCENTED);
+  expect(output).toContain(CJK);
+  expect(output).toContain(EMOJI);
+}
+
+describe("html-to-markdown utf8", () => {
+  const html = `<h1>${KOREAN}</h1><p>${ACCENTED}</p><p>${CJK}</p><p>${EMOJI}</p>`;
+  const binaryHtml = toBinaryStringFromUtf8(html);
+
+  it("preserves UTF-8 bytes when HTML comes from stdin", async () => {
+    const env = new Bash({ files: { "/stdin.html": binaryHtml } });
+
+    const result = await env.exec("cat /stdin.html | html-to-markdown");
+
+    expect(result.exitCode).toBe(0);
+    expectUtf8Preserved(result.stdout);
+  });
+
+  it("preserves UTF-8 bytes when HTML comes from file input", async () => {
+    const env = new Bash({ files: { "/input.html": binaryHtml } });
+
+    const result = await env.exec("html-to-markdown /input.html");
+
+    expect(result.exitCode).toBe(0);
+    expectUtf8Preserved(result.stdout);
+  });
+});


### PR DESCRIPTION
Same root cause as #219 (jq). decodeBinaryToUtf8IfNeeded applied at ctx.stdin / file content sites in html-to-markdown.ts. Regression test at html-to-markdown.utf8.test.ts.