### PR TITLE
fix(js-exec): preserve UTF-8 bytes when forwarding stdin / inline code

### DIFF
--- a/.changeset/js-exec-utf8-fix.md
+++ b/.changeset/js-exec-utf8-fix.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Preserve UTF-8 bytes when forwarding `js-exec` stdin source code by decoding latin1-style binary strings before passing code to the QuickJS worker.

--- a/packages/just-bash/src/commands/js-exec/js-exec.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.ts
@@ -33,6 +33,32 @@ import type {
   JsExecWorkerOutput,
 } from "./js-exec-worker.js";
 
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+
+function decodeBinaryToUtf8IfNeeded(input: string): string {
+  if (!input) return input;
+
+  let hasHighByte = false;
+  for (let i = 0; i < input.length; i++) {
+    const code = input.charCodeAt(i);
+    if (code > 0xff) return input;
+    if (code > 0x7f) hasHighByte = true;
+  }
+
+  if (!hasHighByte) return input;
+
+  const bytes = new Uint8Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    bytes[i] = input.charCodeAt(i);
+  }
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return input;
+  }
+}
+
 /** Default JavaScript execution timeout in milliseconds */
 const DEFAULT_JS_TIMEOUT_MS = 10000;
 /** Default JavaScript execution timeout when network is enabled */
@@ -577,8 +603,8 @@ export const jsExecCommand: Command = {
           exitCode: 2,
         };
       }
-    } else if (ctx.stdin.trim()) {
-      jsCode = ctx.stdin;
+    } else if (decodeBinaryToUtf8IfNeeded(ctx.stdin).trim()) {
+      jsCode = decodeBinaryToUtf8IfNeeded(ctx.stdin);
       scriptPath = "<stdin>";
     } else {
       return {

--- a/packages/just-bash/src/commands/js-exec/js-exec.utf8.test.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.utf8.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("js-exec utf8 stdin/code handling", () => {
+  it(
+    "preserves UTF-8 when JavaScript source is provided via stdin",
+    { timeout: 30000 },
+    async () => {
+      const env = new Bash({ javascript: true });
+      const result = await env.exec("echo 'console.log(\"한국\")' | js-exec");
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("한국\n");
+    },
+  );
+
+  it(
+    "preserves UTF-8 when inline code is provided via -c",
+    { timeout: 30000 },
+    async () => {
+      const env = new Bash({ javascript: true });
+      const result = await env.exec(`js-exec -c "console.log('한')"`);
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("한\n");
+    },
+  );
+
+  it(
+    "preserves UTF-8 for runtime stdin passed from QuickJS exec",
+    { timeout: 30000 },
+    async () => {
+      const env = new Bash({ javascript: true });
+      const result = await env.exec(
+        `js-exec -c "const { execSync } = require('child_process'); console.log(execSync('bash -c \\\"cat\\\"', { stdin: '한글😀' }));"`,
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("한글😀\n");
+    },
+  );
+});


### PR DESCRIPTION
Same root cause as #219 (jq). Apply `decodeBinaryToUtf8IfNeeded` at `ctx.stdin` sites in js-exec.ts before forwarding to the QuickJS worker. Regression test at `js-exec.utf8.test.ts`.