### PR TITLE
fix(rg): preserve UTF-8 bytes during ripgrep search

### DIFF
--- a/.changeset/rg-utf8-fix.md
+++ b/.changeset/rg-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+fix rg UTF-8 decoding when stdin or file contents are provided as latin1/binary strings.

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -44,6 +44,34 @@ function validateGlob(glob: string): string | null {
   return null;
 }
 
+/**
+ * Decode strings that actually contain UTF-8 bytes stored in latin1/binary form.
+ * If the string already contains real Unicode text, returns it unchanged.
+ */
+function decodeBinaryToUtf8IfNeeded(content: string): string {
+  for (let index = 0; index < content.length; index++) {
+    if (content.charCodeAt(index) > 0xff) {
+      return content;
+    }
+  }
+
+  const bytes = Uint8Array.from(content, (char) => char.charCodeAt(0));
+  const decoded = new TextDecoder().decode(bytes);
+  const reencoded = new TextEncoder().encode(decoded);
+
+  if (reencoded.length !== bytes.length) {
+    return content;
+  }
+
+  for (let index = 0; index < bytes.length; index++) {
+    if (bytes[index] !== reencoded[index]) {
+      return content;
+    }
+  }
+
+  return decoded;
+}
+
 export interface SearchContext {
   ctx: CommandContext;
   options: RgOptions;
@@ -84,10 +112,10 @@ export async function executeSearch(
       let content: string;
       if (patternFile === "-") {
         // Read from stdin
-        content = ctx.stdin;
+        content = decodeBinaryToUtf8IfNeeded(ctx.stdin);
       } else {
         const filePath = ctx.fs.resolvePath(ctx.cwd, patternFile);
-        content = await ctx.fs.readFile(filePath);
+        content = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(filePath));
       }
       const filePatterns = content
         .split("\n")
@@ -724,8 +752,9 @@ async function readFileContent(
           args: [filePath],
         });
         if (result.exitCode === 0 && result.stdout) {
-          const sample = result.stdout.slice(0, 8192);
-          return { content: result.stdout, isBinary: sample.includes("\0") };
+          const content = decodeBinaryToUtf8IfNeeded(result.stdout);
+          const sample = content.slice(0, 8192);
+          return { content, isBinary: sample.includes("\0") };
         }
         // Preprocessing failed, fall through to normal file read
       }
@@ -747,7 +776,7 @@ async function readFileContent(
     }
 
     // Regular file read
-    const content = await ctx.fs.readFile(filePath);
+    const content = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(filePath));
     const sample = content.slice(0, 8192);
     return { content, isBinary: sample.includes("\0") };
   } catch {

--- a/packages/just-bash/src/commands/rg/rg.utf8.test.ts
+++ b/packages/just-bash/src/commands/rg/rg.utf8.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+function toLatin1BinaryString(text: string): string {
+  return Buffer.from(text, "utf8").toString("latin1");
+}
+
+describe("rg utf8 decoding", () => {
+  it("matches Korean pattern read from latin1-encoded stdin (-f-)", async () => {
+    const bash = new Bash({
+      cwd: "/home/user",
+      files: {
+        "/home/user/input.txt": "앞 한국 뒤\n",
+      },
+    });
+
+    const result = await bash.exec("rg -f- input.txt", {
+      stdin: toLatin1BinaryString("한국\n"),
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("앞 한국 뒤\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("counts Korean matches from latin1-encoded file content", async () => {
+    const bash = new Bash({
+      cwd: "/home/user",
+      files: {
+        "/home/user/input.txt": toLatin1BinaryString(
+          "한국\n영어\n한국\n한국어\n",
+        ),
+      },
+    });
+
+    const result = await bash.exec("rg -c 한국 input.txt");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("3\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("reports character-aware match positions in json output", async () => {
+    const bash = new Bash({
+      cwd: "/home/user",
+      files: {
+        "/home/user/input.txt": toLatin1BinaryString("가나다한국라마바사\n"),
+      },
+    });
+
+    const result = await bash.exec("rg --json 한국 input.txt");
+
+    expect(result.exitCode).toBe(0);
+    const lines = result.stdout
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line) as Record<string, unknown>);
+
+    const matchMessage = lines.find((line) => line.type === "match") as {
+      type: "match";
+      data: {
+        lines: { text: string };
+        absolute_offset: number;
+        submatches: Array<{ start: number; end: number; match: { text: string } }>;
+      };
+    };
+
+    expect(matchMessage.data.lines.text).toBe("가나다한국라마바사\n");
+    expect(matchMessage.data.absolute_offset).toBe(0);
+    expect(matchMessage.data.submatches[0]).toEqual({
+      start: 3,
+      end: 5,
+      match: { text: "한국" },
+    });
+  });
+});


### PR DESCRIPTION
Same root cause as #219 (jq). Apply `decodeBinaryToUtf8IfNeeded` at `ctx.stdin` / file content sites in rg-search.ts. Regression test at `rg.utf8.test.ts`.