### PR TITLE
fix(xan): preserve UTF-8 bytes in CSV input

### DIFF
--- a/.changeset/xan-csv-utf8-fix.md
+++ b/.changeset/xan-csv-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Fix xan CSV input decoding to preserve UTF-8 text from stdin and file reads, preventing mojibake for multibyte characters.

--- a/packages/just-bash/src/commands/xan/csv.ts
+++ b/packages/just-bash/src/commands/xan/csv.ts
@@ -5,6 +5,32 @@
 import Papa from "papaparse";
 import type { CommandContext, ExecResult } from "../../types.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+export function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 export interface CsvRow {
   [key: string]: string | number | boolean | null;
 }
@@ -88,11 +114,11 @@ export async function readCsvInput(
   let input: string;
 
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBinaryToUtf8IfNeeded(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);
-      input = await ctx.fs.readFile(path);
+      input = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(path));
     } catch {
       return {
         headers: [],

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -9,6 +9,7 @@ import {
   type CsvData,
   type CsvRow,
   createSafeRow,
+  decodeBinaryToUtf8IfNeeded,
   formatCsv,
   readCsvInput,
   safeSetRow,
@@ -128,11 +129,11 @@ export async function cmdFixlengths(
   let input: string;
 
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBinaryToUtf8IfNeeded(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);
-      input = await ctx.fs.readFile(path);
+      input = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(path));
     } catch {
       return {
         stdout: "",
@@ -482,11 +483,11 @@ async function cmdFromJson(
   let input: string;
 
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBinaryToUtf8IfNeeded(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);
-      input = await ctx.fs.readFile(path);
+      input = decodeBinaryToUtf8IfNeeded(await ctx.fs.readFile(path));
     } catch {
       return {
         stdout: "",

--- a/packages/just-bash/src/commands/xan/xan-simple.ts
+++ b/packages/just-bash/src/commands/xan/xan-simple.ts
@@ -10,6 +10,7 @@ import {
   type CsvData,
   type CsvRow,
   createSafeRow,
+  decodeBinaryToUtf8IfNeeded,
   formatCsv,
   parseCsv,
   readCsvInput,
@@ -162,7 +163,7 @@ export async function cmdCat(
   let allHeaders: string[] = [];
 
   for (const { content } of result.files) {
-    const { headers, data } = parseCsv(content);
+    const { headers, data } = parseCsv(decodeBinaryToUtf8IfNeeded(content));
     allFiles.push({ headers, data });
 
     // Collect all unique headers

--- a/packages/just-bash/src/commands/xan/xan.utf8.test.ts
+++ b/packages/just-bash/src/commands/xan/xan.utf8.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+const UTF8_TEXT = "한글 café 東京 😀";
+
+function toLatin1BinaryString(input: string): string {
+  return Buffer.from(input, "utf8").toString("latin1");
+}
+
+describe("xan utf8 csv input handling", () => {
+  it("preserves UTF-8 CSV cells from stdin", async () => {
+    const csv = `id,message\n1,${UTF8_TEXT}\n`;
+    const binaryCsv = toLatin1BinaryString(csv);
+
+    const bash = new Bash({ files: { "/in.csv": binaryCsv } });
+    const result = await bash.exec("cat /in.csv | xan select message");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(UTF8_TEXT);
+  });
+
+  it("preserves UTF-8 CSV cells from file input", async () => {
+    const csv = `id,message\n1,${UTF8_TEXT}\n`;
+    const binaryCsv = toLatin1BinaryString(csv);
+
+    const bash = new Bash({ files: { "/in.csv": binaryCsv } });
+    const result = await bash.exec("xan select message /in.csv");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(UTF8_TEXT);
+  });
+});

--- a/packages/just-bash/src/commands/xan/xan.utf8.test.ts
+++ b/packages/just-bash/src/commands/xan/xan.utf8.test.ts
@@ -29,4 +29,15 @@ describe("xan utf8 csv input handling", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toContain(UTF8_TEXT);
   });
+
+  it("preserves UTF-8 CSV cells through xan cat (file input)", async () => {
+    const csv = `id,message\n1,${UTF8_TEXT}\n`;
+    const binaryCsv = toLatin1BinaryString(csv);
+
+    const bash = new Bash({ files: { "/a.csv": binaryCsv } });
+    const result = await bash.exec("xan cat /a.csv");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain(UTF8_TEXT);
+  });
 });


### PR DESCRIPTION
Same root cause as #219 (jq). decodeBinaryToUtf8IfNeeded at all three ctx.stdin sites in xan/csv.ts and xan/xan-data.ts. Regression test at xan/xan.utf8.test.ts.