### PR TITLE
fix(sqlite3): preserve UTF-8 bytes in SQL input

### DIFF
--- a/.changeset/sqlite3-utf8-fix.md
+++ b/.changeset/sqlite3-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Fix sqlite3 stdin SQL decoding to preserve UTF-8 string literals when input arrives as a latin1-style binary string.

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -42,6 +42,32 @@ import type {
 /** Default query timeout in milliseconds (5 seconds) */
 const DEFAULT_QUERY_TIMEOUT_MS = 5000;
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 const sqlite3Help = {
   name: "sqlite3",
   summary: "SQLite database CLI",
@@ -540,7 +566,7 @@ export const sqlite3Command: Command = {
     }
 
     // Get SQL from argument or stdin, prepend -cmd if provided
-    let sql = sqlArg || ctx.stdin.trim();
+    let sql = sqlArg || decodeBinaryToUtf8IfNeeded(ctx.stdin).trim();
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.utf8.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.utf8.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 utf8 stdin", () => {
+  const KOREAN = "한글";
+  const ACCENTED = "café";
+  const CJK = "漢字";
+
+  it("preserves UTF-8 SQL string literals piped via stdin", async () => {
+    const env = new Bash();
+    const sql =
+      `CREATE TABLE t(k TEXT, a TEXT, c TEXT); ` +
+      `INSERT INTO t VALUES('${KOREAN}','${ACCENTED}','${CJK}'); ` +
+      "SELECT k, a, c FROM t;";
+
+    const result = await env.exec(`echo "${sql}" | sqlite3 :memory:`);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(`${KOREAN}|${ACCENTED}|${CJK}`);
+  });
+
+  it("inserts and reads back UTF-8 values correctly through sql.js execution", async () => {
+    const env = new Bash();
+    const insertSql =
+      "CREATE TABLE messages(text TEXT); " +
+      `INSERT INTO messages VALUES('${KOREAN} ${ACCENTED} ${CJK}');`;
+
+    const insert = await env.exec(`echo "${insertSql}" | sqlite3 /utf8.db`);
+    expect(insert.exitCode).toBe(0);
+
+    const select = await env.exec('sqlite3 /utf8.db "SELECT text FROM messages"');
+    expect(select.exitCode).toBe(0);
+    expect(select.stdout).toContain(`${KOREAN} ${ACCENTED} ${CJK}`);
+  });
+});


### PR DESCRIPTION
Same root cause as #219 (jq). SQL piped via stdin could arrive as a latin1-style binary string, so UTF-8 literals were corrupted before reaching sql.js. This normalizes only SQL input from ctx.stdin and adds regression coverage for UTF-8 round-trips via sqlite3 stdin.