### PR TITLE
fix(grep): preserve UTF-8 bytes during pattern matching

### DIFF
--- a/.changeset/grep-utf8-fix.md
+++ b/.changeset/grep-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Fix grep UTF-8 input decoding by applying `decodeBinaryToUtf8IfNeeded` at stdin and file-content input boundaries before pattern matching.

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -4,6 +4,32 @@ import { matchGlob } from "../../utils/glob.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 import { buildRegex, searchContent } from "../search-engine/index.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 /** File entry with optional type info from glob expansion */
 interface FileEntry {
   path: string;
@@ -227,7 +253,7 @@ export const grepCommand: Command = {
 
     // If no files and stdin is provided (including empty string), read from stdin
     if (files.length === 0 && ctx.stdin !== undefined) {
-      const result = searchContent(ctx.stdin, regex, {
+      const result = searchContent(decodeBinaryToUtf8IfNeeded(ctx.stdin), regex, {
         invertMatch,
         showLineNumbers,
         countOnly,
@@ -354,7 +380,7 @@ export const grepCommand: Command = {
             }
 
             const content = await ctx.fs.readFile(filePath);
-            const result = searchContent(content, regex, {
+            const result = searchContent(decodeBinaryToUtf8IfNeeded(content), regex, {
               invertMatch,
               showLineNumbers,
               countOnly,

--- a/packages/just-bash/src/commands/grep/grep.utf8.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.utf8.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("grep utf8 input decoding", () => {
+  it("matches Korean pattern from stdin and file input", async () => {
+    const encodedLines = new TextEncoder().encode("한국\n영어\n한국어\n");
+    const env = new Bash({
+      files: {
+        "/korean.txt": encodedLines,
+      },
+    });
+
+    const stdinResult = await env.exec("cat /korean.txt | grep '한국'");
+    expect(stdinResult.exitCode).toBe(0);
+    expect(stdinResult.stdout).toBe("한국\n한국어\n");
+
+    const fileResult = await env.exec("grep '한국' /korean.txt");
+    expect(fileResult.exitCode).toBe(0);
+    expect(fileResult.stdout).toBe("한국\n한국어\n");
+  });
+
+  it("counts non-ascii matches with -c", async () => {
+    const env = new Bash({
+      files: {
+        "/count.txt": "한\n둘\n한글\n셋\n",
+      },
+    });
+
+    const result = await env.exec("grep -c '한' /count.txt");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("2\n");
+  });
+
+  it("matches anchored utf8 patterns with -E", async () => {
+    const env = new Bash({
+      files: {
+        "/anchor.txt": "한글\n영어\n한자\n",
+      },
+    });
+
+    const result = await env.exec("grep -E '^한' /anchor.txt");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글\n한자\n");
+  });
+});


### PR DESCRIPTION
Same root cause as #219 (jq). Apply `decodeBinaryToUtf8IfNeeded` at `ctx.stdin` / file content sites in grep.ts. Regression test at `grep.utf8.test.ts` covers Korean / CJK content matching, line counting, and anchored patterns.