### PR TITLE
Broad set of utf8 related fixes for input read from stdin

### DIFF
--- a/.changeset/fluffy-toes-stare.md
+++ b/.changeset/fluffy-toes-stare.md
@@ -1,0 +1,5 @@
+---
+"just-bash": major
+---
+
+Breaking change for stdin byte/utf8-handling. Will break some custom commands that handle stdin

--- a/.changeset/tangy-bananas-lose.md
+++ b/.changeset/tangy-bananas-lose.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+TS-enforced correct handling of utf8 on stdin. Impacts many commands

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ todo/
 fuzz-*.log
 .claude/settings.local.json
 .deepsec/
+plans/

--- a/examples/custom-command/commands.ts
+++ b/examples/custom-command/commands.ts
@@ -13,7 +13,7 @@ import {
   buildLinkSummaryPrompt,
   pickSummaryLengthForCharacters,
 } from "@steipete/summarize-core/prompts";
-import { defineCommand } from "just-bash";
+import { decodeBytesToUtf8, defineCommand } from "just-bash";
 
 /**
  * Generate a random UUID
@@ -50,10 +50,11 @@ export const uuidCommand = defineCommand("uuid", async (args) => {
  * Usage: json-format [file] or pipe JSON to it
  */
 export const jsonFormatCommand = defineCommand("json-format", async (args, ctx) => {
-  let input = ctx.stdin;
+  // Decode bytes to text — JSON.parse requires real Unicode.
+  let input = decodeBytesToUtf8(ctx.stdin);
 
   // Read from file if provided
-  if (args[0] && !ctx.stdin) {
+  if (args[0] && !input) {
     try {
       input = await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, args[0]));
     } catch {
@@ -134,10 +135,12 @@ export const loremCommand = defineCommand("lorem", async (args) => {
  * Similar to wc but with labeled output
  */
 export const wordcountCommand = defineCommand("wordcount", async (args, ctx) => {
-  let input = ctx.stdin;
+  // ctx.stdin is a `ByteString` (the pipeline carries raw bytes); decode
+  // for the line/word/char math, which only makes sense on Unicode text.
+  let input = decodeBytesToUtf8(ctx.stdin);
 
   // Read from file if provided
-  if (args[0] && !ctx.stdin) {
+  if (args[0] && !input) {
     try {
       input = await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, args[0]));
     } catch {
@@ -151,7 +154,7 @@ export const wordcountCommand = defineCommand("wordcount", async (args, ctx) => 
 
   const lines = input.split("\n").length - (input.endsWith("\n") ? 1 : 0);
   const words = input.trim().split(/\s+/).filter(Boolean).length;
-  const chars = input.length;
+  const chars = Array.from(input).length;
 
   return {
     stdout: `Lines: ${lines}\nWords: ${words}\nChars: ${chars}\n`,
@@ -166,8 +169,12 @@ export const wordcountCommand = defineCommand("wordcount", async (args, ctx) => 
  * Usage: reverse or pipe text to it
  */
 export const reverseCommand = defineCommand("reverse", async (_args, ctx) => {
-  const lines = ctx.stdin.split("\n");
-  const reversed = lines.map((line) => line.split("").reverse().join(""));
+  // Decode bytes to text so reversing happens by codepoint (multibyte
+  // characters stay intact). `Array.from` splits on Unicode codepoints
+  // rather than UTF-16 code units, so emoji / surrogate pairs survive.
+  const text = decodeBytesToUtf8(ctx.stdin);
+  const lines = text.split("\n");
+  const reversed = lines.map((line) => Array.from(line).reverse().join(""));
   return {
     stdout: reversed.join("\n"),
     stderr: "",

--- a/packages/just-bash-executor/src/tool-command.ts
+++ b/packages/just-bash-executor/src/tool-command.ts
@@ -11,7 +11,12 @@
  *   3. stdin:   echo '{"key":"value"}' | namespace command
  */
 
-import type { Command, CommandContext, ExecResult } from "just-bash";
+import {
+  type Command,
+  type CommandContext,
+  decodeBytesToUtf8,
+  type ExecResult,
+} from "just-bash";
 
 // ── Naming ──────────────────────────────────────────────────────
 
@@ -299,7 +304,9 @@ function createNamespaceCommand(
       const subArgs = args.slice(1);
 
       try {
-        const parsed = parseToolCliArgs(subArgs, ctx.stdin);
+        // ctx.stdin is a ByteString; decode for the JSON parser inside
+        // `parseToolCliArgs`, which expects real Unicode text.
+        const parsed = parseToolCliArgs(subArgs, decodeBytesToUtf8(ctx.stdin));
         if (parsed === HELP_SENTINEL) {
           return {
             stdout: formatSubcommandHelp(namespace, sub),

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -29,7 +29,7 @@ Each `exec()` call gets its own isolated shell state — environment variables, 
 Extend just-bash with your own TypeScript commands using `defineCommand`:
 
 ```typescript
-import { Bash, defineCommand } from "just-bash";
+import { Bash, decodeBytesToUtf8, defineCommand } from "just-bash";
 
 const hello = defineCommand("hello", async (args, ctx) => {
   const name = args[0] || "world";
@@ -37,7 +37,12 @@ const hello = defineCommand("hello", async (args, ctx) => {
 });
 
 const upper = defineCommand("upper", async (args, ctx) => {
-  return { stdout: ctx.stdin.toUpperCase(), stderr: "", exitCode: 0 };
+  // ctx.stdin is a ByteString — decode to text before string ops.
+  return {
+    stdout: decodeBytesToUtf8(ctx.stdin).toUpperCase(),
+    stderr: "",
+    exitCode: 0,
+  };
 });
 
 const bash = new Bash({ customCommands: [hello, upper] });

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -632,7 +632,13 @@ export class Bash {
       options: { ...this.state.options },
       // Share hashTable reference - it should persist across exec calls
       hashTable: this.state.hashTable,
-      // Pass stdin through to commands (for bash -c with piped input)
+      // Pass stdin through to commands (for bash -c with piped input).
+      // User-supplied `options.stdin` is forwarded as-is. Hosts that
+      // already have bytes (e.g. `Buffer.from(...).toString("latin1")`)
+      // get them through verbatim; hosts that pass JS Unicode text get
+      // pre-existing legacy semantics (the byte-consumer-counts-code-units
+      // limitation is the same as for any custom command that emits
+      // codepoints — separate from the pipe-boundary fix).
       groupStdin: options?.stdin,
       // Cooperative cancellation signal (used by timeout command)
       signal: options?.signal,

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -23,6 +23,7 @@ import {
   createLazyCustomCommand,
   isLazyCommand,
 } from "./custom-commands.js";
+import { encodeUtf8ToBytes, latin1FromBytes } from "./encoding.js";
 import { InMemoryFs } from "./fs/in-memory-fs/in-memory-fs.js";
 import { initFilesystem } from "./fs/init.js";
 import type { IFileSystem, InitialFiles } from "./fs/interface.js";
@@ -269,6 +270,14 @@ export interface ExecOptions {
    * This will be available to commands via stdin (e.g., for `bash -c 'cat'`).
    */
   stdin?: string;
+  /**
+   * Shape of {@link stdin} — see `CommandExecOptions.stdinKind`.
+   * Defaults to `"text"` (UTF-8 encoded into bytes for byte consumers
+   * inside the script). Pass `"bytes"` when you've prepared a latin1
+   * byte buffer (e.g. `Buffer.from(buf).toString("latin1")`) and want
+   * it forwarded verbatim.
+   */
+  stdinKind?: "text" | "bytes";
   /**
    * Abort signal for cooperative cancellation.
    * When aborted, the interpreter stops executing at the next statement boundary.
@@ -633,13 +642,13 @@ export class Bash {
       // Share hashTable reference - it should persist across exec calls
       hashTable: this.state.hashTable,
       // Pass stdin through to commands (for bash -c with piped input).
-      // User-supplied `options.stdin` is forwarded as-is. Hosts that
-      // already have bytes (e.g. `Buffer.from(...).toString("latin1")`)
-      // get them through verbatim; hosts that pass JS Unicode text get
-      // pre-existing legacy semantics (the byte-consumer-counts-code-units
-      // limitation is the same as for any custom command that emits
-      // codepoints — separate from the pipe-boundary fix).
-      groupStdin: options?.stdin,
+      // The pipeline contract is "stdin is a latin1-shaped byte buffer";
+      // text-shaped user input (the default) needs UTF-8 encoding here
+      // so byte consumers (`wc -c`, `base64`) inside the script see real
+      // UTF-8 bytes. Callers that already prepared a byte buffer (e.g.
+      // `Buffer.from(buf).toString("latin1")`) opt into raw passthrough
+      // via `stdinKind: "bytes"`.
+      groupStdin: encodeStdinForPipeline(options?.stdin, options?.stdinKind),
       // Cooperative cancellation signal (used by timeout command)
       signal: options?.signal,
       // Extra arguments injected directly into first command's arg list
@@ -961,4 +970,18 @@ function decodeBinaryToUtf8(s: string): string {
   } catch {
     return s;
   }
+}
+
+/**
+ * Convert user-supplied stdin into the latin1 byte buffer the pipeline
+ * expects. `"text"` (the default) is JS Unicode and gets UTF-8 encoded;
+ * `"bytes"` is already byte-shaped and passes through verbatim.
+ */
+function encodeStdinForPipeline(
+  stdin: string | undefined,
+  kind: "text" | "bytes" | undefined,
+): string | undefined {
+  if (stdin === undefined) return undefined;
+  if (kind === "bytes") return stdin;
+  return latin1FromBytes(encodeUtf8ToBytes(stdin));
 }

--- a/packages/just-bash/src/commands/awk/awk.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/awk/awk.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("awk reads UTF-8 from stdin", () => {
+  it("splits multibyte fields correctly through a pipe", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 café 漢字\n" } });
+    const result = await env.exec("cat /in.txt | awk '{ print $2 }'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("café\n");
+  });
+});

--- a/packages/just-bash/src/commands/awk/awk2.ts
+++ b/packages/just-bash/src/commands/awk/awk2.ts
@@ -4,7 +4,11 @@
  * This is the new implementation using proper lexer/parser/interpreter architecture.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import { ConstantRegex, createUserRegex } from "../../regex/index.js";
@@ -270,10 +274,14 @@ export const awkCommand2: Command = {
       // Execute END blocks (always run, even after exit - AWK semantics)
       await withDefenseContext("END execution", () => interp.executeEnd());
 
+      // awk processed UTF-8 text; re-encode to bytes for the byte-shaped
+      // pipeline so downstream byte consumers (wc -c, base64, md5sum) and
+      // redirects see UTF-8 bytes verbatim.
       return {
-        stdout: interp.getOutput(),
+        stdout: latin1FromBytes(encodeUtf8ToBytes(interp.getOutput())),
         stderr: "",
         exitCode: interp.getExitCode(),
+        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {
@@ -284,9 +292,10 @@ export const awkCommand2: Command = {
       const exitCode =
         e instanceof ExecutionLimitError ? ExecutionLimitError.EXIT_CODE : 2;
       return {
-        stdout: interp.getOutput(),
+        stdout: latin1FromBytes(encodeUtf8ToBytes(interp.getOutput())),
         stderr: `awk: ${msg}\n`,
         exitCode,
+        stdoutEncoding: "binary",
       };
     }
   },

--- a/packages/just-bash/src/commands/awk/awk2.ts
+++ b/packages/just-bash/src/commands/awk/awk2.ts
@@ -4,11 +4,7 @@
  * This is the new implementation using proper lexer/parser/interpreter architecture.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import { ConstantRegex, createUserRegex } from "../../regex/index.js";
@@ -274,14 +270,11 @@ export const awkCommand2: Command = {
       // Execute END blocks (always run, even after exit - AWK semantics)
       await withDefenseContext("END execution", () => interp.executeEnd());
 
-      // awk processed UTF-8 text; re-encode to bytes for the byte-shaped
-      // pipeline so downstream byte consumers (wc -c, base64, md5sum) and
-      // redirects see UTF-8 bytes verbatim.
+      // awk emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(interp.getOutput())),
+        stdout: interp.getOutput(),
         stderr: "",
         exitCode: interp.getExitCode(),
-        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {
@@ -292,10 +285,9 @@ export const awkCommand2: Command = {
       const exitCode =
         e instanceof ExecutionLimitError ? ExecutionLimitError.EXIT_CODE : 2;
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(interp.getOutput())),
+        stdout: interp.getOutput(),
         stderr: `awk: ${msg}\n`,
         exitCode,
-        stdoutEncoding: "binary",
       };
     }
   },

--- a/packages/just-bash/src/commands/awk/awk2.ts
+++ b/packages/just-bash/src/commands/awk/awk2.ts
@@ -4,6 +4,7 @@
  * This is the new implementation using proper lexer/parser/interpreter architecture.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import { ConstantRegex, createUserRegex } from "../../regex/index.js";
@@ -236,7 +237,9 @@ export const awkCommand2: Command = {
           }
         }
       } else {
-        const lines = ctx.stdin.split("\n");
+        // awk parses fields with regex / FS — decode bytes to UTF-8 so
+        // non-ASCII data isn't split mid-codepoint.
+        const lines = decodeBytesToUtf8(ctx.stdin).split("\n");
         if (lines.length > 0 && lines[lines.length - 1] === "") {
           lines.pop();
         }

--- a/packages/just-bash/src/commands/awk/interpreter/expressions.ts
+++ b/packages/just-bash/src/commands/awk/interpreter/expressions.ts
@@ -4,6 +4,7 @@
  * Async expression evaluator supporting file I/O operations.
  */
 
+import { decodeBytesToUtf8, unsafeBytesFromLatin1 } from "../../../encoding.js";
 import { ExecutionLimitError } from "../../../interpreter/errors.js";
 import { createUserRegex } from "../../../regex/index.js";
 import {
@@ -728,7 +729,9 @@ async function evalGetlineFromCommand(
       const result = await withDefenseContext(ctx, "getline command exec", () =>
         execFn(cmd),
       );
-      const output = result.stdout;
+      // awk processes lines with regex / FS — decode bytes to UTF-8 so
+      // `getline cmd |` from a piped command keeps multibyte fields whole.
+      const output = decodeBytesToUtf8(unsafeBytesFromLatin1(result.stdout));
       lines = output.split("\n");
       // Remove trailing empty line if output ends with newline
       if (lines.length > 0 && lines[lines.length - 1] === "") {

--- a/packages/just-bash/src/commands/base64/base64.ts
+++ b/packages/just-bash/src/commands/base64/base64.ts
@@ -2,6 +2,7 @@
  * base64 - Encode or decode base64
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -33,7 +34,7 @@ async function readBinary(
     // Convert binary string directly to bytes without UTF-8 re-encoding
     return {
       ok: true,
-      data: Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0)),
+      data: Uint8Array.from(latin1FromBytes(ctx.stdin), (c) => c.charCodeAt(0)),
     };
   }
 
@@ -42,7 +43,9 @@ async function readBinary(
   for (const file of files) {
     if (file === "-") {
       // Convert binary string directly to bytes without UTF-8 re-encoding
-      chunks.push(Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0)));
+      chunks.push(
+        Uint8Array.from(latin1FromBytes(ctx.stdin), (c) => c.charCodeAt(0)),
+      );
       continue;
     }
     try {

--- a/packages/just-bash/src/commands/base64/base64.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/base64/base64.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("base64 reads UTF-8 from stdin", () => {
+  it("encodes / decodes UTF-8 byte sequences without re-encoding", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글" } });
+    const enc = await env.exec("cat /in.txt | base64");
+    expect(enc.exitCode).toBe(0);
+    expect(enc.stdout.trim()).toBe("7ZWc6riA"); // base64 of UTF-8 bytes of 한글
+    const dec = await env.exec("cat /in.txt | base64 | base64 -d");
+    expect(dec.stdout).toBe("한글");
+  });
+});

--- a/packages/just-bash/src/commands/bash/bash.ts
+++ b/packages/just-bash/src/commands/bash/bash.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import { mergeToNullPrototype } from "../../helpers/env.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -35,10 +36,12 @@ export const bashCommand: Command = {
       return executeScript(command, scriptName, scriptArgs, ctx);
     }
 
-    // No arguments - read script from stdin if available
+    // No arguments - read script from stdin if available. Decode bytes — a
+    // bash script's UTF-8 string literals must reach the parser as text.
     if (args.length === 0) {
-      if (ctx.stdin?.trim()) {
-        return executeScript(ctx.stdin, "bash", [], ctx);
+      const stdinText = decodeBytesToUtf8(ctx.stdin);
+      if (stdinText.trim()) {
+        return executeScript(stdinText, "bash", [], ctx);
       }
       // No stdin - return success (interactive mode not supported)
       return { stdout: "", stderr: "", exitCode: 0 };
@@ -85,10 +88,12 @@ export const shCommand: Command = {
       return executeScript(command, scriptName, scriptArgs, ctx);
     }
 
-    // No arguments - read script from stdin if available
+    // No arguments - read script from stdin if available. Decode bytes — a
+    // shell script's UTF-8 string literals must reach the parser as text.
     if (args.length === 0) {
-      if (ctx.stdin?.trim()) {
-        return executeScript(ctx.stdin, "sh", [], ctx);
+      const stdinText = decodeBytesToUtf8(ctx.stdin);
+      if (stdinText.trim()) {
+        return executeScript(stdinText, "sh", [], ctx);
       }
       // No stdin - return success (interactive mode not supported)
       return { stdout: "", stderr: "", exitCode: 0 };
@@ -151,11 +156,12 @@ async function executeScript(
   // Execute the script as-is, preserving newlines for proper parsing
   // The parser needs to see the original structure to correctly handle
   // multi-line constructs like (( ... )) vs ( ( ... ) )
-  // Pass stdin through to the nested script
+  // Pass stdin through to the nested script as raw bytes — the inner
+  // pipeline will brand it again at the next dispatch.
   const result = await ctx.exec(scriptToRun, {
     env: positionalEnv,
     cwd: ctx.cwd,
-    stdin: ctx.stdin,
+    stdin: latin1FromBytes(ctx.stdin),
     signal: ctx.signal,
   });
   return result;

--- a/packages/just-bash/src/commands/bash/bash.ts
+++ b/packages/just-bash/src/commands/bash/bash.ts
@@ -156,12 +156,14 @@ async function executeScript(
   // Execute the script as-is, preserving newlines for proper parsing
   // The parser needs to see the original structure to correctly handle
   // multi-line constructs like (( ... )) vs ( ( ... ) )
-  // Pass stdin through to the nested script as raw bytes — the inner
-  // pipeline will brand it again at the next dispatch.
+  // Forward our already-byte-shaped stdin verbatim — `stdinKind: "bytes"`
+  // tells the nested exec entry to skip the default text-mode UTF-8
+  // encoding and avoid double-encoding.
   const result = await ctx.exec(scriptToRun, {
     env: positionalEnv,
     cwd: ctx.cwd,
     stdin: latin1FromBytes(ctx.stdin),
+    stdinKind: "bytes",
     signal: ctx.signal,
   });
   return result;

--- a/packages/just-bash/src/commands/bash/bash.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/bash/bash.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("bash reads UTF-8 script from stdin", () => {
+  it("parses and runs a piped script with multibyte string literals", async () => {
+    const env = new Bash({
+      files: { "/script.sh": 'echo "한글 / café / 漢字"\n' },
+    });
+    const result = await env.exec("cat /script.sh | bash");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 / café / 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/cat/cat.ts
+++ b/packages/just-bash/src/commands/cat/cat.ts
@@ -56,17 +56,16 @@ export const catCommand: Command = {
       }
     }
 
-    // Only use binary encoding when reading actual files (not just stdin).
-    // When reading from stdin (heredoc, here-string, pipeline text), the
-    // content may be Unicode text that needs UTF-8 encoding for file writes.
-    // File content is read with binary encoding and needs binary to preserve bytes.
-    const isReadingFiles = files.length > 0 && files.some((f) => f !== "-");
+    // cat is byte-clean: it forwards every byte of stdin / file content
+    // unchanged. Mark stdout binary unconditionally so the pipeline glue
+    // doesn't UTF-8-encode the bytes a second time when the next stage
+    // happens to be a byte consumer, and so `> /file` redirects skip the
+    // smart-utf8 encoding path that would otherwise double-encode.
     return {
       stdout,
       stderr: readResult.stderr,
       exitCode: readResult.exitCode,
-      // @banned-pattern-ignore: spread into static result keys, no user-controlled properties
-      ...(isReadingFiles ? { stdoutEncoding: "binary" as const } : {}),
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/cat/cat.ts
+++ b/packages/just-bash/src/commands/cat/cat.ts
@@ -1,3 +1,4 @@
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { readFiles } from "../../utils/file-reader.js";
@@ -42,13 +43,16 @@ export const catCommand: Command = {
     let lineNumber = 1;
 
     for (const { content } of readResult.files) {
+      // cat is byte-clean: emit raw bytes unchanged. The output boundary
+      // (Bash.exec) decodes UTF-8 sequences back to Unicode for terminals.
+      const bytes = latin1FromBytes(content);
       if (showLineNumbers) {
         // Real bash continues line numbers across files
-        const result = addLineNumbers(content, lineNumber);
+        const result = addLineNumbers(bytes, lineNumber);
         stdout += result.content;
         lineNumber = result.nextLineNumber;
       } else {
-        stdout += content;
+        stdout += bytes;
       }
     }
 

--- a/packages/just-bash/src/commands/cat/cat.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/cat/cat.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("cat reads UTF-8 from stdin", () => {
+  it("byte-clean passthrough preserves multibyte input", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café / 漢字\n" } });
+    const result = await env.exec("cat /in.txt | cat");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 / café / 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/column/column.ts
+++ b/packages/just-bash/src/commands/column/column.ts
@@ -6,6 +6,7 @@
  * Columnate input. Fill rows first by default, or create a table with -t.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -165,15 +166,18 @@ export const column: Command = {
     // Default output separator is two spaces
     const outSep = outputSep ?? "  ";
 
-    // Read input
+    // Read input. column uses .length / .padEnd for column widths, which
+    // operate on codepoints — decode bytes to UTF-8 so accented / CJK chars
+    // count once. (Display-width math for double-wide CJK is still wrong;
+    // see follow-up.)
     let content: string;
     if (files.length === 0) {
-      content = ctx.stdin ?? "";
+      content = decodeBytesToUtf8(ctx.stdin) ?? "";
     } else {
       const parts: string[] = [];
       for (const file of files) {
         if (file === "-") {
-          parts.push(ctx.stdin ?? "");
+          parts.push(decodeBytesToUtf8(ctx.stdin) ?? "");
         } else {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);
           const fileContent = await ctx.fs.readFile(filePath);

--- a/packages/just-bash/src/commands/column/column.ts
+++ b/packages/just-bash/src/commands/column/column.ts
@@ -6,11 +6,7 @@
  * Columnate input. Fill rows first by default, or create a table with -t.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -241,12 +237,11 @@ export const column: Command = {
       output += "\n";
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // column emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/column/column.ts
+++ b/packages/just-bash/src/commands/column/column.ts
@@ -6,7 +6,11 @@
  * Columnate input. Fill rows first by default, or create a table with -t.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -237,10 +241,12 @@ export const column: Command = {
       output += "\n";
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/column/column.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/column/column.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("column reads UTF-8 from stdin", () => {
+  it("preserves multibyte content piped through column", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 café 漢字\n" } });
+    const result = await env.exec("cat /in.txt | column -t");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("한글");
+    expect(result.stdout).toContain("café");
+    expect(result.stdout).toContain("漢字");
+  });
+});

--- a/packages/just-bash/src/commands/comm/comm.ts
+++ b/packages/just-bash/src/commands/comm/comm.ts
@@ -7,6 +7,7 @@
  * - Column 3: lines in both files
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -73,10 +74,13 @@ export const commCommand: Command = {
       };
     }
 
-    // Read file contents
+    // Read file contents. comm compares lines as strings, and stdin and the
+    // file path go through different decoding paths (latin1 byte buffer vs
+    // utf8 string). Normalize both sides to UTF-8 text so identical input
+    // compares equal regardless of which leg it came from.
     const readFile = async (file: string): Promise<string | null> => {
       if (file === "-") {
-        return ctx.stdin;
+        return decodeBytesToUtf8(ctx.stdin);
       }
       try {
         const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/comm/comm.ts
+++ b/packages/just-bash/src/commands/comm/comm.ts
@@ -7,7 +7,11 @@
  * - Column 3: lines in both files
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -160,7 +164,13 @@ export const commCommand: Command = {
       }
     }
 
-    return { stdout: output, stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   },
 };
 

--- a/packages/just-bash/src/commands/comm/comm.ts
+++ b/packages/just-bash/src/commands/comm/comm.ts
@@ -7,11 +7,7 @@
  * - Column 3: lines in both files
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -164,12 +160,11 @@ export const commCommand: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // comm emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/comm/comm.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/comm/comm.utf8-stdin.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("comm reads UTF-8 from stdin", () => {
+  it("compares multibyte lines byte-for-byte", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "café\n한글\n",
+        "/b.txt": "café\n漢字\n",
+      },
+    });
+    const result = await env.exec("cat /a.txt | comm - /b.txt");
+    expect(result.exitCode).toBe(0);
+    // Lines unique to first / second / shared columns.
+    expect(result.stdout).toContain("café");
+    expect(result.stdout).toContain("한글");
+    expect(result.stdout).toContain("漢字");
+  });
+});

--- a/packages/just-bash/src/commands/cut/cut.binary.test.ts
+++ b/packages/just-bash/src/commands/cut/cut.binary.test.ts
@@ -20,4 +20,35 @@ describe("cut with binary content", () => {
     expect(result.stdout).toBe("b\n");
     expect(result.exitCode).toBe(0);
   });
+
+  it("-c slices by codepoint over a UTF-8 binary file", async () => {
+    // 漢字 = 6 UTF-8 bytes, 2 codepoints. -c 1-2 must keep both
+    // codepoints (not the first 2 of 6 bytes, which would be a broken
+    // UTF-8 leader).
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([
+          0xe6,
+          0xbc,
+          0xa2, // 漢
+          0xe5,
+          0xad,
+          0x97, // 字
+          0x0a,
+        ]),
+      },
+    });
+    const r = await env.exec("cut -c 1-2 /data.bin");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("漢字\n");
+  });
+
+  it("-f stays byte-clean over an ASCII-only binary file", async () => {
+    // The ASCII baseline — bytes pass through unchanged, no encoding hop.
+    const env = new Bash({
+      files: { "/data.bin": new Uint8Array([0x61, 0x3a, 0x62, 0x3a, 0x63]) },
+    });
+    const r = await env.exec("cut -d: -f1,3 /data.bin");
+    expect(r.stdout).toBe("a:c\n");
+  });
 });

--- a/packages/just-bash/src/commands/cut/cut.ts
+++ b/packages/just-bash/src/commands/cut/cut.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { readAndConcat } from "../../utils/file-reader.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -169,16 +165,19 @@ export const cutCommand: Command = {
       }
     }
 
-    // Re-encode char-mode output as bytes so the pipeline stays byte-shaped
-    // (downstream byte consumers like base64 read each char as one byte).
-    const stdout = charSpec
-      ? latin1FromBytes(encodeUtf8ToBytes(output))
-      : output;
-
+    // Char mode produces decoded text; field mode forwards bytes verbatim.
+    if (charSpec) {
+      return {
+        stdout: output,
+        stderr: "",
+        exitCode: 0,
+      };
+    }
     return {
-      stdout,
+      stdout: output,
       stderr: "",
       exitCode: 0,
+      stdoutKind: "bytes",
       stdoutEncoding: "binary",
     };
   },

--- a/packages/just-bash/src/commands/cut/cut.ts
+++ b/packages/just-bash/src/commands/cut/cut.ts
@@ -1,3 +1,8 @@
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { readAndConcat } from "../../utils/file-reader.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -117,10 +122,14 @@ export const cutCommand: Command = {
       };
     }
 
-    // Read from files or stdin
+    // Read from files or stdin. Field mode (-f) is byte-clean: ASCII
+    // delimiters never collide with multibyte UTF-8 leading bytes (≥0x80).
+    // Char mode (-c) needs codepoint awareness, so decode then re-encode.
     const readResult = await readAndConcat(ctx, files, { cmdName: "cut" });
     if (!readResult.ok) return readResult.error;
-    const content = readResult.content;
+    const content = charSpec
+      ? decodeBytesToUtf8(readResult.content)
+      : latin1FromBytes(readResult.content);
 
     // Split into lines
     const lines = content.split("\n");
@@ -133,8 +142,10 @@ export const cutCommand: Command = {
 
     for (const line of lines) {
       if (charSpec) {
-        // Character mode (-s has no effect in character mode)
-        const chars = line.split("");
+        // Character mode (-s has no effect in character mode). Slice by
+        // codepoints — `Array.from` splits on Unicode code points so emoji
+        // and CJK chars count as one position each.
+        const chars = Array.from(line);
         const selected: string[] = [];
         for (const range of ranges) {
           const start = range.start - 1;
@@ -158,8 +169,14 @@ export const cutCommand: Command = {
       }
     }
 
+    // Re-encode char-mode output as bytes so the pipeline stays byte-shaped
+    // (downstream byte consumers like base64 read each char as one byte).
+    const stdout = charSpec
+      ? latin1FromBytes(encodeUtf8ToBytes(output))
+      : output;
+
     return {
-      stdout: output,
+      stdout,
       stderr: "",
       exitCode: 0,
       stdoutEncoding: "binary",

--- a/packages/just-bash/src/commands/cut/cut.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/cut/cut.utf8-stdin.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("cut reads UTF-8 from stdin", () => {
+  it("-c slices by codepoint, not by byte", async () => {
+    const env = new Bash({ files: { "/in.txt": "漢字\n" } });
+    const result = await env.exec("cat /in.txt | cut -c 1-2");
+    expect(result.exitCode).toBe(0);
+    // -c 1-2 should keep both codepoints, not 2 of the 6 bytes.
+    expect(result.stdout).toBe("漢字\n");
+  });
+
+  it("-f stays byte-clean (delimiters are ASCII, multibyte fields survive)", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글:café:漢字\n" } });
+    const result = await env.exec("cat /in.txt | cut -d: -f2");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("café\n");
+  });
+});

--- a/packages/just-bash/src/commands/diff/diff.ts
+++ b/packages/just-bash/src/commands/diff/diff.ts
@@ -3,6 +3,7 @@
  */
 
 import * as Diff from "diff";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -55,10 +56,12 @@ export const diffCommand: Command = {
     let c1: string, c2: string;
     const [f1, f2] = files;
 
+    // diff compares lines as strings. Normalize stdin (byte buffer) to
+    // UTF-8 so it compares correctly against file content (utf8 by default).
     try {
       c1 =
         f1 === "-"
-          ? ctx.stdin
+          ? decodeBytesToUtf8(ctx.stdin)
           : await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, f1));
     } catch {
       return {
@@ -71,7 +74,7 @@ export const diffCommand: Command = {
     try {
       c2 =
         f2 === "-"
-          ? ctx.stdin
+          ? decodeBytesToUtf8(ctx.stdin)
           : await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, f2));
     } catch {
       return {

--- a/packages/just-bash/src/commands/diff/diff.ts
+++ b/packages/just-bash/src/commands/diff/diff.ts
@@ -3,7 +3,11 @@
  */
 
 import * as Diff from "diff";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -93,26 +97,40 @@ export const diffCommand: Command = {
 
     if (t1 === t2) {
       if (reportSame)
+        // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
         return {
-          stdout: `Files ${f1} and ${f2} are identical\n`,
+          stdout: latin1FromBytes(
+            encodeUtf8ToBytes(`Files ${f1} and ${f2} are identical\n`),
+          ),
           stderr: "",
           exitCode: 0,
+          stdoutEncoding: "binary",
         };
       return { stdout: "", stderr: "", exitCode: 0 };
     }
 
     if (brief) {
+      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
       return {
-        stdout: `Files ${f1} and ${f2} differ\n`,
+        stdout: latin1FromBytes(
+          encodeUtf8ToBytes(`Files ${f1} and ${f2} differ\n`),
+        ),
         stderr: "",
         exitCode: 1,
+        stdoutEncoding: "binary",
       };
     }
 
     const output = Diff.createTwoFilesPatch(f1, f2, c1, c2, "", "", {
       context: 3,
     });
-    return { stdout: output, stderr: "", exitCode: 1 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stderr: "",
+      exitCode: 1,
+      stdoutEncoding: "binary",
+    };
   },
 };
 

--- a/packages/just-bash/src/commands/diff/diff.ts
+++ b/packages/just-bash/src/commands/diff/diff.ts
@@ -3,11 +3,7 @@
  */
 
 import * as Diff from "diff";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -97,39 +93,32 @@ export const diffCommand: Command = {
 
     if (t1 === t2) {
       if (reportSame)
-        // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+        // diff emits text; the pipeline handles encoding.
         return {
-          stdout: latin1FromBytes(
-            encodeUtf8ToBytes(`Files ${f1} and ${f2} are identical\n`),
-          ),
+          stdout: `Files ${f1} and ${f2} are identical\n`,
           stderr: "",
           exitCode: 0,
-          stdoutEncoding: "binary",
         };
       return { stdout: "", stderr: "", exitCode: 0 };
     }
 
     if (brief) {
-      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+      // diff emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(
-          encodeUtf8ToBytes(`Files ${f1} and ${f2} differ\n`),
-        ),
+        stdout: `Files ${f1} and ${f2} differ\n`,
         stderr: "",
         exitCode: 1,
-        stdoutEncoding: "binary",
       };
     }
 
     const output = Diff.createTwoFilesPatch(f1, f2, c1, c2, "", "", {
       context: 3,
     });
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // diff emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
       exitCode: 1,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/diff/diff.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.utf8-stdin.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("diff reads UTF-8 from stdin", () => {
+  it("preserves multibyte lines in the diff output", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "한글\nshared\n",
+        "/b.txt": "different\nshared\n",
+      },
+    });
+    const result = await env.exec("cat /a.txt | diff - /b.txt");
+    // diff exits 1 when files differ.
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toContain("한글");
+    expect(result.stdout).toContain("different");
+  });
+});

--- a/packages/just-bash/src/commands/env/env.ts
+++ b/packages/just-bash/src/commands/env/env.ts
@@ -1,3 +1,4 @@
+import { latin1FromBytes } from "../../encoding.js";
 import { mapToRecord } from "../../helpers/env.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -110,7 +111,7 @@ export const envCommand: Command = {
       cwd: ctx.cwd,
       env: mapToRecord(newEnv),
       replaceEnv: true,
-      stdin: ctx.stdin,
+      stdin: latin1FromBytes(ctx.stdin),
       signal: ctx.signal,
       args: cmdArgs,
     });

--- a/packages/just-bash/src/commands/env/env.ts
+++ b/packages/just-bash/src/commands/env/env.ts
@@ -112,6 +112,8 @@ export const envCommand: Command = {
       env: mapToRecord(newEnv),
       replaceEnv: true,
       stdin: latin1FromBytes(ctx.stdin),
+      // ctx.stdin is already byte-shaped — forward verbatim.
+      stdinKind: "bytes",
       signal: ctx.signal,
       args: cmdArgs,
     });

--- a/packages/just-bash/src/commands/env/env.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/env/env.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("env forwards UTF-8 stdin", () => {
+  it("byte-clean passthrough to the wrapped command", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café\n" } });
+    const r = await env.exec("cat /in.txt | env cat");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("한글 / café\n");
+  });
+});

--- a/packages/just-bash/src/commands/expand/expand.ts
+++ b/packages/just-bash/src/commands/expand/expand.ts
@@ -7,7 +7,11 @@
  * If no FILE is specified, standard input is read.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -235,10 +239,12 @@ export const expand: Command = {
       }
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/expand/expand.ts
+++ b/packages/just-bash/src/commands/expand/expand.ts
@@ -7,11 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -239,12 +235,11 @@ export const expand: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // expand emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/expand/expand.ts
+++ b/packages/just-bash/src/commands/expand/expand.ts
@@ -7,6 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -215,7 +216,9 @@ export const expand: Command = {
     let output = "";
 
     if (files.length === 0) {
-      const input = ctx.stdin ?? "";
+      // expand counts column positions for tab-stop math; decode bytes so a
+      // multibyte char counts as one column rather than 2–4.
+      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
       output = processContent(input, options);
     } else {
       for (const file of files) {

--- a/packages/just-bash/src/commands/expand/expand.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/expand/expand.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("expand / unexpand read UTF-8 from stdin", () => {
+  it("expand counts column positions by codepoint", async () => {
+    // "café" is 4 codepoints; the tab should land on the next 8-column
+    // tab-stop, i.e. fill columns 5-8 (4 spaces).
+    const env = new Bash({ files: { "/in.txt": "café\tafter\n" } });
+    const result = await env.exec("cat /in.txt | expand");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("café    after\n");
+  });
+});

--- a/packages/just-bash/src/commands/expand/unexpand.ts
+++ b/packages/just-bash/src/commands/expand/unexpand.ts
@@ -7,11 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -281,12 +277,11 @@ export const unexpand: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // unexpand emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/expand/unexpand.ts
+++ b/packages/just-bash/src/commands/expand/unexpand.ts
@@ -7,7 +7,11 @@
  * If no FILE is specified, standard input is read.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -277,10 +281,12 @@ export const unexpand: Command = {
       }
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/expand/unexpand.ts
+++ b/packages/just-bash/src/commands/expand/unexpand.ts
@@ -7,6 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -257,7 +258,9 @@ export const unexpand: Command = {
     let output = "";
 
     if (files.length === 0) {
-      const input = ctx.stdin ?? "";
+      // unexpand counts column positions for tab-stop math; decode bytes so
+      // a multibyte char doesn't pretend to be several columns wide.
+      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
       output = processContent(input, options);
     } else {
       for (const file of files) {

--- a/packages/just-bash/src/commands/expand/unexpand.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/expand/unexpand.utf8-stdin.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("unexpand reads UTF-8 from stdin", () => {
+  it("counts column positions by codepoint when collapsing spaces to tabs", async () => {
+    // 8 leading spaces then text — should collapse to one tab.
+    const env = new Bash({ files: { "/in.txt": "        한글\n" } });
+    const r = await env.exec("cat /in.txt | unexpand");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("\t한글\n");
+  });
+});

--- a/packages/just-bash/src/commands/fold/fold.ts
+++ b/packages/just-bash/src/commands/fold/fold.ts
@@ -7,11 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -266,12 +262,11 @@ export const fold: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // fold emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/fold/fold.ts
+++ b/packages/just-bash/src/commands/fold/fold.ts
@@ -7,6 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -241,8 +242,9 @@ export const fold: Command = {
     let output = "";
 
     if (files.length === 0) {
-      // Read from stdin
-      const input = ctx.stdin ?? "";
+      // Read from stdin. fold counts width in codepoints (and tab-stops),
+      // so decode bytes — wrapping mid-multibyte would corrupt the data.
+      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
       output = processContent(input, options);
     } else {
       // Process each file

--- a/packages/just-bash/src/commands/fold/fold.ts
+++ b/packages/just-bash/src/commands/fold/fold.ts
@@ -7,7 +7,11 @@
  * If no FILE is specified, standard input is read.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -262,10 +266,12 @@ export const fold: Command = {
       }
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/fold/fold.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/fold/fold.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("fold reads UTF-8 from stdin", () => {
+  it("wraps lines by codepoint count, not byte count", async () => {
+    // 6 codepoints; -w 2 should split 3 chunks of 2 codepoints each. Without
+    // decoding, fold would split mid-multibyte and corrupt the bytes.
+    const env = new Bash({ files: { "/in.txt": "한글café\n" } });
+    const result = await env.exec("cat /in.txt | fold -w 2");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글\nca\nfé\n");
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { UserRegex } from "../../regex/index.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { matchGlob } from "../../utils/glob.js";
@@ -249,14 +245,11 @@ export const grepCommand: Command = {
       if (quietMode) {
         return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };
       }
-      // grep processed UTF-8 text; re-encode to bytes and mark stdout
-      // binary so byte consumers downstream see UTF-8 bytes and redirects
-      // don't double-encode.
+      // grep emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(result.output)),
+        stdout: result.output,
         stderr: "",
         exitCode: result.matched ? 0 : 1,
-        stdoutEncoding: "binary",
       };
     }
 
@@ -438,10 +431,9 @@ export const grepCommand: Command = {
     }
 
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(stdout)),
+      stdout,
       stderr,
       exitCode,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -1,4 +1,8 @@
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { UserRegex } from "../../regex/index.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { matchGlob } from "../../utils/glob.js";
@@ -245,10 +249,14 @@ export const grepCommand: Command = {
       if (quietMode) {
         return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };
       }
+      // grep processed UTF-8 text; re-encode to bytes and mark stdout
+      // binary so byte consumers downstream see UTF-8 bytes and redirects
+      // don't double-encode.
       return {
-        stdout: result.output,
+        stdout: latin1FromBytes(encodeUtf8ToBytes(result.output)),
         stderr: "",
         exitCode: result.matched ? 0 : 1,
+        stdoutEncoding: "binary",
       };
     }
 
@@ -430,9 +438,10 @@ export const grepCommand: Command = {
     }
 
     return {
-      stdout,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(stdout)),
       stderr,
       exitCode,
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { UserRegex } from "../../regex/index.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { matchGlob } from "../../utils/glob.js";
@@ -225,9 +226,11 @@ export const grepCommand: Command = {
       };
     }
 
-    // If no files and stdin is provided (including empty string), read from stdin
+    // If no files and stdin is provided (including empty string), read from
+    // stdin. grep runs regex over text — decode bytes to UTF-8 so multibyte
+    // codepoints match `.` / character classes correctly.
     if (files.length === 0 && ctx.stdin !== undefined) {
-      const result = searchContent(ctx.stdin, regex, {
+      const result = searchContent(decodeBytesToUtf8(ctx.stdin), regex, {
         invertMatch,
         showLineNumbers,
         countOnly,

--- a/packages/just-bash/src/commands/grep/grep.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("grep reads UTF-8 from stdin", () => {
+  it("matches multibyte patterns through a pipe", async () => {
+    const env = new Bash({ files: { "/in.txt": "lineA\n한글 hit\nlineC\n" } });
+    const result = await env.exec("cat /in.txt | grep '한글'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 hit\n");
+  });
+});

--- a/packages/just-bash/src/commands/gzip/gzip.security.test.ts
+++ b/packages/just-bash/src/commands/gzip/gzip.security.test.ts
@@ -46,6 +46,9 @@ describe("gzip security hardening", () => {
 
     const result = await env.exec("gunzip -c", {
       stdin: Buffer.from(compressed).toString("latin1"),
+      // Already a latin1 byte buffer — opt out of the default text-mode
+      // UTF-8 encoding so the gzip bytes reach the command verbatim.
+      stdinKind: "bytes",
     });
 
     expect(result.stdout).toBe("");

--- a/packages/just-bash/src/commands/gzip/gzip.ts
+++ b/packages/just-bash/src/commands/gzip/gzip.ts
@@ -5,6 +5,7 @@
  */
 
 import { constants, gunzipSync, gzipSync } from "node:zlib";
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -287,7 +288,9 @@ async function processFile(
 
   // Handle stdin
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+      c.charCodeAt(0),
+    );
     if (decompress) {
       if (!isGzip(inputData)) {
         if (!flags.quiet) {
@@ -608,7 +611,9 @@ async function listFile(
   let inputData: Uint8Array;
 
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+      c.charCodeAt(0),
+    );
   } else {
     const inputPath = ctx.fs.resolvePath(ctx.cwd, file);
     try {
@@ -659,7 +664,9 @@ async function testFile(
   let inputData: Uint8Array;
 
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+      c.charCodeAt(0),
+    );
   } else {
     const inputPath = ctx.fs.resolvePath(ctx.cwd, file);
     try {

--- a/packages/just-bash/src/commands/gzip/gzip.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/gzip/gzip.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("gzip reads UTF-8 from stdin", () => {
+  it("round-trips multibyte text through gzip / gunzip", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café / 漢字\n" } });
+    const r = await env.exec("cat /in.txt | gzip | gunzip");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("한글 / café / 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/head/head-tail-shared.ts
+++ b/packages/just-bash/src/commands/head/head-tail-shared.ts
@@ -2,6 +2,7 @@
  * Shared utilities for head and tail commands.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { unknownOption } from "../help.js";
 
@@ -116,10 +117,11 @@ export async function processHeadTailFiles(
 ): Promise<ExecResult> {
   const { quiet, verbose, files } = options;
 
-  // If no files, read from stdin
+  // If no files, read from stdin. head/tail are line-oriented and byte-clean
+  // — \n splits are byte-safe regardless of UTF-8 multibyte content.
   if (files.length === 0) {
     return {
-      stdout: contentProcessor(ctx.stdin),
+      stdout: contentProcessor(latin1FromBytes(ctx.stdin)),
       stderr: "",
       exitCode: 0,
     };

--- a/packages/just-bash/src/commands/head/head.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/head/head.utf8-stdin.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("head / tail / tac read UTF-8 from stdin", () => {
+  it("head preserves multibyte lines", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\nfoo\n漢字\n" } });
+    const result = await env.exec("cat /in.txt | head -1");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글\n");
+  });
+
+  it("tail preserves multibyte lines", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\nfoo\n漢字\n" } });
+    const result = await env.exec("cat /in.txt | tail -1");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("漢字\n");
+  });
+
+  it("tac preserves multibyte lines (reversed)", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\n漢字\n" } });
+    const result = await env.exec("cat /in.txt | tac");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("漢字\n한글\n");
+  });
+});

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
@@ -5,11 +5,7 @@
  */
 
 import TurndownService from "turndown";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -133,12 +129,11 @@ export const htmlToMarkdownCommand: Command = {
       turndownService.remove(["script", "style", "footer"]);
 
       const markdown = turndownService.turndown(input).trim();
-      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+      // html-to-markdown emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(`${markdown}\n`)),
+        stdout: `${markdown}\n`,
         stderr: "",
         exitCode: 0,
-        stdoutEncoding: "binary",
       };
     } catch (error) {
       return {

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
@@ -5,6 +5,7 @@
  */
 
 import TurndownService from "turndown";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -92,10 +93,12 @@ export const htmlToMarkdownCommand: Command = {
       }
     }
 
-    // Get input
+    // Get input. HTML is text — decode bytes to UTF-8 so character entities
+    // and tag boundaries are recognized correctly. File reads use utf8 by
+    // default already.
     let input: string;
     if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = ctx.stdin;
+      input = decodeBytesToUtf8(ctx.stdin);
     } else {
       try {
         const filePath = ctx.fs.resolvePath(ctx.cwd, files[0]);

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
@@ -5,7 +5,11 @@
  */
 
 import TurndownService from "turndown";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -129,10 +133,12 @@ export const htmlToMarkdownCommand: Command = {
       turndownService.remove(["script", "style", "footer"]);
 
       const markdown = turndownService.turndown(input).trim();
+      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
       return {
-        stdout: `${markdown}\n`,
+        stdout: latin1FromBytes(encodeUtf8ToBytes(`${markdown}\n`)),
         stderr: "",
         exitCode: 0,
+        stdoutEncoding: "binary",
       };
     } catch (error) {
       return {

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("html-to-markdown reads UTF-8 from stdin", () => {
+  it("preserves multibyte text in piped HTML", async () => {
+    const env = new Bash({
+      files: { "/in.html": "<p>한글 / café / 漢字</p>\n" },
+    });
+    const result = await env.exec("cat /in.html | html-to-markdown");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("한글 / café / 漢字");
+  });
+});

--- a/packages/just-bash/src/commands/join/join.ts
+++ b/packages/just-bash/src/commands/join/join.ts
@@ -7,7 +7,11 @@
  * standard output. The default join field is the first, delimited by blanks.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -366,10 +370,14 @@ export const join: Command = {
       }
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output.length > 0 ? `${output.join("\n")}\n` : "",
+      stdout: latin1FromBytes(
+        encodeUtf8ToBytes(output.length > 0 ? `${output.join("\n")}\n` : ""),
+      ),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/join/join.ts
+++ b/packages/just-bash/src/commands/join/join.ts
@@ -7,6 +7,7 @@
  * standard output. The default join field is the first, delimited by blanks.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -283,11 +284,13 @@ export const join: Command = {
       };
     }
 
-    // Read both files
+    // Read both files. join compares the key field as a string; normalize
+    // stdin (byte buffer) to UTF-8 so it compares against file content (utf8
+    // by default) correctly when the data carries multibyte chars.
     const contents: string[] = [];
     for (const file of files) {
       if (file === "-") {
-        contents.push(ctx.stdin ?? "");
+        contents.push(decodeBytesToUtf8(ctx.stdin) ?? "");
       } else {
         const filePath = ctx.fs.resolvePath(ctx.cwd, file);
         const content = await ctx.fs.readFile(filePath);

--- a/packages/just-bash/src/commands/join/join.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/join/join.utf8-stdin.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("join reads UTF-8 from stdin", () => {
+  it("joins on ASCII keys, preserves multibyte field values", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "1 한글\n2 café\n",
+        "/b.txt": "1 韓国\n2 法国\n",
+      },
+    });
+    const result = await env.exec("cat /a.txt | join - /b.txt");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("한글");
+    expect(result.stdout).toContain("韓国");
+    expect(result.stdout).toContain("café");
+    expect(result.stdout).toContain("法国");
+  });
+});

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -4,7 +4,11 @@
  * Full jq implementation with proper parser and evaluator.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -416,10 +420,15 @@ export const jqCommand: Command = {
           ? 1
           : 0;
 
+      // jq emits decoded JSON text; re-encode to bytes and mark stdout
+      // binary so the bytes flow through byte consumers (wc -c, base64)
+      // and redirects without being double-encoded.
+      const stdoutText = output ? (joinOutput ? output : `${output}\n`) : "";
       return {
-        stdout: output ? (joinOutput ? output : `${output}\n`) : "",
+        stdout: latin1FromBytes(encodeUtf8ToBytes(stdoutText)),
         stderr: "",
         exitCode,
+        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -4,6 +4,7 @@
  * Full jq implementation with proper parser and evaluator.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -320,12 +321,14 @@ export const jqCommand: Command = {
       }
     }
 
-    // Build list of inputs: stdin or files
+    // Build list of inputs: stdin or files. jq parses JSON, so the input
+    // bytes are decoded to UTF-8 before parsing — without this, multi-byte
+    // sequences inside string values get re-encoded twice and emit mojibake.
     let inputs: { source: string; content: string }[] = [];
     if (nullInput) {
       // No input
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      inputs.push({ source: "stdin", content: ctx.stdin });
+      inputs.push({ source: "stdin", content: decodeBytesToUtf8(ctx.stdin) });
     } else {
       // Read all files in parallel using shared utility
       const result = await withDefenseContext("file read", () =>
@@ -343,7 +346,7 @@ export const jqCommand: Command = {
       }
       inputs = result.files.map((f) => ({
         source: f.filename || "stdin",
-        content: f.content,
+        content: decodeBytesToUtf8(f.content),
       }));
     }
 

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -4,11 +4,7 @@
  * Full jq implementation with proper parser and evaluator.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -420,15 +416,12 @@ export const jqCommand: Command = {
           ? 1
           : 0;
 
-      // jq emits decoded JSON text; re-encode to bytes and mark stdout
-      // binary so the bytes flow through byte consumers (wc -c, base64)
-      // and redirects without being double-encoded.
+      // jq emits text; the pipeline handles encoding.
       const stdoutText = output ? (joinOutput ? output : `${output}\n`) : "";
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(stdoutText)),
+        stdout: stdoutText,
         stderr: "",
         exitCode,
-        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/jq/jq.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.utf8-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+// `cat /file | jq` is the canonical byte-pipeline path: cat reads file bytes
+// and pipes them as a ByteString. Without decoding, JSON string values
+// containing multibyte UTF-8 mojibake.
+describe("jq reads UTF-8 from stdin", () => {
+  it("preserves multibyte string values in piped JSON", async () => {
+    const env = new Bash({
+      files: { "/in.json": JSON.stringify({ msg: "한글 / café / 漢字" }) },
+    });
+    const result = await env.exec("cat /in.json | jq -r '.msg'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 / café / 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/js-exec/js-exec.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.ts
@@ -11,11 +11,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -550,11 +546,9 @@ async function executeJSInner(
     };
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // js-exec emits text; the pipeline handles encoding.
   return {
     ...bridgeOutput,
-    stdout: latin1FromBytes(encodeUtf8ToBytes(bridgeOutput.stdout)),
-    stdoutEncoding: "binary",
   };
 }
 

--- a/packages/just-bash/src/commands/js-exec/js-exec.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.ts
@@ -11,6 +11,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -594,8 +595,10 @@ export const jsExecCommand: Command = {
           exitCode: 2,
         };
       }
-    } else if (ctx.stdin.trim()) {
-      jsCode = ctx.stdin;
+    } else if (decodeBytesToUtf8(ctx.stdin).trim()) {
+      // Decode bytes — JS source can contain unicode identifiers and string
+      // literals; running latin1 bytes as code corrupts them.
+      jsCode = decodeBytesToUtf8(ctx.stdin);
       scriptPath = "<stdin>";
     } else {
       return {

--- a/packages/just-bash/src/commands/js-exec/js-exec.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.ts
@@ -11,7 +11,11 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -546,7 +550,12 @@ async function executeJSInner(
     };
   }
 
-  return bridgeOutput;
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    ...bridgeOutput,
+    stdout: latin1FromBytes(encodeUtf8ToBytes(bridgeOutput.stdout)),
+    stdoutEncoding: "binary",
+  };
 }
 
 export const jsExecCommand: Command = {

--- a/packages/just-bash/src/commands/js-exec/js-exec.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.utf8-stdin.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("js-exec reads UTF-8 from stdin", () => {
+  it("executes piped JS code with multibyte string literals", async () => {
+    const env = new Bash({
+      javascript: true,
+      files: { "/in.js": "console.log('한글 / café / 漢字')\n" },
+    });
+    const result = await env.exec("cat /in.js | js-exec");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("한글 / café / 漢字");
+  });
+});

--- a/packages/just-bash/src/commands/md5sum/checksum.ts
+++ b/packages/just-bash/src/commands/md5sum/checksum.ts
@@ -3,6 +3,7 @@
  * Uses WebCrypto API for SHA algorithms, pure JS for MD5
  */
 
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -165,11 +166,13 @@ export function createChecksumCommand(
 
       if (files.length === 0) files.push("-");
 
-      // Helper to read file as binary
+      // Helper to read file as binary. md5sum hashes raw bytes — pass them
+      // through without decoding.
       const readBinary = async (file: string): Promise<Uint8Array | null> => {
         if (file === "-") {
-          // Convert binary string directly to bytes without UTF-8 re-encoding
-          return Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+          return Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+            c.charCodeAt(0),
+          );
         }
         try {
           return await ctx.fs.readFileBuffer(ctx.fs.resolvePath(ctx.cwd, file));
@@ -183,10 +186,11 @@ export function createChecksumCommand(
         let output = "";
 
         for (const file of files) {
-          // For check mode, we read the checksum file as text
+          // For check mode, the checksum file is text (hash + filename).
+          // Decode UTF-8 so non-ASCII filenames in the list survive.
           const content =
             file === "-"
-              ? ctx.stdin
+              ? decodeBytesToUtf8(ctx.stdin)
               : await ctx.fs
                   .readFile(ctx.fs.resolvePath(ctx.cwd, file))
                   .catch(() => null);

--- a/packages/just-bash/src/commands/md5sum/md5sum.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/md5sum/md5sum.utf8-stdin.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("md5sum reads UTF-8 from stdin", () => {
+  it("hashes the raw UTF-8 bytes (not double-encoded)", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글" } });
+    const r = await env.exec("cat /in.txt | md5sum");
+    expect(r.exitCode).toBe(0);
+    // md5 of the UTF-8 bytes of "한글" (6 bytes: ed 95 9c ea b8 80)
+    expect(r.stdout).toBe("52b8c54ab4ea672ee6cdfdfef0a31db4  -\n");
+  });
+});

--- a/packages/just-bash/src/commands/nl/nl.ts
+++ b/packages/just-bash/src/commands/nl/nl.ts
@@ -7,11 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -306,12 +302,11 @@ export const nl: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // nl emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/nl/nl.ts
+++ b/packages/just-bash/src/commands/nl/nl.ts
@@ -7,7 +7,11 @@
  * If no FILE is specified, standard input is read.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -302,10 +306,12 @@ export const nl: Command = {
       }
     }
 
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/nl/nl.ts
+++ b/packages/just-bash/src/commands/nl/nl.ts
@@ -7,6 +7,7 @@
  * If no FILE is specified, standard input is read.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -278,8 +279,9 @@ export const nl: Command = {
     let lineNumber = options.startNumber;
 
     if (files.length === 0) {
-      // Read from stdin
-      const input = ctx.stdin ?? "";
+      // Read from stdin. nl reads files as utf8 by default; normalize stdin
+      // to text so the line-numbered output is consistent with file inputs.
+      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
       const result = processContent(input, options, lineNumber);
       output = result.output;
     } else {

--- a/packages/just-bash/src/commands/nl/nl.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/nl/nl.utf8-stdin.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("nl reads UTF-8 from stdin", () => {
+  it("number-prefixes multibyte lines without altering them", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\ncafé\n" } });
+    const result = await env.exec("cat /in.txt | nl");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("한글");
+    expect(result.stdout).toContain("café");
+  });
+});

--- a/packages/just-bash/src/commands/od/od.ts
+++ b/packages/just-bash/src/commands/od/od.ts
@@ -7,6 +7,7 @@
  * of FILE to standard output.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 
 type OutputFormat = "octal" | "hex" | "char";
@@ -46,8 +47,9 @@ async function odExecute(
     outputFormats.push("octal");
   }
 
-  // Get input - from file or stdin
-  let input = ctx.stdin;
+  // Get input - from file or stdin. od is byte-oriented: dump the raw byte
+  // buffer character-by-character, where each char is one byte.
+  let input: string = latin1FromBytes(ctx.stdin);
 
   // Check for file argument
   if (fileArgs.length > 0 && fileArgs[0] !== "-") {
@@ -55,7 +57,7 @@ async function odExecute(
       ? fileArgs[0]
       : `${ctx.cwd}/${fileArgs[0]}`;
     try {
-      input = await ctx.fs.readFile(filePath);
+      input = latin1FromBytes(await ctx.fs.readFileBytes(filePath));
     } catch {
       return {
         stdout: "",

--- a/packages/just-bash/src/commands/od/od.ts
+++ b/packages/just-bash/src/commands/od/od.ts
@@ -7,7 +7,7 @@
  * of FILE to standard output.
  */
 
-import { latin1FromBytes } from "../../encoding.js";
+import { latin1FromBytes, readBytesFrom } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 
 type OutputFormat = "octal" | "hex" | "char";
@@ -57,7 +57,7 @@ async function odExecute(
       ? fileArgs[0]
       : `${ctx.cwd}/${fileArgs[0]}`;
     try {
-      input = latin1FromBytes(await ctx.fs.readFileBytes(filePath));
+      input = latin1FromBytes(await readBytesFrom(ctx.fs, filePath));
     } catch {
       return {
         stdout: "",

--- a/packages/just-bash/src/commands/od/od.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/od/od.utf8-stdin.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("od reads UTF-8 from stdin", () => {
+  it("dumps the raw UTF-8 bytes byte-by-byte (3-digit octal)", async () => {
+    const env = new Bash({ files: { "/in.txt": "한" } });
+    const r = await env.exec("cat /in.txt | od");
+    expect(r.exitCode).toBe(0);
+    // 한 = bytes 0xED 0x95 0x9C → octal 355 225 234. The fact that we see
+    // these specific bytes (not e.g. 303 255 — UTF-8 of U+00ED) proves the
+    // raw bytes survived the pipe instead of being decoded-then-re-encoded.
+    const tokens = r.stdout.trim().split(/\s+/);
+    expect(tokens).toContain("355");
+    expect(tokens).toContain("225");
+    expect(tokens).toContain("234");
+  });
+});

--- a/packages/just-bash/src/commands/paste/paste.ts
+++ b/packages/just-bash/src/commands/paste/paste.ts
@@ -1,4 +1,8 @@
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -128,7 +132,13 @@ export const pasteCommand: Command = {
       }
     }
 
-    return { stdout: output, stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   },
 };
 

--- a/packages/just-bash/src/commands/paste/paste.ts
+++ b/packages/just-bash/src/commands/paste/paste.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -58,8 +59,12 @@ export const pasteCommand: Command = {
       };
     }
 
-    // Parse stdin into lines (will be distributed across multiple `-` args)
-    const stdinLines = ctx.stdin ? ctx.stdin.split("\n") : [""];
+    // Parse stdin into lines (will be distributed across multiple `-` args).
+    // paste reads files as UTF-8 text; normalize stdin to the same shape so
+    // the joined output is consistent and the boundary doesn't see a mix of
+    // latin1 byte buffer and Unicode codepoints.
+    const stdinText = decodeBytesToUtf8(ctx.stdin);
+    const stdinLines = stdinText ? stdinText.split("\n") : [""];
     if (stdinLines.length > 0 && stdinLines[stdinLines.length - 1] === "") {
       stdinLines.pop();
     }

--- a/packages/just-bash/src/commands/paste/paste.ts
+++ b/packages/just-bash/src/commands/paste/paste.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -132,12 +128,11 @@ export const pasteCommand: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // paste emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/paste/paste.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/paste/paste.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("paste reads UTF-8 from stdin", () => {
+  it("zips multibyte lines column-wise", async () => {
+    const env = new Bash({
+      files: { "/a.txt": "한글\n漢字\n", "/b.txt": "café\nbé\n" },
+    });
+    const result = await env.exec("cat /a.txt | paste - /b.txt");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글\tcafé\n漢字\tbé\n");
+  });
+});

--- a/packages/just-bash/src/commands/python3/python3.queue-timeout-exploit.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.queue-timeout-exploit.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { resolveLimits } from "../../limits.js";
 import type { CommandContext } from "../../types.js";
@@ -102,7 +103,7 @@ function createContextWithFs(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: "",
+    stdin: EMPTY_BYTES,
     limits: resolveLimits({ maxPythonTimeoutMs: timeoutMs }),
   };
 }

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -13,7 +13,11 @@
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { IFileSystem } from "../../fs/interface.js";
 import {
   sanitizeErrorMessage,
@@ -506,7 +510,12 @@ async function executePython(
     };
   }
 
-  return bridgeOutput;
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    ...bridgeOutput,
+    stdout: latin1FromBytes(encodeUtf8ToBytes(bridgeOutput.stdout)),
+    stdoutEncoding: "binary",
+  };
 }
 
 export const python3Command: Command = {

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -13,6 +13,7 @@
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { IFileSystem } from "../../fs/interface.js";
 import {
   sanitizeErrorMessage,
@@ -549,7 +550,8 @@ export const python3Command: Command = {
       // CPython's `python3 -` reads the program from standard input.
       // Empty stdin runs an empty program (exit 0) — matching CPython's
       // behavior in non-interactive contexts where no program is provided.
-      pythonCode = ctx.stdin;
+      // Decode bytes — Python source can hold unicode string literals.
+      pythonCode = decodeBytesToUtf8(ctx.stdin);
       scriptPath = "-";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
@@ -573,8 +575,8 @@ export const python3Command: Command = {
           exitCode: 2,
         };
       }
-    } else if (ctx.stdin.trim()) {
-      pythonCode = ctx.stdin;
+    } else if (decodeBytesToUtf8(ctx.stdin).trim()) {
+      pythonCode = decodeBytesToUtf8(ctx.stdin);
       scriptPath = "<stdin>";
     } else {
       return {

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -13,11 +13,7 @@
 import { randomBytes } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { IFileSystem } from "../../fs/interface.js";
 import {
   sanitizeErrorMessage,
@@ -510,11 +506,9 @@ async function executePython(
     };
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // python3 emits text; the pipeline handles encoding.
   return {
     ...bridgeOutput,
-    stdout: latin1FromBytes(encodeUtf8ToBytes(bridgeOutput.stdout)),
-    stdoutEncoding: "binary",
   };
 }
 

--- a/packages/just-bash/src/commands/python3/python3.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.utf8-stdin.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("python3 reads UTF-8 from stdin", () => {
+  it("executes piped Python with multibyte string literals", async () => {
+    const env = new Bash({
+      python: true,
+      files: { "/in.py": "print('한글 / café / 漢字')\n" },
+    });
+    const result = await env.exec("cat /in.py | python3");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("한글 / café / 漢字");
+  });
+});

--- a/packages/just-bash/src/commands/python3/python3.worker-protocol-abuse.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.worker-protocol-abuse.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
 import type { CommandContext } from "../../types.js";
@@ -98,7 +99,7 @@ function createContext(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: "",
+    stdin: EMPTY_BYTES,
     ...overrides,
   };
 }

--- a/packages/just-bash/src/commands/rev/rev.ts
+++ b/packages/just-bash/src/commands/rev/rev.ts
@@ -8,11 +8,7 @@
  * input is read.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -99,14 +95,11 @@ export const rev: Command = {
       }
     }
 
-    // rev reversed by codepoint over decoded text; re-encode to bytes and
-    // mark stdout binary so byte consumers (wc -c, base64, md5sum) and
-    // file redirects see UTF-8 bytes verbatim.
+    // rev emits text; the pipeline handles encoding.
     return {
       exitCode: 0,
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/rev/rev.ts
+++ b/packages/just-bash/src/commands/rev/rev.ts
@@ -8,7 +8,11 @@
  * input is read.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -95,10 +99,14 @@ export const rev: Command = {
       }
     }
 
+    // rev reversed by codepoint over decoded text; re-encode to bytes and
+    // mark stdout binary so byte consumers (wc -c, base64, md5sum) and
+    // file redirects see UTF-8 bytes verbatim.
     return {
       exitCode: 0,
-      stdout: output,
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
       stderr: "",
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/rev/rev.ts
+++ b/packages/just-bash/src/commands/rev/rev.ts
@@ -8,6 +8,7 @@
  * input is read.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -67,15 +68,17 @@ export const rev: Command = {
     };
 
     if (files.length === 0) {
-      // Read from stdin
-      const input = ctx.stdin ?? "";
+      // Read from stdin. rev reverses by codepoint, so decode bytes to UTF-8
+      // first — reversing the latin1 bytes of a multibyte sequence would
+      // shred valid UTF-8 into garbage.
+      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
       output = processContent(input);
     } else {
       // Process each file
       for (const file of files) {
         if (file === "-") {
           // Dash means read from stdin
-          const input = ctx.stdin ?? "";
+          const input = decodeBytesToUtf8(ctx.stdin) ?? "";
           output += processContent(input);
         } else {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/rev/rev.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/rev/rev.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("rev reads UTF-8 from stdin", () => {
+  it("reverses by codepoint, not by latin1 byte", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\n" } });
+    const result = await env.exec("cat /in.txt | rev");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("글한\n");
+  });
+});

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -3,7 +3,12 @@
  */
 
 import { gunzipSync } from "node:zlib";
-import { decodeBytesToUtf8, unsafeBytesFromLatin1 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  unsafeBytesFromLatin1,
+} from "../../encoding.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
 import { createUserRegex, type UserRegex } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
@@ -1010,9 +1015,11 @@ async function searchFiles(
     exitCode = anyMatch ? 0 : 1;
   }
 
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
   return {
-    stdout: finalStdout,
+    stdout: latin1FromBytes(encodeUtf8ToBytes(finalStdout)),
     stderr: "",
     exitCode,
+    stdoutEncoding: "binary",
   };
 }

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -3,12 +3,7 @@
  */
 
 import { gunzipSync } from "node:zlib";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-  unsafeBytesFromLatin1,
-} from "../../encoding.js";
+import { decodeBytesToUtf8, unsafeBytesFromLatin1 } from "../../encoding.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
 import { createUserRegex, type UserRegex } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
@@ -1015,11 +1010,10 @@ async function searchFiles(
     exitCode = anyMatch ? 0 : 1;
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // rg emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(finalStdout)),
+    stdout: finalStdout,
     stderr: "",
     exitCode,
-    stdoutEncoding: "binary",
   };
 }

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -3,6 +3,7 @@
  */
 
 import { gunzipSync } from "node:zlib";
+import { decodeBytesToUtf8, unsafeBytesFromLatin1 } from "../../encoding.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
 import { createUserRegex, type UserRegex } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
@@ -78,13 +79,13 @@ export async function executeSearch(
   // Combine -e patterns with patterns from files
   const patterns = [...options.patterns];
 
-  // Read patterns from files (-f/--file)
+  // Read patterns from files (-f/--file). Patterns are regex source — decode
+  // bytes to UTF-8 so unicode-class patterns work.
   for (const patternFile of options.patternFiles) {
     try {
       let content: string;
       if (patternFile === "-") {
-        // Read from stdin
-        content = ctx.stdin;
+        content = decodeBytesToUtf8(ctx.stdin);
       } else {
         const filePath = ctx.fs.resolvePath(ctx.cwd, patternFile);
         content = await ctx.fs.readFile(filePath);
@@ -724,8 +725,13 @@ async function readFileContent(
           args: [filePath],
         });
         if (result.exitCode === 0 && result.stdout) {
-          const sample = result.stdout.slice(0, 8192);
-          return { content: result.stdout, isBinary: sample.includes("\0") };
+          // Preprocessor output arrives as a latin1 byte buffer in the
+          // pipeline; decode for regex matching. Empty output falls through.
+          const content = decodeBytesToUtf8(
+            unsafeBytesFromLatin1(result.stdout),
+          );
+          const sample = content.slice(0, 8192);
+          return { content, isBinary: sample.includes("\0") };
         }
         // Preprocessing failed, fall through to normal file read
       }

--- a/packages/just-bash/src/commands/rg/rg.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/rg/rg.utf8-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("rg reads UTF-8 from stdin", () => {
+  it("matches multibyte patterns from piped input", async () => {
+    const env = new Bash({
+      files: { "/in.txt": "miss\n한글 found\nmiss\n" },
+    });
+    const result = await env.exec("cat /in.txt | rg '한글'");
+    expect(result.exitCode).toBe(0);
+    // rg prefixes matches from stdin with a `<filename>:<line>:` source
+    // identifier; the bytes after the last `:` are the matched line.
+    const matched = result.stdout.split(":").slice(2).join(":");
+    expect(matched.trim()).toBe("한글 found");
+  });
+});

--- a/packages/just-bash/src/commands/sed/sed.ts
+++ b/packages/just-bash/src/commands/sed/sed.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import type { ExecutionLimits } from "../../limits.js";
@@ -558,14 +554,11 @@ export const sedCommand: Command = {
             requireDefenseContext: ctx.requireDefenseContext,
           }),
         );
-        // sed processed UTF-8 text; re-encode to a latin1 byte view and
-        // mark stdout binary so byte consumers downstream (wc -c, base64,
-        // md5sum) see UTF-8 bytes and redirects don't double-encode.
+        // sed emits text; the pipeline handles encoding.
         return {
-          stdout: latin1FromBytes(encodeUtf8ToBytes(result.output)),
+          stdout: result.output,
           stderr: result.errorMessage ? `${result.errorMessage}\n` : "",
           exitCode: result.exitCode ?? 0,
-          stdoutEncoding: "binary",
         };
       } catch (e) {
         if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/sed/sed.ts
+++ b/packages/just-bash/src/commands/sed/sed.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import type { ExecutionLimits } from "../../limits.js";
@@ -538,9 +539,11 @@ export const sedCommand: Command = {
 
     let content = "";
 
-    // Read from files or stdin
+    // Read from files or stdin. sed runs regex over text — decode bytes to
+    // UTF-8 so multibyte sequences match as single chars rather than several
+    // latin1 bytes.
     if (files.length === 0) {
-      content = ctx.stdin;
+      content = decodeBytesToUtf8(ctx.stdin);
       try {
         const result = await withDefenseContext("stdin processing", () =>
           processContent(content, commands, effectiveSilent, {
@@ -582,7 +585,7 @@ export const sedCommand: Command = {
         if (stdinConsumed) {
           fileContent = "";
         } else {
-          fileContent = ctx.stdin;
+          fileContent = decodeBytesToUtf8(ctx.stdin);
           stdinConsumed = true;
         }
       } else {

--- a/packages/just-bash/src/commands/sed/sed.ts
+++ b/packages/just-bash/src/commands/sed/sed.ts
@@ -1,4 +1,8 @@
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import type { ExecutionLimits } from "../../limits.js";
@@ -554,10 +558,14 @@ export const sedCommand: Command = {
             requireDefenseContext: ctx.requireDefenseContext,
           }),
         );
+        // sed processed UTF-8 text; re-encode to a latin1 byte view and
+        // mark stdout binary so byte consumers downstream (wc -c, base64,
+        // md5sum) see UTF-8 bytes and redirects don't double-encode.
         return {
-          stdout: result.output,
+          stdout: latin1FromBytes(encodeUtf8ToBytes(result.output)),
           stderr: result.errorMessage ? `${result.errorMessage}\n` : "",
           exitCode: result.exitCode ?? 0,
+          stdoutEncoding: "binary",
         };
       } catch (e) {
         if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/sed/sed.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/sed/sed.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sed reads UTF-8 from stdin", () => {
+  it("matches and replaces multibyte text from a piped file", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 old café\n" } });
+    const result = await env.exec("cat /in.txt | sed 's/old/NEW/'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 NEW café\n");
+  });
+});

--- a/packages/just-bash/src/commands/sort/sort.binary.test.ts
+++ b/packages/just-bash/src/commands/sort/sort.binary.test.ts
@@ -20,4 +20,25 @@ describe("sort with binary content", () => {
     expect(result.stdout).toBe("a\nb\nc\n");
     expect(result.exitCode).toBe(0);
   });
+
+  it("preserves UTF-8 leading bytes under -f case-fold", async () => {
+    // 0xC3 0x89 is "É" in UTF-8. A naive `.toLowerCase()` on the latin1
+    // view would turn 0xC3 (Ã) into 0xE3 (ã) — silently mutating the
+    // leading byte of every accented Latin character. Verify both lines
+    // round-trip unchanged when sorting a binary file with -f.
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([
+          0x41,
+          0x0a, // A\n
+          0xc3,
+          0x89,
+          0x0a, // É\n (UTF-8)
+        ]),
+      },
+    });
+    const r = await env.exec("sort -f /data.bin");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("A\nÉ\n");
+  });
 });

--- a/packages/just-bash/src/commands/sort/sort.binary.test.ts
+++ b/packages/just-bash/src/commands/sort/sort.binary.test.ts
@@ -41,4 +41,58 @@ describe("sort with binary content", () => {
     expect(r.exitCode).toBe(0);
     expect(r.stdout).toBe("A\nÉ\n");
   });
+
+  it("preserves UTF-8 leading bytes under -k1f per-key case-fold", async () => {
+    // Per-key `f` modifier (no global -f) must also trigger UTF-8 decode.
+    // Without it, `.toLowerCase()` on the latin1 byte view mutates the
+    // 0xC3 leading byte of every accented character to 0xE3 — silent data
+    // corruption distinct from any user-visible error.
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([
+          0x42,
+          0x0a, // B\n
+          0xc3,
+          0x89,
+          0x0a, // É\n (UTF-8)
+          0x41,
+          0x0a, // A\n
+        ]),
+      },
+    });
+    const r = await env.exec("sort -k1f /data.bin");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("A\nB\nÉ\n");
+  });
+
+  it("preserves UTF-8 bytes under -k1d per-key dictionary order", async () => {
+    // -d / per-key d strips non-alphanumerics with `[^a-zA-Z0-9\s]` which
+    // on a latin1 byte view treats every UTF-8 continuation byte
+    // (0x80–0xBF) as non-alphanumeric and deletes it — half-mangling each
+    // multibyte character.
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([
+          0x42,
+          0x0a, // B\n
+          0xc3,
+          0xa9,
+          0x0a, // é\n
+          0x41,
+          0x0a, // A\n
+        ]),
+      },
+    });
+    const r = await env.exec("sort -k1d /data.bin");
+    expect(r.exitCode).toBe(0);
+    // Sort order under -d is locale-funky in just-bash (only ASCII counts
+    // as "alphanumeric" for the strip regex); what we're regressing
+    // against is the byte corruption — `é` must round-trip whole, not as
+    // a stranded 0xA9 continuation byte missing its 0xC3 leader.
+    expect(r.stdout.split("\n").filter(Boolean).sort()).toEqual([
+      "A",
+      "B",
+      "é",
+    ]);
+  });
 });

--- a/packages/just-bash/src/commands/sort/sort.ts
+++ b/packages/just-bash/src/commands/sort/sort.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { readAndConcat } from "../../utils/file-reader.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -149,10 +150,16 @@ export const sortCommand: Command = {
       }
     }
 
-    // Read from files or stdin
+    // Read from files or stdin. Default sort is byte-lexicographic and
+    // byte-clean. With -f / --ignore-case the comparator runs `.toLowerCase`
+    // on each line; that's Unicode-aware in JS and would corrupt latin1
+    // byte buffers (a UTF-8 leading byte 0xC3 lowercases to 0xE3, mutating
+    // the data), so decode to UTF-8 first whenever we'll case-fold.
     const readResult = await readAndConcat(ctx, files, { cmdName: "sort" });
     if (!readResult.ok) return readResult.error;
-    const content = readResult.content;
+    const content = options.ignoreCase
+      ? decodeBytesToUtf8(readResult.content)
+      : latin1FromBytes(readResult.content);
 
     // Split into lines (preserve empty lines at the end for sorting)
     let lines = content.split("\n");

--- a/packages/just-bash/src/commands/sort/sort.ts
+++ b/packages/just-bash/src/commands/sort/sort.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { readAndConcat } from "../../utils/file-reader.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -200,18 +196,12 @@ export const sortCommand: Command = {
       lines = filterUnique(lines, options);
     }
 
-    const joined = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+    const output = lines.length > 0 ? `${lines.join("\n")}\n` : "";
 
-    // sort always processes Unicode-decoded text; re-encode to a latin1
-    // byte view so the byte-shaped downstream (writeFile + "binary",
-    // stdoutEncoding "binary") doesn't truncate each codepoint to its
-    // low byte.
-    const output = latin1FromBytes(encodeUtf8ToBytes(joined));
-
-    // Output to file if -o specified
+    // sort emits text; the pipeline handles encoding.
     if (options.outputFile) {
       const outPath = ctx.fs.resolvePath(ctx.cwd, options.outputFile);
-      await ctx.fs.writeFile(outPath, output, "binary");
+      await ctx.fs.writeFile(outPath, output);
       return { stdout: "", stderr: "", exitCode: 0 };
     }
 
@@ -219,7 +209,6 @@ export const sortCommand: Command = {
       stdout: output,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/sort/sort.ts
+++ b/packages/just-bash/src/commands/sort/sort.ts
@@ -151,13 +151,22 @@ export const sortCommand: Command = {
     }
 
     // Read from files or stdin. Default sort is byte-lexicographic and
-    // byte-clean. With -f / --ignore-case the comparator runs `.toLowerCase`
-    // on each line; that's Unicode-aware in JS and would corrupt latin1
-    // byte buffers (a UTF-8 leading byte 0xC3 lowercases to 0xE3, mutating
-    // the data), so decode to UTF-8 first whenever we'll case-fold.
+    // byte-clean. Two comparator paths run Unicode-aware string methods on
+    // each line and would silently corrupt latin1 byte buffers (e.g. a
+    // UTF-8 leading byte 0xC3 lowercases to 0xE3, mutating the data):
+    //   - case-fold (-f / --ignore-case, OR per-key `f` like `-k1f`) calls
+    //     `.toLowerCase()`,
+    //   - dictionary order (-d / --dictionary-order, OR per-key `d`) runs a
+    //     `[^a-zA-Z0-9\s]` regex that strips multibyte continuation bytes.
+    // Decode to UTF-8 first whenever any of those modes is active anywhere,
+    // globally or in any per-key modifier.
     const readResult = await readAndConcat(ctx, files, { cmdName: "sort" });
     if (!readResult.ok) return readResult.error;
-    const content = options.ignoreCase
+    const needsDecode =
+      options.ignoreCase ||
+      options.dictionaryOrder ||
+      options.keys.some((k) => k.ignoreCase || k.dictionaryOrder);
+    const content = needsDecode
       ? decodeBytesToUtf8(readResult.content)
       : latin1FromBytes(readResult.content);
 

--- a/packages/just-bash/src/commands/sort/sort.ts
+++ b/packages/just-bash/src/commands/sort/sort.ts
@@ -1,4 +1,8 @@
-import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { readAndConcat } from "../../utils/file-reader.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -150,25 +154,17 @@ export const sortCommand: Command = {
       }
     }
 
-    // Read from files or stdin. Default sort is byte-lexicographic and
-    // byte-clean. Two comparator paths run Unicode-aware string methods on
-    // each line and would silently corrupt latin1 byte buffers (e.g. a
-    // UTF-8 leading byte 0xC3 lowercases to 0xE3, mutating the data):
-    //   - case-fold (-f / --ignore-case, OR per-key `f` like `-k1f`) calls
-    //     `.toLowerCase()`,
-    //   - dictionary order (-d / --dictionary-order, OR per-key `d`) runs a
-    //     `[^a-zA-Z0-9\s]` regex that strips multibyte continuation bytes.
-    // Decode to UTF-8 first whenever any of those modes is active anywhere,
-    // globally or in any per-key modifier.
+    // Read from files or stdin. sort's comparator uses `localeCompare`,
+    // which on byte-encoded UTF-8 returns 0 for many byte pairs (treating
+    // continuation bytes as equal control chars). We need real Unicode
+    // codepoints for stable ordering. Case-fold / dictionary-order paths
+    // additionally run `.toLowerCase()` and `[^a-zA-Z0-9\s]` regex that
+    // would corrupt the latin1 byte view. Always decode for processing,
+    // then re-encode the joined output back to bytes for the byte-shaped
+    // pipeline.
     const readResult = await readAndConcat(ctx, files, { cmdName: "sort" });
     if (!readResult.ok) return readResult.error;
-    const needsDecode =
-      options.ignoreCase ||
-      options.dictionaryOrder ||
-      options.keys.some((k) => k.ignoreCase || k.dictionaryOrder);
-    const content = needsDecode
-      ? decodeBytesToUtf8(readResult.content)
-      : latin1FromBytes(readResult.content);
+    const content = decodeBytesToUtf8(readResult.content);
 
     // Split into lines (preserve empty lines at the end for sorting)
     let lines = content.split("\n");
@@ -204,13 +200,17 @@ export const sortCommand: Command = {
       lines = filterUnique(lines, options);
     }
 
-    const output = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+    const joined = lines.length > 0 ? `${lines.join("\n")}\n` : "";
+
+    // sort always processes Unicode-decoded text; re-encode to a latin1
+    // byte view so the byte-shaped downstream (writeFile + "binary",
+    // stdoutEncoding "binary") doesn't truncate each codepoint to its
+    // low byte.
+    const output = latin1FromBytes(encodeUtf8ToBytes(joined));
 
     // Output to file if -o specified
     if (options.outputFile) {
       const outPath = ctx.fs.resolvePath(ctx.cwd, options.outputFile);
-      // Content was read with binary encoding (readAndConcat), write as binary
-      // to preserve UTF-8 byte sequences
       await ctx.fs.writeFile(outPath, output, "binary");
       return { stdout: "", stderr: "", exitCode: 0 };
     }

--- a/packages/just-bash/src/commands/sort/sort.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/sort/sort.utf8-stdin.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sort reads UTF-8 from stdin", () => {
+  it("default sort preserves bytes (no case-fold corruption)", async () => {
+    const env = new Bash({ files: { "/in.txt": "café\nbé\n" } });
+    const result = await env.exec("cat /in.txt | sort");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("bé\ncafé\n");
+  });
+
+  it("sort -f case-folds without mutating UTF-8 leading bytes", async () => {
+    // Without the fix, naive `.toLowerCase()` over a latin1 byte buffer
+    // turns the 0xC3 leading byte of `é` into 0xE3 — a *different* valid
+    // UTF-8 leading byte — silently corrupting accented characters.
+    const env = new Bash({ files: { "/in.txt": "Café\nApple\n" } });
+    const result = await env.exec("cat /in.txt | sort -f");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("Apple\nCafé\n");
+  });
+});

--- a/packages/just-bash/src/commands/split/split.ts
+++ b/packages/just-bash/src/commands/split/split.ts
@@ -7,7 +7,7 @@
  * default size is 1000 lines, and default PREFIX is 'x'.
  */
 
-import { latin1FromBytes } from "../../encoding.js";
+import { latin1FromBytes, readBytesFrom } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -336,22 +336,28 @@ export const split: Command = {
       prefix = positionalArgs[1];
     }
 
-    // Read input content. split is byte-clean — chunks files by line or byte
-    // count, never interprets content.
+    // Read input content. split is byte-clean — it chunks the file by line
+    // or byte count and never interprets content. Both stdin and named
+    // files are read as the latin1 byte view so the binary writes below
+    // round-trip the bytes byte-for-byte. Reading the named file as utf8
+    // would decode multibyte codepoints, then the binary write would
+    // truncate each one back to a single low byte — silent data loss for
+    // non-ASCII files.
     let content: string;
     if (inputFile === "-") {
       content = latin1FromBytes(ctx.stdin) ?? "";
     } else {
       const filePath = ctx.fs.resolvePath(ctx.cwd, inputFile);
-      const fileContent = await ctx.fs.readFile(filePath);
-      if (fileContent === null) {
+      try {
+        const fileBytes = await readBytesFrom(ctx.fs, filePath);
+        content = latin1FromBytes(fileBytes);
+      } catch {
         return {
           exitCode: 1,
           stdout: "",
           stderr: `split: ${inputFile}: No such file or directory\n`,
         };
       }
-      content = fileContent;
     }
 
     // Handle empty input

--- a/packages/just-bash/src/commands/split/split.ts
+++ b/packages/just-bash/src/commands/split/split.ts
@@ -7,6 +7,7 @@
  * default size is 1000 lines, and default PREFIX is 'x'.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -335,10 +336,11 @@ export const split: Command = {
       prefix = positionalArgs[1];
     }
 
-    // Read input content
+    // Read input content. split is byte-clean — chunks files by line or byte
+    // count, never interprets content.
     let content: string;
     if (inputFile === "-") {
-      content = ctx.stdin ?? "";
+      content = latin1FromBytes(ctx.stdin) ?? "";
     } else {
       const filePath = ctx.fs.resolvePath(ctx.cwd, inputFile);
       const fileContent = await ctx.fs.readFile(filePath);
@@ -401,7 +403,9 @@ export const split: Command = {
       const filename = `${prefix}${suffix}${options.additionalSuffix}`;
       const filePath = ctx.fs.resolvePath(ctx.cwd, filename);
 
-      await ctx.fs.writeFile(filePath, chunk.content);
+      // chunk.content is the latin1 byte view of stdin — write as binary
+      // so writeFile doesn't re-encode every >0x7F char as a UTF-8 sequence.
+      await ctx.fs.writeFile(filePath, chunk.content, "binary");
     }
 
     return {

--- a/packages/just-bash/src/commands/split/split.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/split/split.utf8-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("split reads UTF-8 from stdin", () => {
+  it("preserves multibyte content across split chunks", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\ncafé\n漢字\n" } });
+    const r = await env.exec("cat /in.txt | split -l 1 - /tmp/chunk_");
+    expect(r.exitCode).toBe(0);
+    const aa = await env.fs.readFile("/tmp/chunk_aa", "utf8");
+    const ab = await env.fs.readFile("/tmp/chunk_ab", "utf8");
+    const ac = await env.fs.readFile("/tmp/chunk_ac", "utf8");
+    expect(aa).toBe("한글\n");
+    expect(ab).toBe("café\n");
+    expect(ac).toBe("漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -17,6 +17,7 @@ import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import initSqlJs from "sql.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -539,8 +540,9 @@ export const sqlite3Command: Command = {
       };
     }
 
-    // Get SQL from argument or stdin, prepend -cmd if provided
-    let sql = sqlArg || ctx.stdin.trim();
+    // Get SQL from argument or stdin. SQL is text — decode bytes to UTF-8 so
+    // string literals containing multibyte characters survive intact.
+    let sql = sqlArg || decodeBytesToUtf8(ctx.stdin).trim();
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -17,7 +17,11 @@ import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import initSqlJs from "sql.js";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -675,7 +679,13 @@ export const sqlite3Command: Command = {
       }
     }
 
-    return { stdout, stderr: "", exitCode: hadError && options.bail ? 1 : 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(stdout)),
+      stderr: "",
+      exitCode: hadError && options.bail ? 1 : 0,
+      stdoutEncoding: "binary",
+    };
   },
 };
 

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -17,11 +17,7 @@ import { dirname, join, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
 import initSqlJs from "sql.js";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import {
   sanitizeErrorMessage,
   sanitizeHostErrorMessage,
@@ -679,12 +675,11 @@ export const sqlite3Command: Command = {
       }
     }
 
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // sqlite3 emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(stdout)),
+      stdout,
       stderr: "",
       exitCode: hadError && options.bail ? 1 : 0,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 reads UTF-8 from stdin", () => {
+  it("preserves multibyte string literals piped as SQL", async () => {
+    const env = new Bash({
+      files: { "/q.sql": "SELECT '한글 / café / 漢字' AS msg;\n" },
+    });
+    const result = await env.exec("cat /q.sql | sqlite3 :memory:");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("한글 / café / 漢字");
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.worker-protocol-abuse.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.worker-protocol-abuse.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
 import type { CommandContext } from "../../types.js";
@@ -58,7 +59,7 @@ function createContext(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: "",
+    stdin: EMPTY_BYTES,
     ...overrides,
   };
 }

--- a/packages/just-bash/src/commands/strings/strings.ts
+++ b/packages/just-bash/src/commands/strings/strings.ts
@@ -7,6 +7,7 @@
  * MIN characters long. If no FILE is specified, standard input is read.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
 
@@ -223,21 +224,28 @@ export const strings: Command = {
 
     let output = "";
 
+    // strings extracts ASCII-printable runs from a binary buffer — the
+    // input must reach the byte loop as raw bytes, not as decoded text.
+    // Pass latin1-shaped bytes directly so multibyte UTF-8 sequences in the
+    // source aren't re-encoded by TextEncoder.
+    const stdinBytes = (): Uint8Array =>
+      Uint8Array.from(latin1FromBytes(ctx.stdin) ?? "", (c) => c.charCodeAt(0));
+
     if (files.length === 0) {
       // Read from stdin
-      const input = ctx.stdin ?? "";
-      const strings = extractStrings(input, options);
+      const strings = extractStrings(stdinBytes(), options);
       output = strings.length > 0 ? `${strings.join("\n")}\n` : "";
     } else {
       // Process each file
       for (const file of files) {
-        let content: string | null;
+        let buffer: Uint8Array;
         if (file === "-") {
-          content = ctx.stdin ?? "";
+          buffer = stdinBytes();
         } else {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);
-          content = await ctx.fs.readFile(filePath);
-          if (content === null) {
+          try {
+            buffer = await ctx.fs.readFileBuffer(filePath);
+          } catch {
             return {
               exitCode: 1,
               stdout: output,
@@ -245,7 +253,7 @@ export const strings: Command = {
             };
           }
         }
-        const strings = extractStrings(content, options);
+        const strings = extractStrings(buffer, options);
         if (strings.length > 0) {
           output += `${strings.join("\n")}\n`;
         }

--- a/packages/just-bash/src/commands/strings/strings.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/strings/strings.utf8-stdin.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("strings reads UTF-8 from stdin", () => {
+  it("works on raw bytes without TextEncoder double-encoding", async () => {
+    // Mix printable ASCII + multibyte UTF-8 + a control byte. The ASCII
+    // 'hello world' run is the only run that should survive the printable
+    // filter; the UTF-8 leading bytes are non-printable.
+    const env = new Bash({
+      files: { "/in.bin": "\x01\x02hello world\x00한글" },
+    });
+    const r = await env.exec("cat /in.bin | strings -n 4");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toContain("hello world");
+  });
+});

--- a/packages/just-bash/src/commands/tac/tac.ts
+++ b/packages/just-bash/src/commands/tac/tac.ts
@@ -6,6 +6,7 @@
  * Writes each FILE to standard output, last line first.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 
 async function tacExecute(
@@ -36,8 +37,8 @@ async function tacExecute(
     }
   }
 
-  // Read from stdin
-  const lines = ctx.stdin.split("\n");
+  // Read from stdin. tac is byte-clean — splits on \n then reverses.
+  const lines = latin1FromBytes(ctx.stdin).split("\n");
   if (lines[lines.length - 1] === "") {
     lines.pop();
   }

--- a/packages/just-bash/src/commands/tar/tar.ts
+++ b/packages/just-bash/src/commands/tar/tar.ts
@@ -378,7 +378,16 @@ async function createTarArchive(
   if (allErrors.length > 0) {
     stderr += `${allErrors.join("\n")}\n`;
   }
-  return { stdout, stderr, exitCode: allErrors.length > 0 ? 2 : 0 };
+  // Mark stdout as bytes when emitting an archive (`tar -c -f -`); the
+  // pipeline + redirect layer will preserve the bytes verbatim instead of
+  // UTF-8 encoding them. `-f /path` paths emit empty stdout — the kind
+  // doesn't matter there.
+  return {
+    stdout,
+    stderr,
+    exitCode: allErrors.length > 0 ? 2 : 0,
+    stdoutKind: stdout.length > 0 ? "bytes" : "text",
+  };
 }
 
 /**

--- a/packages/just-bash/src/commands/tar/tar.ts
+++ b/packages/just-bash/src/commands/tar/tar.ts
@@ -5,6 +5,7 @@
  * with optional gzip, bzip2, and xz compression.
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import { createUserRegex } from "../../regex/index.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { formatMode } from "../format-mode.js";
@@ -673,7 +674,9 @@ async function extractTarArchive(
     }
   } else {
     // Read from stdin - convert binary string directly to bytes without UTF-8 re-encoding
-    archiveData = Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+      c.charCodeAt(0),
+    );
   }
 
   // Parse archive - auto-detect compression or use flags
@@ -911,7 +914,9 @@ async function listTarArchive(
     }
   } else {
     // Read from stdin - convert binary string directly to bytes without UTF-8 re-encoding
-    archiveData = Uint8Array.from(ctx.stdin, (c) => c.charCodeAt(0));
+    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+      c.charCodeAt(0),
+    );
   }
 
   // Parse archive - auto-detect compression or use flags

--- a/packages/just-bash/src/commands/tar/tar.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/tar/tar.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("tar reads UTF-8 from stdin", () => {
+  it("round-trips multibyte file content through a tar | untar pipe", async () => {
+    const env = new Bash({ files: { "/dir/k.txt": "한글 / café / 漢字\n" } });
+    const r = await env.exec("tar -cf - dir | tar -xOf - dir/k.txt");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("한글 / café / 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/tee/tee.ts
+++ b/packages/just-bash/src/commands/tee/tee.ts
@@ -36,19 +36,18 @@ export const teeCommand: Command = {
     let stderr = "";
     let exitCode = 0;
 
-    // Write to each file using the default encoding — matches the existing
-    // redirection-layer heuristic (high codepoint → utf8). Note: this means
-    // a latin1 byte buffer of UTF-8 bytes piped through tee will be
-    // re-encoded into a *double*-utf8 file, which is a pre-existing bug
-    // tied to the string-as-byte-buffer pipeline shape. Fixing it cleanly
-    // requires migrating the pipe to `Uint8Array`; tracked separately.
+    // Write to each file in binary mode. The pipe-execution boundary
+    // ensures `ctx.stdin` always reaches us as a latin1-shaped byte
+    // buffer (UTF-8-encoded for non-ASCII), so binary write preserves the
+    // bytes verbatim. Default-utf8 write would re-interpret each char as
+    // a codepoint and double-encode every high byte.
     for (const file of files) {
       try {
         const filePath = ctx.fs.resolvePath(ctx.cwd, file);
         if (append) {
-          await ctx.fs.appendFile(filePath, content);
+          await ctx.fs.appendFile(filePath, content, "binary");
         } else {
-          await ctx.fs.writeFile(filePath, content);
+          await ctx.fs.writeFile(filePath, content, "binary");
         }
       } catch (_error) {
         stderr += `tee: ${file}: No such file or directory\n`;

--- a/packages/just-bash/src/commands/tee/tee.ts
+++ b/packages/just-bash/src/commands/tee/tee.ts
@@ -1,3 +1,4 @@
+import { latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
@@ -29,11 +30,18 @@ export const teeCommand: Command = {
 
     const { append } = parsed.result.flags;
     const files = parsed.result.positional;
-    const content = ctx.stdin;
+    // tee is byte-clean: stdin bytes are written to each file and the same
+    // bytes pass through to stdout.
+    const content = latin1FromBytes(ctx.stdin);
     let stderr = "";
     let exitCode = 0;
 
-    // Write to each file
+    // Write to each file using the default encoding — matches the existing
+    // redirection-layer heuristic (high codepoint → utf8). Note: this means
+    // a latin1 byte buffer of UTF-8 bytes piped through tee will be
+    // re-encoded into a *double*-utf8 file, which is a pre-existing bug
+    // tied to the string-as-byte-buffer pipeline shape. Fixing it cleanly
+    // requires migrating the pipe to `Uint8Array`; tracked separately.
     for (const file of files) {
       try {
         const filePath = ctx.fs.resolvePath(ctx.cwd, file);
@@ -48,11 +56,13 @@ export const teeCommand: Command = {
       }
     }
 
-    // Pass through to stdout
+    // Pass through to stdout as raw bytes — the boundary in Bash.exec
+    // decodes UTF-8 sequences back to Unicode for terminals.
     return {
       stdout: content,
       stderr,
       exitCode,
+      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/tee/tee.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/tee/tee.utf8-stdin.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("tee reads UTF-8 from stdin", () => {
+  it("passes UTF-8 stdin through to stdout unchanged", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café / 漢字\n" } });
+    const result = await env.exec("cat /in.txt | tee /out.txt");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 / café / 漢字\n");
+  });
+
+  it("writes UTF-8 text from a heredoc to a file", async () => {
+    // The heredoc path is the one that lands as a real Unicode string in
+    // tee's stdin (no upstream byte buffer), so the file write goes through
+    // the utf8-by-default encoding and round-trips bytes-perfectly.
+    const env = new Bash();
+    await env.exec("tee /out.txt <<< '한글 / café'");
+    const written = await env.fs.readFileBuffer("/out.txt");
+    expect(new TextDecoder().decode(written)).toBe("한글 / café\n");
+  });
+});

--- a/packages/just-bash/src/commands/time/time.ts
+++ b/packages/just-bash/src/commands/time/time.ts
@@ -1,3 +1,4 @@
+import { latin1FromBytes } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
@@ -116,7 +117,7 @@ export const timeCommand: Command = {
       result = await ctx.exec(shellJoinArgs([commandArgs[0]]), {
         env: mapToRecord(ctx.env),
         cwd: ctx.cwd,
-        stdin: ctx.stdin,
+        stdin: latin1FromBytes(ctx.stdin),
         signal: ctx.signal,
         args: commandArgs.slice(1),
       });

--- a/packages/just-bash/src/commands/time/time.ts
+++ b/packages/just-bash/src/commands/time/time.ts
@@ -118,6 +118,8 @@ export const timeCommand: Command = {
         env: mapToRecord(ctx.env),
         cwd: ctx.cwd,
         stdin: latin1FromBytes(ctx.stdin),
+        // ctx.stdin is already byte-shaped — forward verbatim.
+        stdinKind: "bytes",
         signal: ctx.signal,
         args: commandArgs.slice(1),
       });

--- a/packages/just-bash/src/commands/time/time.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/time/time.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("time forwards UTF-8 stdin", () => {
+  it("byte-clean passthrough to the wrapped command", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café\n" } });
+    const r = await env.exec("cat /in.txt | time cat");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("한글 / café\n");
+  });
+});

--- a/packages/just-bash/src/commands/timeout/timeout.ts
+++ b/packages/just-bash/src/commands/timeout/timeout.ts
@@ -1,3 +1,4 @@
+import { latin1FromBytes } from "../../encoding.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
 import { _clearTimeout, _setTimeout } from "../../timers.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
@@ -133,7 +134,7 @@ export const timeoutCommand: Command = {
         .exec(shellJoinArgs([commandArgs[0]]), {
           cwd: ctx.cwd,
           signal: controller.signal,
-          stdin: ctx.stdin,
+          stdin: latin1FromBytes(ctx.stdin),
           args: commandArgs.slice(1),
         })
         .then((result) => ({ timedOut: false as const, result }));

--- a/packages/just-bash/src/commands/timeout/timeout.ts
+++ b/packages/just-bash/src/commands/timeout/timeout.ts
@@ -135,6 +135,8 @@ export const timeoutCommand: Command = {
           cwd: ctx.cwd,
           signal: controller.signal,
           stdin: latin1FromBytes(ctx.stdin),
+          // ctx.stdin is already byte-shaped — forward verbatim.
+          stdinKind: "bytes",
           args: commandArgs.slice(1),
         })
         .then((result) => ({ timedOut: false as const, result }));

--- a/packages/just-bash/src/commands/timeout/timeout.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/timeout/timeout.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("timeout forwards UTF-8 stdin", () => {
+  it("byte-clean passthrough to the wrapped command", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 / café\n" } });
+    const r = await env.exec("cat /in.txt | timeout 5 cat");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("한글 / café\n");
+  });
+});

--- a/packages/just-bash/src/commands/tr/tr.binary.test.ts
+++ b/packages/just-bash/src/commands/tr/tr.binary.test.ts
@@ -13,4 +13,30 @@ describe("tr with binary content", () => {
     expect(result.stdout).toBe("ABC");
     expect(result.exitCode).toBe(0);
   });
+
+  it("translates by codepoint when input is UTF-8 binary", async () => {
+    // The user's `tr 'é' 'X'` invocation is a real Unicode codepoint,
+    // while the input bytes are 0xC3 0xA9 (UTF-8 for é). Without decoding,
+    // tr would iterate per-byte and never match the codepoint.
+    const env = new Bash({
+      files: { "/data.bin": new Uint8Array([0x63, 0xc3, 0xa9, 0x0a]) }, // c, é, \n
+    });
+    const r = await env.exec("cat /data.bin | tr 'é' 'X'");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("cX\n");
+  });
+
+  it("ASCII passthrough doesn't touch high bytes", async () => {
+    // tr 'a-z' 'A-Z' must only translate ASCII; the embedded UTF-8 bytes
+    // (which are all >0x7F) and any control bytes pass through verbatim.
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([0x61, 0xc3, 0xa9, 0x62, 0x00, 0x63]),
+      },
+    });
+    const r = await env.exec("cat /data.bin | tr 'a-z' 'A-Z'");
+    expect(r.exitCode).toBe(0);
+    // a → A, é stays é, b → B, NUL stays, c → C.
+    expect(r.stdout).toBe("AéB\x00C");
+  });
 });

--- a/packages/just-bash/src/commands/tr/tr.ts
+++ b/packages/just-bash/src/commands/tr/tr.ts
@@ -1,3 +1,8 @@
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
@@ -172,7 +177,10 @@ export const trCommand: Command = {
         exitCode: 1,
       };
     }
-    const content = ctx.stdin;
+    // Translation operates on codepoints — set1 / set2 args are real Unicode
+    // strings, so we must decode bytes to UTF-8 first, otherwise multibyte
+    // chars don't match the SET they were spelled with.
+    const content = decodeBytesToUtf8(ctx.stdin);
 
     // Helper to check if character is in set1 (considering complement mode)
     const isInSet1 = (char: string): boolean => {
@@ -241,7 +249,13 @@ export const trCommand: Command = {
       }
     }
 
-    return { stdout: output, stderr: "", exitCode: 0 };
+    // Re-encode to bytes so the byte-shaped pipeline stays consistent.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   },
 };
 

--- a/packages/just-bash/src/commands/tr/tr.ts
+++ b/packages/just-bash/src/commands/tr/tr.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
@@ -249,12 +245,11 @@ export const trCommand: Command = {
       }
     }
 
-    // Re-encode to bytes so the byte-shaped pipeline stays consistent.
+    // tr emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+      stdout: output,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   },
 };

--- a/packages/just-bash/src/commands/tr/tr.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/tr/tr.utf8-stdin.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("tr reads UTF-8 from stdin", () => {
+  it("translates by codepoint, matching the SET as the user spelled it", async () => {
+    const env = new Bash({ files: { "/in.txt": "café\n" } });
+    const result = await env.exec("cat /in.txt | tr 'é' 'X'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("cafX\n");
+  });
+
+  it("passes through non-matched multibyte chars unchanged", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글 abc\n" } });
+    const result = await env.exec("cat /in.txt | tr 'a-z' 'A-Z'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 ABC\n");
+  });
+});

--- a/packages/just-bash/src/commands/uniq/uniq.binary.test.ts
+++ b/packages/just-bash/src/commands/uniq/uniq.binary.test.ts
@@ -20,4 +20,27 @@ describe("uniq with binary content", () => {
     expect(result.stdout).toBe("a\nb\n");
     expect(result.exitCode).toBe(0);
   });
+
+  it("preserves UTF-8 leading bytes under -i case-fold", async () => {
+    // 0xC3 0xA9 is "é" in UTF-8; 0xC3 0x89 is "É". A naive byte-level
+    // `.toLowerCase()` would mutate 0xC3 → 0xE3, corrupting the bytes.
+    // The two lines case-fold equal, so they collapse to one line whose
+    // bytes match the first occurrence verbatim.
+    const env = new Bash({
+      files: {
+        "/data.bin": new Uint8Array([
+          0xc3,
+          0x89,
+          0x0a, // É\n
+          0xc3,
+          0xa9,
+          0x0a, // é\n
+        ]),
+      },
+    });
+    const r = await env.exec("uniq -i /data.bin");
+    expect(r.exitCode).toBe(0);
+    // First line wins on collapse — bytes intact, no 0xE3 mutation.
+    expect(r.stdout).toBe("É\n");
+  });
 });

--- a/packages/just-bash/src/commands/uniq/uniq.ts
+++ b/packages/just-bash/src/commands/uniq/uniq.ts
@@ -1,8 +1,4 @@
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { readAndConcat } from "../../utils/file-reader.js";
@@ -106,19 +102,19 @@ export const uniqCommand: Command = {
       }
     }
 
-    // We mark stdout as "binary" so the bytes round-trip through redirects
-    // and pipes without re-encoding. When the -i path took us through the
-    // decoded representation, `output` is Unicode codepoints — re-encode
-    // back to a latin1 byte view first, otherwise binary writes truncate
-    // each multibyte codepoint to its low byte.
-    const stdout = ignoreCase
-      ? latin1FromBytes(encodeUtf8ToBytes(output))
-      : output;
-
+    // ignore-case mode produces decoded text; default mode forwards bytes.
+    if (ignoreCase) {
+      return {
+        stdout: output,
+        stderr: "",
+        exitCode: 0,
+      };
+    }
     return {
-      stdout,
+      stdout: output,
       stderr: "",
       exitCode: 0,
+      stdoutKind: "bytes",
       stdoutEncoding: "binary",
     };
   },

--- a/packages/just-bash/src/commands/uniq/uniq.ts
+++ b/packages/just-bash/src/commands/uniq/uniq.ts
@@ -1,4 +1,8 @@
-import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { readAndConcat } from "../../utils/file-reader.js";
@@ -102,8 +106,17 @@ export const uniqCommand: Command = {
       }
     }
 
+    // We mark stdout as "binary" so the bytes round-trip through redirects
+    // and pipes without re-encoding. When the -i path took us through the
+    // decoded representation, `output` is Unicode codepoints — re-encode
+    // back to a latin1 byte view first, otherwise binary writes truncate
+    // each multibyte codepoint to its low byte.
+    const stdout = ignoreCase
+      ? latin1FromBytes(encodeUtf8ToBytes(output))
+      : output;
+
     return {
-      stdout: output,
+      stdout,
       stderr: "",
       exitCode: 0,
       stdoutEncoding: "binary",

--- a/packages/just-bash/src/commands/uniq/uniq.ts
+++ b/packages/just-bash/src/commands/uniq/uniq.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { readAndConcat } from "../../utils/file-reader.js";
@@ -37,10 +38,15 @@ export const uniqCommand: Command = {
       parsed.result.flags;
     const files = parsed.result.positional;
 
-    // Read from files or stdin
+    // Read from files or stdin. With -i / --ignore-case the comparator
+    // calls `.toLowerCase` (Unicode-aware in JS); on a latin1 byte buffer
+    // that would mutate UTF-8 leading bytes (0xC0-0xDE → 0xE0-0xFE),
+    // silently corrupting accented characters. Decode in that mode.
     const readResult = await readAndConcat(ctx, files, { cmdName: "uniq" });
     if (!readResult.ok) return readResult.error;
-    const content = readResult.content;
+    const content = ignoreCase
+      ? decodeBytesToUtf8(readResult.content)
+      : latin1FromBytes(readResult.content);
 
     // Split into lines
     const lines = content.split("\n");

--- a/packages/just-bash/src/commands/uniq/uniq.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/uniq/uniq.utf8-stdin.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("uniq reads UTF-8 from stdin", () => {
+  it("default uniq preserves bytes byte-for-byte", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\n한글\ncafé\n" } });
+    const result = await env.exec("cat /in.txt | uniq");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글\ncafé\n");
+  });
+
+  it("uniq -i case-folds without corrupting UTF-8 leading bytes", async () => {
+    const env = new Bash({ files: { "/in.txt": "café\nCAFÉ\n" } });
+    const result = await env.exec("cat /in.txt | uniq -i");
+    expect(result.exitCode).toBe(0);
+    // Lines case-fold to the same value, so they collapse — first byte-perfect
+    // line wins, no 0xC3→0xE3 mutation in the surviving output.
+    expect(result.stdout).toBe("café\n");
+  });
+});

--- a/packages/just-bash/src/commands/utf8-bytestring.test.ts
+++ b/packages/just-bash/src/commands/utf8-bytestring.test.ts
@@ -1,0 +1,149 @@
+/**
+ * UTF-8 byte preservation across the pipeline boundary.
+ *
+ * The shell pipeline carries data as latin1-shaped byte buffers internally:
+ * a previous command's stdout is a string where each char is one byte. When
+ * a downstream command interprets that buffer as text (regex, parsing, char
+ * iteration, code execution, case folding), multibyte UTF-8 sequences get
+ * misread as several latin1 chars and the result silently mojibakes.
+ *
+ * The fix is the opaque `ByteString` type in `src/encoding.ts` — every
+ * command author must explicitly pick `latin1FromBytes` (forward bytes) or
+ * `decodeBytesToUtf8` (interpret as text). These tests reproduce the bugs
+ * the type system now prevents in the worst-affected commands and make sure
+ * nothing regresses.
+ *
+ * The bytes flow as `printf '\x..\x..\x..' | <cmd>` so stdin holds the
+ * actual UTF-8 byte sequence (latin1-shaped) the pipeline would deliver.
+ * Tests assert the user-visible string at `result.stdout`, which is what
+ * the output boundary in `Bash.exec` decodes back to Unicode.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+const KOREAN_BYTES = "\\xed\\x95\\x9c\\xea\\xb8\\x80"; // 한글
+const KOREAN = "한글";
+const CAFE_BYTES = "caf\\xc3\\xa9"; // café
+const CAFE = "café";
+const CJK_BYTES = "\\xe6\\xbc\\xa2\\xe5\\xad\\x97"; // 漢字
+const CJK = "漢字";
+// 0xC3 0xA9 is the UTF-8 byte sequence for é. Without the brand, naive
+// `.toLowerCase()` on a latin1 byte buffer turns 0xC3 into 0xE3 — silently
+// mutating "é" into a corrupt sequence that decodes as a *different* char.
+const CASEFOLD_DANGER_BYTES = "\\xc3\\x89"; // É (capital)
+const CASEFOLD_DANGER = "É";
+
+describe("UTF-8 byte preservation across the pipeline boundary", () => {
+  describe("bash / sh from stdin", () => {
+    it("parses a script containing non-ASCII string literals", async () => {
+      const env = new Bash();
+      const result = await env.exec(`printf 'echo "${CAFE_BYTES}"\\n' | bash`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${CAFE}\n`);
+    });
+  });
+
+  describe("rev", () => {
+    it("reverses by codepoint, not by latin1 byte", async () => {
+      const env = new Bash();
+      const result = await env.exec(`printf '${KOREAN_BYTES}\\n' | rev`);
+      expect(result.exitCode).toBe(0);
+      // "한글" reversed by codepoint is "글한"
+      expect(result.stdout).toBe("글한\n");
+    });
+  });
+
+  describe("wc", () => {
+    // The interesting case is reading raw multibyte bytes from a file:
+    // `-c` reports 6 (UTF-8 byte length) and `-m` reports 2 (codepoints).
+    // This is the path where ByteString matters — the file is read as
+    // bytes and only `-m` is supposed to decode.
+    it("-c counts bytes and -m counts codepoints from a UTF-8 file", async () => {
+      const env = new Bash({ files: { "/k.txt": KOREAN } });
+      const c = await env.exec("wc -c /k.txt");
+      const m = await env.exec("wc -m /k.txt");
+      expect(c.stdout.trim().split(/\s+/)[0]).toBe("6");
+      expect(m.stdout.trim().split(/\s+/)[0]).toBe("2");
+    });
+  });
+
+  describe("cut -c", () => {
+    it("slices by codepoint, not by byte", async () => {
+      const env = new Bash();
+      const result = await env.exec(`printf '${CJK_BYTES}\\n' | cut -c 1-2`);
+      expect(result.exitCode).toBe(0);
+      // -c 1-2 should give us both codepoints, not 2 of the 6 bytes
+      expect(result.stdout).toBe(`${CJK}\n`);
+    });
+  });
+
+  describe("expand / unexpand", () => {
+    it("counts column positions by codepoint, not by byte", async () => {
+      const env = new Bash();
+      // A single tab after one CJK char should expand to fill column 2
+      // through tab-stop 8 (6 spaces). With byte counting it would land in
+      // the wrong column.
+      const result = await env.exec(
+        `printf '${CAFE_BYTES}\\tafter\\n' | expand`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${CAFE}    after\n`);
+    });
+  });
+
+  describe("tr", () => {
+    it("translates by codepoint", async () => {
+      const env = new Bash();
+      const result = await env.exec(`printf '${CAFE_BYTES}\\n' | tr 'é' 'X'`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("cafX\n");
+    });
+  });
+
+  describe("sort -f / uniq -i — case-fold without corruption", () => {
+    it("sort -f preserves UTF-8 bytes (does not lowercase 0xC3 to 0xE3)", async () => {
+      const env = new Bash();
+      // É (capital) appears once. With naive byte-level toLowerCase the
+      // leading byte 0xC3 mutates to 0xE3, producing a different valid
+      // UTF-8 character — silent data corruption.
+      const result = await env.exec(
+        `printf '${CASEFOLD_DANGER_BYTES}\\n' | sort -f`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${CASEFOLD_DANGER}\n`);
+    });
+
+    it("uniq -i case-folds by codepoint, preserves bytes in output", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf '${CAFE_BYTES}\\n${CAFE_BYTES.replace("caf", "CAF")}\\n' | uniq -i`,
+      );
+      expect(result.exitCode).toBe(0);
+      // Two lines that case-fold to the same value collapse to one — the
+      // first one wins, byte-perfect.
+      expect(result.stdout).toBe(`${CAFE}\n`);
+    });
+  });
+
+  describe("cat / head / tail / tee — passthrough must stay byte-clean", () => {
+    it("cat round-trips multibyte bytes through stdin and stdout", async () => {
+      const env = new Bash();
+      const result = await env.exec(`printf '${KOREAN_BYTES}\\n' | cat`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${KOREAN}\n`);
+    });
+
+    it("tee passes UTF-8 stdin through to its stdout unchanged", async () => {
+      // (Byte-perfect file write through tee for piped binary data is a
+      // pre-existing limitation tied to using a JS string as a byte buffer;
+      // fixing it requires migrating the pipe to Uint8Array. tee's stdout
+      // path still round-trips correctly through the output boundary.)
+      const env = new Bash();
+      const result = await env.exec(
+        `printf '${CJK_BYTES}\\n' | tee /tmp/out.txt`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe(`${CJK}\n`);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/utf8-bytestring.test.ts
+++ b/packages/just-bash/src/commands/utf8-bytestring.test.ts
@@ -125,6 +125,78 @@ describe("UTF-8 byte preservation across the pipeline boundary", () => {
     });
   });
 
+  describe("decoded-text → byte-consumer pipe boundary", () => {
+    // When sed/grep/rev/awk decode their stdin and emit Unicode codepoints,
+    // the pipe boundary must re-encode that text back to UTF-8 bytes
+    // before the next command sees it. Otherwise byte consumers (`wc -c`,
+    // `base64`, `md5sum`, etc.) operate on JS code units instead of bytes.
+
+    it("text-emitting cmd → wc -c reports byte count, not code units", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글" } });
+      // sed decodes, runs the regex, emits Unicode text.
+      // wc -c must see 6 (UTF-8 bytes), not 2 (code units of "한글").
+      const r = await env.exec(`cat /in.txt | sed 's/$//' | wc -c`);
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe("6");
+    });
+
+    it("rev → base64 round-trips through UTF-8 bytes correctly", async () => {
+      const env = new Bash({ files: { "/in.txt": "한" } });
+      // rev decodes, reverses by codepoint, emits text. Then base64 must
+      // see UTF-8 bytes — without re-encoding it would treat the single
+      // codepoint U+D55C as one byte and emit garbage.
+      const r = await env.exec(`cat /in.txt | rev | base64`);
+      expect(r.exitCode).toBe(0);
+      // base64 of UTF-8 bytes 0xED 0x95 0x9C is "7ZWc".
+      expect(r.stdout.trim()).toBe("7ZWc");
+    });
+
+    it("grep → md5sum hashes the original UTF-8 bytes", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글\n" } });
+      // grep -o decodes for regex, emits matched text. md5 of "한글\n"
+      // (7 UTF-8 bytes) must match `printf '한글\n' | md5sum` semantics.
+      const r = await env.exec(`cat /in.txt | grep -o '한글' | md5sum`);
+      expect(r.exitCode).toBe(0);
+      // md5 of the 7 UTF-8 bytes "한글\n" — verified against host
+      // `printf '한글\n' | md5sum`. (just-bash's md5sum emits two
+      // spaces before the filename to match GNU coreutils format.)
+      expect(r.stdout.trim()).toBe("ebef630fbec2e89fbcd589797bb6441c  -");
+    });
+  });
+
+  describe("split named-file UTF-8 chunking", () => {
+    it("splits a UTF-8 file by line without truncating multibyte chars", async () => {
+      const env = new Bash({ files: { "/in.txt": "한\n글\n漢\n" } });
+      const r = await env.exec("split -l 1 /in.txt /tmp/c_");
+      expect(r.exitCode).toBe(0);
+      const aa = await env.fs.readFile("/tmp/c_aa", "utf8");
+      const ab = await env.fs.readFile("/tmp/c_ab", "utf8");
+      const ac = await env.fs.readFile("/tmp/c_ac", "utf8");
+      expect(aa).toBe("한\n");
+      expect(ab).toBe("글\n");
+      expect(ac).toBe("漢\n");
+    });
+  });
+
+  describe("sort -f / uniq -i write decoded output as UTF-8 bytes", () => {
+    it("sort -f -o preserves UTF-8 bytes in the written file", async () => {
+      const env = new Bash({ files: { "/in.txt": "Café\nApple\n" } });
+      const r = await env.exec("sort -f -o /out.txt /in.txt");
+      expect(r.exitCode).toBe(0);
+      const written = await env.fs.readFileBuffer("/out.txt");
+      expect(new TextDecoder().decode(written)).toBe("Apple\nCafé\n");
+    });
+
+    it("uniq -i piped to wc -c reports the right byte count", async () => {
+      const env = new Bash({ files: { "/in.txt": "Café\nCAFÉ\n" } });
+      // After case-fold collapse, output is "Café\n" — 6 UTF-8 bytes
+      // (C=1, a=1, f=1, é=2, \n=1).
+      const r = await env.exec("uniq -i /in.txt | wc -c");
+      expect(r.exitCode).toBe(0);
+      expect(r.stdout.trim()).toBe("6");
+    });
+  });
+
   describe("cat / head / tail / tee — passthrough must stay byte-clean", () => {
     it("cat round-trips multibyte bytes through stdin and stdout", async () => {
       const env = new Bash();

--- a/packages/just-bash/src/commands/wc/wc.binary.test.ts
+++ b/packages/just-bash/src/commands/wc/wc.binary.test.ts
@@ -25,4 +25,38 @@ describe("wc with binary files", () => {
     expect(result.stdout).toContain("3");
     expect(result.exitCode).toBe(0);
   });
+
+  it("counts -m as codepoints over a UTF-8 file (bytes vs chars diverge)", async () => {
+    // "한글" is 6 UTF-8 bytes / 2 codepoints. -c reports 6, -m reports 2.
+    // The asymmetry is the regression net against conflating the two.
+    const env = new Bash({
+      files: {
+        "/utf8.txt": new Uint8Array([
+          0xed,
+          0x95,
+          0x9c, // 한
+          0xea,
+          0xb8,
+          0x80, // 글
+        ]),
+      },
+    });
+    const c = await env.exec("wc -c /utf8.txt");
+    const m = await env.exec("wc -m /utf8.txt");
+    expect(c.stdout.trim().split(/\s+/)[0]).toBe("6");
+    expect(m.stdout.trim().split(/\s+/)[0]).toBe("2");
+  });
+
+  it("counts -c as raw bytes for a file with non-UTF-8 bytes", async () => {
+    // 0xFF / 0xFE are invalid UTF-8 leading bytes; the redirect / read
+    // layer maps them to U+FFFD when decoding. -c must still report 5 (the
+    // file size), not whatever the replacement chars happen to encode to.
+    const env = new Bash({
+      files: {
+        "/raw.bin": new Uint8Array([0x00, 0x01, 0x02, 0xff, 0xfe]),
+      },
+    });
+    const r = await env.exec("wc -c /raw.bin");
+    expect(r.stdout.trim().split(/\s+/)[0]).toBe("5");
+  });
 });

--- a/packages/just-bash/src/commands/wc/wc.ts
+++ b/packages/just-bash/src/commands/wc/wc.ts
@@ -1,3 +1,8 @@
+import {
+  type ByteString,
+  decodeBytesToUtf8,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { readFiles } from "../../utils/file-reader.js";
@@ -35,14 +40,16 @@ export const wcCommand: Command = {
     if (!parsed.ok) return parsed.error;
 
     let { lines: showLines, words: showWords } = parsed.result.flags;
-    // -c (bytes) and -m (chars) both show character counts
-    let showChars = parsed.result.flags.bytes || parsed.result.flags.chars;
+    let showBytes = parsed.result.flags.bytes;
+    const showChars = parsed.result.flags.chars;
     const files = parsed.result.positional;
 
-    // If no flags specified, show all
-    if (!showLines && !showWords && !showChars) {
-      showLines = showWords = showChars = true;
+    // If no flags specified, default to lines + words + bytes (-c).
+    if (!showLines && !showWords && !showBytes && !showChars) {
+      showLines = showWords = showBytes = true;
     }
+    // The third column is either bytes or chars, depending on flag.
+    const showThird = showBytes || showChars;
 
     // Read files
     const readResult = await readFiles(ctx, files, {
@@ -52,9 +59,9 @@ export const wcCommand: Command = {
 
     // If reading from stdin (no files), use simpler output
     if (files.length === 0) {
-      const stats = countStats(readResult.files[0].content);
+      const stats = countStats(readResult.files[0].content, showChars);
       return {
-        stdout: `${formatStats(stats, showLines, showWords, showChars, "", 0)}\n`,
+        stdout: `${formatStats(stats, showLines, showWords, showThird, "", 0)}\n`,
         stderr: "",
         exitCode: 0,
       };
@@ -63,17 +70,17 @@ export const wcCommand: Command = {
     // First pass: count stats for all files and calculate max widths
     const allStats: Array<{
       filename: string;
-      stats: { lines: number; words: number; chars: number };
+      stats: { lines: number; words: number; third: number };
     }> = [];
     let totalLines = 0;
     let totalWords = 0;
-    let totalChars = 0;
+    let totalThird = 0;
 
     for (const { filename, content } of readResult.files) {
-      const stats = countStats(content);
+      const stats = countStats(content, showChars);
       totalLines += stats.lines;
       totalWords += stats.words;
-      totalChars += stats.chars;
+      totalThird += stats.third;
       allStats.push({ filename, stats });
     }
 
@@ -87,31 +94,31 @@ export const wcCommand: Command = {
       files.length > 1
         ? totalWords
         : Math.max(...allStats.map((s) => s.stats.words));
-    const maxChars =
+    const maxThird =
       files.length > 1
-        ? totalChars
-        : Math.max(...allStats.map((s) => s.stats.chars));
+        ? totalThird
+        : Math.max(...allStats.map((s) => s.stats.third));
 
     // Calculate width based on which columns are shown
     // Use minimum width of 3 for alignment when there are multiple files (matches osh behavior)
     let maxWidth = files.length > 1 ? 3 : 0;
     if (showLines) maxWidth = Math.max(maxWidth, String(maxLines).length);
     if (showWords) maxWidth = Math.max(maxWidth, String(maxWords).length);
-    if (showChars) maxWidth = Math.max(maxWidth, String(maxChars).length);
+    if (showThird) maxWidth = Math.max(maxWidth, String(maxThird).length);
 
     // Second pass: format output with proper alignment
     let stdout = "";
     for (const { filename, stats } of allStats) {
-      stdout += `${formatStats(stats, showLines, showWords, showChars, filename, maxWidth)}\n`;
+      stdout += `${formatStats(stats, showLines, showWords, showThird, filename, maxWidth)}\n`;
     }
 
     // Show total for multiple files
     if (files.length > 1) {
       stdout += `${formatStats(
-        { lines: totalLines, words: totalWords, chars: totalChars },
+        { lines: totalLines, words: totalWords, third: totalThird },
         showLines,
         showWords,
-        showChars,
+        showThird,
         "total",
         maxWidth,
       )}\n`;
@@ -121,19 +128,41 @@ export const wcCommand: Command = {
   },
 };
 
-function countStats(content: string): {
+/**
+ * Count line / word / third-column stats. The third column is bytes for
+ * `-c` and Unicode codepoints for `-m`. Words and lines are byte-clean —
+ * `\n` / whitespace are ASCII so they never collide with multibyte UTF-8
+ * continuation or leading bytes.
+ *
+ * We use string `.length` for the byte count rather than UTF-8 re-encoding.
+ * In the typical pipeline path each char represents one byte (latin1 shape)
+ * so `.length` IS the byte count. In the rare path where an upstream
+ * already decoded to Unicode, we accept that `-c` reports JS code units —
+ * that matches real bash's `wc -c` byte count for ASCII / latin1 input,
+ * preserves existing behavior for invalid-UTF-8 binary input that the
+ * redirect layer mapped to U+FFFD, and stays consistent with the rest of
+ * the pipeline's byte-shaped string semantics.
+ */
+function countStats(
+  content: ByteString,
+  countCodepoints: boolean,
+): {
   lines: number;
   words: number;
-  chars: number;
+  third: number;
 } {
-  const len = content.length;
+  const bytes = latin1FromBytes(content);
+  const len = bytes.length;
+  const third = countCodepoints
+    ? Array.from(decodeBytesToUtf8(content)).length
+    : len;
   let lines = 0;
   let words = 0;
   let inWord = false;
 
   // Single pass through content to count lines and words
   for (let i = 0; i < len; i++) {
-    const c = content[i];
+    const c = bytes[i];
     if (c === "\n") {
       lines++;
       if (inWord) {
@@ -155,14 +184,14 @@ function countStats(content: string): {
     words++;
   }
 
-  return { lines, words, chars: len };
+  return { lines, words, third };
 }
 
 function formatStats(
-  stats: { lines: number; words: number; chars: number },
+  stats: { lines: number; words: number; third: number },
   showLines: boolean,
   showWords: boolean,
-  showChars: boolean,
+  showThird: boolean,
   filename: string,
   minWidth: number,
 ): string {
@@ -173,8 +202,8 @@ function formatStats(
   if (showWords) {
     values.push(String(stats.words).padStart(minWidth));
   }
-  if (showChars) {
-    values.push(String(stats.chars).padStart(minWidth));
+  if (showThird) {
+    values.push(String(stats.third).padStart(minWidth));
   }
 
   let result = values.join(" ");

--- a/packages/just-bash/src/commands/wc/wc.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/wc/wc.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("wc reads UTF-8 from stdin", () => {
+  // 한글 is 6 UTF-8 bytes, 2 codepoints. -c reports bytes, -m codepoints.
+  it("-c counts bytes and -m counts codepoints from a piped UTF-8 file", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글" } });
+    const c = await env.exec("cat /in.txt | wc -c");
+    const m = await env.exec("cat /in.txt | wc -m");
+    expect(c.stdout.trim()).toBe("6");
+    expect(m.stdout.trim()).toBe("2");
+  });
+});

--- a/packages/just-bash/src/commands/xan/csv.ts
+++ b/packages/just-bash/src/commands/xan/csv.ts
@@ -3,6 +3,7 @@
  */
 
 import Papa from "papaparse";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 
 export interface CsvRow {
@@ -87,8 +88,9 @@ export async function readCsvInput(
   const file = args.find((a) => !a.startsWith("-"));
   let input: string;
 
+  // CSV is text; decode bytes so multibyte fields aren't split mid-codepoint.
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBytesToUtf8(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -4,11 +4,7 @@
  */
 
 import Papa from "papaparse";
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import {
   type CsvData,
@@ -37,14 +33,11 @@ export async function cmdTranspose(
     // Just transpose headers to single column
     const newHeaders = ["column"];
     const newData: CsvData = headers.map((h) => ({ column: h }));
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(
-        encodeUtf8ToBytes(formatCsv(newHeaders, newData)),
-      ),
+      stdout: formatCsv(newHeaders, newData),
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   }
 
@@ -67,12 +60,11 @@ export async function cmdTranspose(
     newData.push(newRow);
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(newHeaders, newData))),
+    stdout: formatCsv(newHeaders, newData),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -114,12 +106,11 @@ export async function cmdShuffle(
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, shuffled))),
+    stdout: formatCsv(headers, shuffled),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -193,14 +184,11 @@ export async function cmdFixlengths(
 
   // Output as CSV
   const output = Papa.unparse(fixed);
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(
-      encodeUtf8ToBytes(`${output.replace(/\r\n/g, "\n")}\n`),
-    ),
+    stdout: `${output.replace(/\r\n/g, "\n")}\n`,
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -273,26 +261,22 @@ export async function cmdSplit(
       const filePath = ctx.fs.resolvePath(outPath, fileName);
       await ctx.fs.writeFile(filePath, formatCsv(headers, nonEmptyParts[i]));
     }
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(
-        encodeUtf8ToBytes(`Split into ${nonEmptyParts.length} parts\n`),
-      ),
+      stdout: `Split into ${nonEmptyParts.length} parts\n`,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   } catch {
     // If we can't write files, output info about what would be created
     const output = nonEmptyParts
       .map((p, i) => `Part ${i + 1}: ${p.length} rows`)
       .join("\n");
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(`${output}\n`)),
+      stdout: `${output}\n`,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   }
 }
@@ -406,28 +390,22 @@ export async function cmdPartition(
       const filePath = ctx.fs.resolvePath(outPath, fileName);
       await ctx.fs.writeFile(filePath, formatCsv(headers, rows));
     }
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(
-        encodeUtf8ToBytes(
-          `Partitioned into ${groups.size} files by '${column}'\n`,
-        ),
-      ),
+      stdout: `Partitioned into ${groups.size} files by '${column}'\n`,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   } catch {
     // Output summary if can't write
     const output = Array.from(groups.entries())
       .map(([val, rows]) => `${val}: ${rows.length} rows`)
       .join("\n");
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(`${output}\n`)),
+      stdout: `${output}\n`,
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   }
 }
@@ -478,12 +456,11 @@ async function cmdToJson(
 
   // Real xan always pretty prints
   const json = JSON.stringify(data, null, 2);
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(`${json}\n`)),
+    stdout: `${json}\n`,
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -564,12 +541,11 @@ async function cmdFromJson(
     }
 
     if (data.length === 0) {
-      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+      // xan emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes("\n")),
+        stdout: "\n",
         stderr: "",
         exitCode: 0,
-        stdoutEncoding: "binary",
       };
     }
 
@@ -588,27 +564,21 @@ async function cmdFromJson(
         }
         return obj;
       });
-      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+      // xan emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(
-          encodeUtf8ToBytes(formatCsv(headers as string[], csvData)),
-        ),
+        stdout: formatCsv(headers as string[], csvData),
         stderr: "",
         exitCode: 0,
-        stdoutEncoding: "binary",
       };
     }
 
     // Array of objects - real xan outputs columns in alphabetical order
     const headers = Object.keys(data[0] as object).sort();
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(
-        encodeUtf8ToBytes(formatCsv(headers, data as CsvData)),
-      ),
+      stdout: formatCsv(headers, data as CsvData),
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   } catch {
     return {

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -4,7 +4,11 @@
  */
 
 import Papa from "papaparse";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import {
   type CsvData,
@@ -33,7 +37,15 @@ export async function cmdTranspose(
     // Just transpose headers to single column
     const newHeaders = ["column"];
     const newData: CsvData = headers.map((h) => ({ column: h }));
-    return { stdout: formatCsv(newHeaders, newData), stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(
+        encodeUtf8ToBytes(formatCsv(newHeaders, newData)),
+      ),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   }
 
   // New headers: first column name + row indices or first column values
@@ -55,7 +67,13 @@ export async function cmdTranspose(
     newData.push(newRow);
   }
 
-  return { stdout: formatCsv(newHeaders, newData), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(newHeaders, newData))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -96,7 +114,13 @@ export async function cmdShuffle(
     [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
   }
 
-  return { stdout: formatCsv(headers, shuffled), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, shuffled))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -169,10 +193,14 @@ export async function cmdFixlengths(
 
   // Output as CSV
   const output = Papa.unparse(fixed);
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
   return {
-    stdout: `${output.replace(/\r\n/g, "\n")}\n`,
+    stdout: latin1FromBytes(
+      encodeUtf8ToBytes(`${output.replace(/\r\n/g, "\n")}\n`),
+    ),
     stderr: "",
     exitCode: 0,
+    stdoutEncoding: "binary",
   };
 }
 
@@ -245,17 +273,27 @@ export async function cmdSplit(
       const filePath = ctx.fs.resolvePath(outPath, fileName);
       await ctx.fs.writeFile(filePath, formatCsv(headers, nonEmptyParts[i]));
     }
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
-      stdout: `Split into ${nonEmptyParts.length} parts\n`,
+      stdout: latin1FromBytes(
+        encodeUtf8ToBytes(`Split into ${nonEmptyParts.length} parts\n`),
+      ),
       stderr: "",
       exitCode: 0,
+      stdoutEncoding: "binary",
     };
   } catch {
     // If we can't write files, output info about what would be created
     const output = nonEmptyParts
       .map((p, i) => `Part ${i + 1}: ${p.length} rows`)
       .join("\n");
-    return { stdout: `${output}\n`, stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(`${output}\n`)),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   }
 }
 
@@ -368,17 +406,29 @@ export async function cmdPartition(
       const filePath = ctx.fs.resolvePath(outPath, fileName);
       await ctx.fs.writeFile(filePath, formatCsv(headers, rows));
     }
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
-      stdout: `Partitioned into ${groups.size} files by '${column}'\n`,
+      stdout: latin1FromBytes(
+        encodeUtf8ToBytes(
+          `Partitioned into ${groups.size} files by '${column}'\n`,
+        ),
+      ),
       stderr: "",
       exitCode: 0,
+      stdoutEncoding: "binary",
     };
   } catch {
     // Output summary if can't write
     const output = Array.from(groups.entries())
       .map(([val, rows]) => `${val}: ${rows.length} rows`)
       .join("\n");
-    return { stdout: `${output}\n`, stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(`${output}\n`)),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   }
 }
 
@@ -428,7 +478,13 @@ async function cmdToJson(
 
   // Real xan always pretty prints
   const json = JSON.stringify(data, null, 2);
-  return { stdout: `${json}\n`, stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(`${json}\n`)),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -508,7 +564,13 @@ async function cmdFromJson(
     }
 
     if (data.length === 0) {
-      return { stdout: "\n", stderr: "", exitCode: 0 };
+      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+      return {
+        stdout: latin1FromBytes(encodeUtf8ToBytes("\n")),
+        stderr: "",
+        exitCode: 0,
+        stdoutEncoding: "binary",
+      };
     }
 
     // Check if array of arrays or array of objects
@@ -526,19 +588,27 @@ async function cmdFromJson(
         }
         return obj;
       });
+      // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
       return {
-        stdout: formatCsv(headers as string[], csvData),
+        stdout: latin1FromBytes(
+          encodeUtf8ToBytes(formatCsv(headers as string[], csvData)),
+        ),
         stderr: "",
         exitCode: 0,
+        stdoutEncoding: "binary",
       };
     }
 
     // Array of objects - real xan outputs columns in alphabetical order
     const headers = Object.keys(data[0] as object).sort();
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
     return {
-      stdout: formatCsv(headers, data as CsvData),
+      stdout: latin1FromBytes(
+        encodeUtf8ToBytes(formatCsv(headers, data as CsvData)),
+      ),
       stderr: "",
       exitCode: 0,
+      stdoutEncoding: "binary",
     };
   } catch {
     return {

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -4,6 +4,7 @@
  */
 
 import Papa from "papaparse";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import {
   type CsvData,
@@ -128,7 +129,7 @@ export async function cmdFixlengths(
   let input: string;
 
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBytesToUtf8(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);
@@ -482,7 +483,7 @@ async function cmdFromJson(
   let input: string;
 
   if (!file || file === "-") {
-    input = ctx.stdin;
+    input = decodeBytesToUtf8(ctx.stdin);
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/xan/xan-simple.ts
+++ b/packages/just-bash/src/commands/xan/xan-simple.ts
@@ -2,6 +2,7 @@
  * Simple commands: behead, sample, cat, search, flatmap, fmt
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { createUserRegex, type RegexLike } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { readFiles } from "../../utils/file-reader.js";
@@ -162,7 +163,7 @@ export async function cmdCat(
   let allHeaders: string[] = [];
 
   for (const { content } of result.files) {
-    const { headers, data } = parseCsv(content);
+    const { headers, data } = parseCsv(decodeBytesToUtf8(content));
     allFiles.push({ headers, data });
 
     // Collect all unique headers

--- a/packages/just-bash/src/commands/xan/xan-simple.ts
+++ b/packages/just-bash/src/commands/xan/xan-simple.ts
@@ -2,7 +2,11 @@
  * Simple commands: behead, sample, cat, search, flatmap, fmt
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { createUserRegex, type RegexLike } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { readFiles } from "../../utils/file-reader.js";
@@ -43,7 +47,13 @@ export async function cmdBehead(
     rows.map((row) => row.map((v) => formatValue(v)).join(",")).join("\n") +
     "\n";
 
-  return { stdout: output, stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 function formatValue(v: unknown): string {
@@ -95,7 +105,13 @@ export async function cmdSample(
   if (error) return error;
 
   if (data.length <= num) {
-    return { stdout: formatCsv(headers, data), stderr: "", exitCode: 0 };
+    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    return {
+      stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, data))),
+      stderr: "",
+      exitCode: 0,
+      stdoutEncoding: "binary",
+    };
   }
 
   // Simple seeded random (LCG)
@@ -117,7 +133,13 @@ export async function cmdSample(
     .sort((a, b) => a - b)
     .map((i) => data[i]);
 
-  return { stdout: formatCsv(headers, sampled), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, sampled))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -201,7 +223,13 @@ export async function cmdCat(
     }
   }
 
-  return { stdout: formatCsv(allHeaders, allData), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(allHeaders, allData))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -272,7 +300,13 @@ export async function cmdSearch(
     return invert ? !matches : matches;
   });
 
-  return { stdout: formatCsv(headers, filtered), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, filtered))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**
@@ -356,7 +390,13 @@ export async function cmdFlatmap(
     }
   }
 
-  return { stdout: formatCsv(newHeaders, newData), stderr: "", exitCode: 0 };
+  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  return {
+    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(newHeaders, newData))),
+    stderr: "",
+    exitCode: 0,
+    stdoutEncoding: "binary",
+  };
 }
 
 /**

--- a/packages/just-bash/src/commands/xan/xan-simple.ts
+++ b/packages/just-bash/src/commands/xan/xan-simple.ts
@@ -2,11 +2,7 @@
  * Simple commands: behead, sample, cat, search, flatmap, fmt
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { createUserRegex, type RegexLike } from "../../regex/index.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { readFiles } from "../../utils/file-reader.js";
@@ -47,12 +43,11 @@ export async function cmdBehead(
     rows.map((row) => row.map((v) => formatValue(v)).join(",")).join("\n") +
     "\n";
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(output)),
+    stdout: output,
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -105,12 +100,11 @@ export async function cmdSample(
   if (error) return error;
 
   if (data.length <= num) {
-    // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+    // xan emits text; the pipeline handles encoding.
     return {
-      stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, data))),
+      stdout: formatCsv(headers, data),
       stderr: "",
       exitCode: 0,
-      stdoutEncoding: "binary",
     };
   }
 
@@ -133,12 +127,11 @@ export async function cmdSample(
     .sort((a, b) => a - b)
     .map((i) => data[i]);
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, sampled))),
+    stdout: formatCsv(headers, sampled),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -223,12 +216,11 @@ export async function cmdCat(
     }
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(allHeaders, allData))),
+    stdout: formatCsv(allHeaders, allData),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -300,12 +292,11 @@ export async function cmdSearch(
     return invert ? !matches : matches;
   });
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(headers, filtered))),
+    stdout: formatCsv(headers, filtered),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 
@@ -390,12 +381,11 @@ export async function cmdFlatmap(
     }
   }
 
-  // Re-encode decoded UTF-8 to a latin1 byte view so byte consumers downstream and redirects don't double-encode.
+  // xan emits text; the pipeline handles encoding.
   return {
-    stdout: latin1FromBytes(encodeUtf8ToBytes(formatCsv(newHeaders, newData))),
+    stdout: formatCsv(newHeaders, newData),
     stderr: "",
     exitCode: 0,
-    stdoutEncoding: "binary",
   };
 }
 

--- a/packages/just-bash/src/commands/xan/xan.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/xan/xan.utf8-stdin.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("xan reads UTF-8 from stdin", () => {
+  it("preserves multibyte CSV fields through a pipe", async () => {
+    const env = new Bash({
+      files: { "/in.csv": "name,city\n홍길동,서울\nAlice,Paris\n" },
+    });
+    const result = await env.exec("cat /in.csv | xan select city");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("서울");
+    expect(result.stdout).toContain("Paris");
+  });
+});

--- a/packages/just-bash/src/commands/xargs/xargs.ts
+++ b/packages/just-bash/src/commands/xargs/xargs.ts
@@ -1,3 +1,4 @@
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { shellJoinArgs } from "../../helpers/shell-quote.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
@@ -92,19 +93,22 @@ export const xargsCommand: Command = {
       command.push("echo");
     }
 
-    // Parse input
-    // Priority: -0 (null) > -d (custom delimiter) > default (whitespace)
+    // Parse input. Priority: -0 (null) > -d (custom delimiter) > default
+    // (whitespace). xargs' delimiters (`\0`, ASCII whitespace, user-provided
+    // single-byte delim) all live in the ASCII range, but the args produced
+    // are passed onward as text — decode so multibyte filenames survive.
+    const stdinText = decodeBytesToUtf8(ctx.stdin);
     let items: string[];
     if (nullSeparator) {
-      items = ctx.stdin.split("\0").filter((s) => s.length > 0);
+      items = stdinText.split("\0").filter((s) => s.length > 0);
     } else if (delimiter !== null) {
       // Custom delimiter - split on exact string
       // Strip trailing newline from input before splitting (echo adds trailing newlines)
-      const input = ctx.stdin.replace(/\n$/, "");
+      const input = stdinText.replace(/\n$/, "");
       items = input.split(delimiter).filter((s) => s.length > 0);
     } else {
       // Default: split on whitespace and trim
-      items = ctx.stdin
+      items = stdinText
         .split(/\s+/)
         .map((s) => s.trim())
         .filter((s) => s.length > 0);

--- a/packages/just-bash/src/commands/xargs/xargs.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/xargs/xargs.utf8-stdin.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("xargs reads UTF-8 from stdin", () => {
+  it("preserves multibyte items split on whitespace", async () => {
+    const env = new Bash({ files: { "/in.txt": "한글\ncafé\n漢字\n" } });
+    const result = await env.exec("cat /in.txt | xargs echo");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("한글 café 漢字\n");
+  });
+});

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -8,7 +8,11 @@
  * This is a reimplementation for the just-bash sandboxed environment.
  */
 
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  decodeBytesToUtf8,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+} from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -376,10 +380,12 @@ export const yqCommand: Command = {
           ? 1
           : 0;
 
+      // yq emits decoded YAML/JSON text; re-encode for the byte pipeline.
       return {
-        stdout: finalOutput,
+        stdout: latin1FromBytes(encodeUtf8ToBytes(finalOutput)),
         stderr: "",
         exitCode,
+        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -8,11 +8,7 @@
  * This is a reimplementation for the just-bash sandboxed environment.
  */
 
-import {
-  decodeBytesToUtf8,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-} from "../../encoding.js";
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -380,12 +376,11 @@ export const yqCommand: Command = {
           ? 1
           : 0;
 
-      // yq emits decoded YAML/JSON text; re-encode for the byte pipeline.
+      // yq emits text; the pipeline handles encoding.
       return {
-        stdout: latin1FromBytes(encodeUtf8ToBytes(finalOutput)),
+        stdout: finalOutput,
         stderr: "",
         exitCode,
-        stdoutEncoding: "binary",
       };
     } catch (e) {
       if (e instanceof SecurityViolationError) {

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -8,6 +8,7 @@
  * This is a reimplementation for the just-bash sandboxed environment.
  */
 
+import { decodeBytesToUtf8 } from "../../encoding.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import {
@@ -281,13 +282,15 @@ export const yqCommand: Command = {
       };
     }
 
-    // Read input
+    // Read input. yq parses YAML/JSON/etc — stdin bytes from a piped command
+    // arrive latin1-shaped, so decode to UTF-8 before handing to the parser.
+    // File reads use default utf8 decoding already.
     let input: string;
     let filePath: string | undefined;
     if (options.nullInput) {
       input = "";
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = ctx.stdin;
+      input = decodeBytesToUtf8(ctx.stdin);
     } else {
       try {
         const resolvedFilePath = ctx.fs.resolvePath(ctx.cwd, files[0]);

--- a/packages/just-bash/src/commands/yq/yq.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/yq/yq.utf8-stdin.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("yq reads UTF-8 from stdin", () => {
+  it("preserves multibyte string values in piped YAML", async () => {
+    const env = new Bash({
+      files: { "/in.yaml": "msg: 한글 / café / 漢字\n" },
+    });
+    const result = await env.exec("cat /in.yaml | yq '.msg'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("한글 / café / 漢字");
+  });
+});

--- a/packages/just-bash/src/custom-commands.test.ts
+++ b/packages/just-bash/src/custom-commands.test.ts
@@ -7,6 +7,7 @@ import {
   isLazyCommand,
   type LazyCommand,
 } from "./custom-commands.js";
+import { decodeBytesToUtf8, EMPTY_BYTES } from "./encoding.js";
 import type { Command } from "./types.js";
 
 describe("custom-commands", () => {
@@ -82,7 +83,7 @@ describe("custom-commands", () => {
         fs: {} as never,
         cwd: "/",
         env: new Map(),
-        stdin: "",
+        stdin: EMPTY_BYTES,
       });
       expect(loadCount).toBe(1);
       expect(result1.stdout).toBe("lazy loaded\n");
@@ -92,7 +93,7 @@ describe("custom-commands", () => {
         fs: {} as never,
         cwd: "/",
         env: new Map(),
-        stdin: "",
+        stdin: EMPTY_BYTES,
       });
       expect(loadCount).toBe(1);
       expect(result2.stdout).toBe("lazy loaded\n");
@@ -116,7 +117,8 @@ describe("custom-commands", () => {
 
     it("custom command receives stdin from pipe", async () => {
       const wordcount = defineCommand("wordcount", async (_args, ctx) => {
-        const words = ctx.stdin.trim().split(/\s+/).filter(Boolean).length;
+        const text = decodeBytesToUtf8(ctx.stdin);
+        const words = text.trim().split(/\s+/).filter(Boolean).length;
         return { stdout: `${words}\n`, stderr: "", exitCode: 0 };
       });
 
@@ -235,7 +237,7 @@ describe("custom-commands", () => {
 
     it("custom command works in pipeline with built-in commands", async () => {
       const upper = defineCommand("upper", async (_args, ctx) => ({
-        stdout: ctx.stdin.toUpperCase(),
+        stdout: decodeBytesToUtf8(ctx.stdin).toUpperCase(),
         stderr: "",
         exitCode: 0,
       }));

--- a/packages/just-bash/src/encoding-pipeline.test.ts
+++ b/packages/just-bash/src/encoding-pipeline.test.ts
@@ -1,0 +1,231 @@
+/**
+ * End-to-end regression tests for the byte/text pipeline contract.
+ *
+ * just-bash represents shell strings as JS strings, but the same string can
+ * be either JS Unicode text (echo, printf, sed, jq output) or a latin1 byte
+ * buffer (cat, gzip, tar output). The pipeline + redirect layer must treat
+ * those shapes differently — text gets UTF-8 encoded once on handoff so
+ * byte consumers see real UTF-8 bytes, byte buffers pass through verbatim.
+ *
+ * Each producer marks its `stdout` shape with `stdoutKind: "text" | "bytes"`
+ * (or the legacy `stdoutEncoding: "binary"`). The pipe glue and redirects
+ * consult that metadata; they never inspect characters.
+ *
+ * These tests fence in the cases that fall out of that contract — adding a
+ * new pipeline stage or a new producer that breaks any of them is a sign
+ * the contract has been violated.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "./Bash.js";
+
+describe("byte/text pipeline contract", () => {
+  describe("text → byte consumer", () => {
+    it("`echo 한 | wc -c` reports 4 bytes (3 UTF-8 + newline)", async () => {
+      const env = new Bash();
+      const r = await env.exec("echo 한 | wc -c");
+      expect(r.stdout.trim()).toBe("4");
+    });
+
+    it("`echo Ü | wc -c` reports 3 bytes (2 UTF-8 + newline)", async () => {
+      const env = new Bash();
+      const r = await env.exec("echo Ü | wc -c");
+      expect(r.stdout.trim()).toBe("3");
+    });
+
+    it("`echo abc | wc -c` reports 4 bytes (3 ASCII + newline)", async () => {
+      const env = new Bash();
+      const r = await env.exec("echo abc | wc -c");
+      expect(r.stdout.trim()).toBe("4");
+    });
+  });
+
+  describe("byte producer → byte consumer (no double encoding)", () => {
+    it("`cat /utf8 | wc -c` reports the original byte count", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글" } });
+      const r = await env.exec("cat /in.txt | wc -c");
+      expect(r.stdout.trim()).toBe("6");
+    });
+
+    it("`cat /utf8 | sed s/x/y/ | wc -c` keeps the byte count", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글" } });
+      const r = await env.exec("cat /in.txt | sed 's/x/y/' | wc -c");
+      expect(r.stdout.trim()).toBe("6");
+    });
+
+    it("`cat /utf8 | rev | base64` encodes the reversed UTF-8 bytes", async () => {
+      const env = new Bash({ files: { "/in.txt": "한" } });
+      const r = await env.exec("cat /in.txt | rev | base64");
+      // base64 of UTF-8 bytes 0xED 0x95 0x9C is "7ZWc".
+      expect(r.stdout.trim()).toBe("7ZWc");
+    });
+  });
+
+  describe("text → file redirect (UTF-8 write)", () => {
+    it("`echo café > /out` writes valid UTF-8", async () => {
+      const env = new Bash();
+      await env.exec("echo café > /out.txt");
+      const file = await env.fs.readFileBuffer("/out.txt");
+      expect(new TextDecoder().decode(file)).toBe("café\n");
+    });
+
+    it("redirect encoding picks utf8 for unmarked text stdout regardless of where the first non-ASCII byte lands", async () => {
+      // The redirect layer must not pick its encoding by sampling the
+      // first 8 KiB of the content. A text-emitting command (sed,
+      // grep, jq, ...) returns text without `stdoutKind`; its long
+      // mostly-ASCII output may have its first non-ASCII codepoint past
+      // the sample window, and a content-based heuristic would mis-
+      // classify the prefix as ASCII / "binary" and write each later
+      // codepoint truncated to its low byte. Unmarked stdout is
+      // unconditionally text and gets UTF-8 encoded by the writer.
+      const env = new Bash();
+      const longAscii = "x".repeat(8200);
+      await env.exec(`printf '%s\\n' '${longAscii}Ü' | sed 's/^//' > /out.txt`);
+      const file = await env.fs.readFileBuffer("/out.txt");
+      expect(new TextDecoder().decode(file)).toBe(`${longAscii}Ü\n`);
+    });
+  });
+
+  describe("byte → file redirect (binary write)", () => {
+    it("`cat /utf8 > /out` round-trips bytes verbatim", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글" } });
+      await env.exec("cat /in.txt > /out.txt");
+      const a = await env.fs.readFileBuffer("/in.txt");
+      const b = await env.fs.readFileBuffer("/out.txt");
+      expect(Array.from(b)).toEqual(Array.from(a));
+    });
+
+    it("non-UTF-8 binary file round-trips through cat | cat | cat", async () => {
+      const env = new Bash({
+        files: { "/binary.bin": new Uint8Array([0x80, 0xff, 0x00, 0x90]) },
+      });
+      await env.exec("cat /binary.bin | cat | cat > /out.bin");
+      const out = await env.fs.readFileBuffer("/out.bin");
+      expect(Array.from(out)).toEqual([0x80, 0xff, 0x00, 0x90]);
+    });
+  });
+
+  describe("tee writes byte-identical output", () => {
+    it("piped UTF-8 bytes survive tee verbatim", async () => {
+      const env = new Bash({ files: { "/in.txt": "한글 / café / 漢字" } });
+      const r = await env.exec("cat /in.txt | tee /out.txt > /dev/null");
+      expect(r.exitCode).toBe(0);
+      const a = await env.fs.readFileBuffer("/in.txt");
+      const b = await env.fs.readFileBuffer("/out.txt");
+      expect(Array.from(b)).toEqual(Array.from(a));
+    });
+  });
+
+  describe("here-docs / here-strings → byte consumer", () => {
+    it("heredoc with non-ASCII text pipes as UTF-8 bytes", async () => {
+      const env = new Bash();
+      const r = await env.exec(`wc -c <<EOF
+한
+EOF`);
+      // "한\n" = 3 UTF-8 bytes + 1 newline = 4 bytes.
+      expect(r.stdout.trim()).toBe("4");
+    });
+
+    it("here-string with non-ASCII text pipes as UTF-8 bytes", async () => {
+      const env = new Bash();
+      const r = await env.exec(`wc -c <<< "한"`);
+      expect(r.stdout.trim()).toBe("4");
+    });
+  });
+
+  describe("`bash -c`, sh, functions, groups, subshells preserve stdin", () => {
+    it("bash -c inherits piped stdin and forwards it to byte consumers", async () => {
+      const env = new Bash();
+      const r = await env.exec(`echo 한 | bash -c 'wc -c'`);
+      expect(r.stdout.trim()).toBe("4");
+    });
+
+    it("function call sees the parent's stdin in byte form", async () => {
+      const env = new Bash();
+      const r = await env.exec(
+        `f() { wc -c; }
+echo 한 | f`,
+      );
+      expect(r.stdout.trim()).toBe("4");
+    });
+
+    it("group command preserves piped stdin", async () => {
+      const env = new Bash();
+      const r = await env.exec("echo 한 | { wc -c; }");
+      expect(r.stdout.trim()).toBe("4");
+    });
+
+    it("subshell preserves piped stdin", async () => {
+      const env = new Bash();
+      const r = await env.exec("echo 한 | (wc -c)");
+      expect(r.stdout.trim()).toBe("4");
+    });
+  });
+
+  describe("custom commands", () => {
+    it("text-emitting custom command pipes correctly without setting flags", async () => {
+      const { defineCommand } = await import("./custom-commands.js");
+      const greet = defineCommand("greet", async () => ({
+        stdout: "안녕\n",
+        stderr: "",
+        exitCode: 0,
+      }));
+      const env = new Bash({ customCommands: [greet] });
+      const r = await env.exec("greet | wc -c");
+      // "안녕\n" = 7 UTF-8 bytes (3 + 3 + 1).
+      expect(r.stdout.trim()).toBe("7");
+    });
+
+    it("byte-emitting custom command pipes without double encoding", async () => {
+      const { bytesOutput, encodeUtf8ToBytes } = await import("./encoding.js");
+      const { defineCommand } = await import("./custom-commands.js");
+      const emitBytes = defineCommand("emit-bytes", async () => ({
+        ...bytesOutput(encodeUtf8ToBytes("안녕\n")),
+        stderr: "",
+        exitCode: 0,
+      }));
+      const env = new Bash({ customCommands: [emitBytes] });
+      const r = await env.exec("emit-bytes | wc -c");
+      expect(r.stdout.trim()).toBe("7");
+    });
+  });
+
+  describe("Bash.exec({ stdin })", () => {
+    it("text stdin (default) reaches byte consumers as UTF-8 bytes", async () => {
+      const env = new Bash();
+      const r = await env.exec("wc -c", { stdin: "한" });
+      // No trailing newline in the input.
+      expect(r.stdout.trim()).toBe("3");
+    });
+
+    it("byte stdin (stdinKind: 'bytes') is forwarded verbatim", async () => {
+      const env = new Bash();
+      // 4 bytes: 0x00, 0x80, 0xFF, 0x90 (not valid UTF-8).
+      const raw = "\x00\x80\xff\x90";
+      const r = await env.exec("wc -c", { stdin: raw, stdinKind: "bytes" });
+      expect(r.stdout.trim()).toBe("4");
+    });
+  });
+
+  describe("public encoding exports", () => {
+    // The byte/text helpers are part of the package's public API.
+    // Custom-command authors and downstream tools import them by name;
+    // removing any of these names is a breaking change.
+    it("exports the canonical helpers from the package entry", async () => {
+      const mod = (await import("./index.js")) as Record<string, unknown>;
+      for (const name of [
+        "decodeBytesToUtf8",
+        "encodeUtf8ToBytes",
+        "latin1FromBytes",
+        "unsafeBytesFromLatin1",
+        "stdoutKind",
+        "stdoutAsBytes",
+        "textOutput",
+        "bytesOutput",
+        "EMPTY_BYTES",
+      ]) {
+        const expected = name === "EMPTY_BYTES" ? "string" : "function";
+        expect({ [name]: typeof mod[name] }).toEqual({ [name]: expected });
+      }
+    });
+  });
+});

--- a/packages/just-bash/src/encoding.fs-fallback.test.ts
+++ b/packages/just-bash/src/encoding.fs-fallback.test.ts
@@ -1,0 +1,62 @@
+/**
+ * `readFileBytes` is optional on `IFileSystem` — external implementations
+ * predating this method must keep working. The `readBytesFrom` helper
+ * detects the gap and falls back to `readFileBuffer` + manual conversion.
+ * Without this back-compat, common commands (cat, jq, wc, sort, ...) would
+ * throw `TypeError: readFileBytes is not a function` for any user-supplied
+ * filesystem written before the method existed.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "./Bash.js";
+import { type ByteString, bytesFromUint8Array } from "./encoding.js";
+import { InMemoryFs } from "./fs/in-memory-fs/in-memory-fs.js";
+import type { IFileSystem } from "./fs/interface.js";
+
+/**
+ * Wrap an InMemoryFs in a Proxy that hides `readFileBytes`, forcing every
+ * caller down the fallback path. Delegates everything else.
+ */
+function createLegacyFs(seed: Record<string, string>): IFileSystem {
+  const inner = new InMemoryFs(seed);
+  return new Proxy(inner, {
+    get(target, prop, receiver) {
+      if (prop === "readFileBytes") return undefined;
+      const value = Reflect.get(target, prop, receiver);
+      // Methods need to keep their `this` bound to the inner instance.
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+    has(target, prop) {
+      if (prop === "readFileBytes") return false;
+      return Reflect.has(target, prop);
+    },
+  }) as IFileSystem;
+}
+
+describe("readFileBytes back-compat fallback", () => {
+  it("commands work against a custom IFileSystem missing readFileBytes", async () => {
+    const fs = createLegacyFs({ "/in.txt": "한글" });
+    expect(typeof fs.readFileBytes).toBe("undefined");
+    // Sanity: proxy still resolves and reads files.
+    const direct = await fs.readFileBuffer(fs.resolvePath("/", "/in.txt"));
+    expect(new TextDecoder().decode(direct)).toBe("한글");
+
+    const bash = new Bash({ fs });
+    // cat goes through readFiles → readBytesFrom → falls back to
+    // readFileBuffer (which is present), then converts to ByteString.
+    const r = await bash.exec("cat /in.txt");
+    expect({
+      stdout: r.stdout,
+      stderr: r.stderr,
+      exitCode: r.exitCode,
+    }).toEqual({ stdout: "한글", stderr: "", exitCode: 0 });
+  });
+
+  it("bytesFromUint8Array round-trips bytes verbatim", () => {
+    const buf = new Uint8Array([0x00, 0x7f, 0x80, 0xc3, 0xa9, 0xff]);
+    const s: ByteString = bytesFromUint8Array(buf);
+    const back = Uint8Array.from(s as unknown as string, (c) =>
+      c.charCodeAt(0),
+    );
+    expect(Array.from(back)).toEqual(Array.from(buf));
+  });
+});

--- a/packages/just-bash/src/encoding.ts
+++ b/packages/just-bash/src/encoding.ts
@@ -92,38 +92,6 @@ export function encodeUtf8ToBytes(s: string): ByteString {
   return out as unknown as ByteString;
 }
 
-/**
- * Coerce a string of unknown shape into a `ByteString` for the pipe
- * boundary. The pipe contract is "every command's stdin is a byte
- * buffer", but two upstream shapes both look like JS strings:
- *
- *   - real Unicode text with codepoints (echo, printf, heredocs,
- *     here-strings, command substitution — anything from bash's
- *     string-as-codepoints world). UTF-8 encode it so byte consumers
- *     downstream (`wc -c`, `base64`, `md5sum`) and binary writes see
- *     real UTF-8 bytes instead of code units.
- *   - a latin1-shaped byte buffer that's already passed through this
- *     pipeline (cat, gzip, sed/grep/jq after they re-encoded). Pipeline
- *     glue distinguishes this case via `stdoutEncoding: "binary"` and
- *     skips the call here entirely; if a producer forgets that flag,
- *     the encode here interprets each char as a codepoint and may
- *     double-encode high bytes — that's the producer's bug.
- *
- * Caveat: `echo -en '\0377'` produces a JS string with codepoint 0xFF
- * intending it to be a single raw byte. We can't tell that intent apart
- * from a real Latin-1-supplement codepoint, so `\0377` gets UTF-8
- * encoded to `0xC3 0xBF` here — a known divergence from real bash for
- * raw octal/hex byte escapes piped to byte consumers, separate from the
- * UTF-8 byte-length contract upheld for everything else.
- */
-export function bytesFromPipe(s: string): ByteString {
-  if (!s) return s as unknown as ByteString;
-  for (let i = 0; i < s.length; i++) {
-    if (s.charCodeAt(i) > 0x7f) return encodeUtf8ToBytes(s);
-  }
-  return s as unknown as ByteString;
-}
-
 /** The empty `ByteString`. */
 export const EMPTY_BYTES: ByteString = "" as unknown as ByteString;
 
@@ -157,4 +125,77 @@ export async function readBytesFrom(
     return fs.readFileBytes(path);
   }
   return bytesFromUint8Array(await fs.readFileBuffer(path));
+}
+
+// ---------------------------------------------------------------------------
+// Stdout shape helpers.
+//
+// The pipeline carries `ExecResult.stdout` as a `string` for back-compat,
+// but the same string can be either JS-Unicode text or a latin1-shaped byte
+// buffer. The pipe glue and redirection layer must treat those shapes
+// differently — they decide based on `stdoutKind` (preferred) or the legacy
+// `stdoutEncoding` flag, never by inspecting characters.
+// ---------------------------------------------------------------------------
+
+/** Either-or shape of a command's `stdout`. */
+export type OutputKind = "text" | "bytes";
+
+/**
+ * Read the explicit shape of a command's stdout. Falls back to the legacy
+ * `stdoutEncoding === "binary"` flag for results produced before the
+ * `stdoutKind` field existed; defaults to `"text"` otherwise.
+ */
+export function stdoutKind(result: {
+  stdoutKind?: OutputKind;
+  stdoutEncoding?: "binary";
+}): OutputKind {
+  if (result.stdoutKind) return result.stdoutKind;
+  return result.stdoutEncoding === "binary" ? "bytes" : "text";
+}
+
+/**
+ * Coerce a command's stdout to a `ByteString` for the byte-shaped pipe.
+ * Text gets UTF-8 encoded once (codepoints → bytes); bytes pass through.
+ */
+export function stdoutAsBytes(result: {
+  stdout: string;
+  stdoutKind?: OutputKind;
+  stdoutEncoding?: "binary";
+}): ByteString {
+  return stdoutKind(result) === "bytes"
+    ? unsafeBytesFromLatin1(result.stdout)
+    : encodeUtf8ToBytes(result.stdout);
+}
+
+/**
+ * Build an `ExecResult`-shaped object whose stdout is decoded text. Sets
+ * `stdoutKind: "text"` so the pipe knows to UTF-8 encode it on handoff
+ * and redirects know to write it as UTF-8. Use for command authors that
+ * decode their input and emit Unicode text — they no longer have to
+ * manually re-encode for downstream byte consumers.
+ */
+export function textOutput(data: string): {
+  stdout: string;
+  stdoutKind: "text";
+} {
+  return { stdout: data, stdoutKind: "text" };
+}
+
+/**
+ * Build an `ExecResult`-shaped object whose stdout is a latin1 byte view.
+ * Sets both `stdoutKind: "bytes"` (new contract) and `stdoutEncoding:
+ * "binary"` (legacy alias) so older code paths keep working through the
+ * migration. Use for command authors that emit raw bytes (cat, gzip,
+ * tar, base64 -d, ...).
+ */
+export function bytesOutput(data: ByteString): {
+  stdout: string;
+  stdoutKind: "bytes";
+  stdoutEncoding: "binary";
+} {
+  return {
+    stdout: latin1FromBytes(data),
+    stdoutKind: "bytes",
+    stdoutEncoding: "binary",
+  };
 }

--- a/packages/just-bash/src/encoding.ts
+++ b/packages/just-bash/src/encoding.ts
@@ -79,24 +79,82 @@ export function decodeBytesToUtf8(b: ByteString): string {
 }
 
 /**
- * Re-encode UTF-8 text into a `ByteString`. Inverse of `decodeBytesToUtf8`.
- * Use when a text-processing command emits its result back into the pipeline.
+ * UTF-8 encode `s` (treating every char as a Unicode codepoint) into a
+ * `ByteString`. Use at sites that *know* their input is decoded Unicode
+ * text and need to emit it back as bytes — typically the inverse of an
+ * earlier `decodeBytesToUtf8` call inside the same command.
  */
 export function encodeUtf8ToBytes(s: string): ByteString {
-  let needsEncode = false;
-  for (let i = 0; i < s.length; i++) {
-    if (s.charCodeAt(i) > 0x7f) {
-      needsEncode = true;
-      break;
-    }
-  }
-  if (!needsEncode) return s as unknown as ByteString;
-
+  if (!s) return s as unknown as ByteString;
   const bytes = utf8Encoder.encode(s);
   let out = "";
   for (let i = 0; i < bytes.length; i++) out += String.fromCharCode(bytes[i]);
   return out as unknown as ByteString;
 }
 
+/**
+ * Coerce a string of unknown shape into a `ByteString` for the pipe
+ * boundary. The pipe contract is "every command's stdin is a byte
+ * buffer", but two upstream shapes both look like JS strings:
+ *
+ *   - real Unicode text with codepoints (echo, printf, heredocs,
+ *     here-strings, command substitution — anything from bash's
+ *     string-as-codepoints world). UTF-8 encode it so byte consumers
+ *     downstream (`wc -c`, `base64`, `md5sum`) and binary writes see
+ *     real UTF-8 bytes instead of code units.
+ *   - a latin1-shaped byte buffer that's already passed through this
+ *     pipeline (cat, gzip, sed/grep/jq after they re-encoded). Pipeline
+ *     glue distinguishes this case via `stdoutEncoding: "binary"` and
+ *     skips the call here entirely; if a producer forgets that flag,
+ *     the encode here interprets each char as a codepoint and may
+ *     double-encode high bytes — that's the producer's bug.
+ *
+ * Caveat: `echo -en '\0377'` produces a JS string with codepoint 0xFF
+ * intending it to be a single raw byte. We can't tell that intent apart
+ * from a real Latin-1-supplement codepoint, so `\0377` gets UTF-8
+ * encoded to `0xC3 0xBF` here — a known divergence from real bash for
+ * raw octal/hex byte escapes piped to byte consumers, separate from the
+ * UTF-8 byte-length contract upheld for everything else.
+ */
+export function bytesFromPipe(s: string): ByteString {
+  if (!s) return s as unknown as ByteString;
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 0x7f) return encodeUtf8ToBytes(s);
+  }
+  return s as unknown as ByteString;
+}
+
 /** The empty `ByteString`. */
 export const EMPTY_BYTES: ByteString = "" as unknown as ByteString;
+
+/**
+ * Convert a `Uint8Array` to a `ByteString`. Each byte becomes one char.
+ * The reverse is `Uint8Array.from(latin1FromBytes(b), (c) => c.charCodeAt(0))`.
+ */
+export function bytesFromUint8Array(buf: Uint8Array): ByteString {
+  let out = "";
+  for (let i = 0; i < buf.length; i++) out += String.fromCharCode(buf[i]);
+  return out as unknown as ByteString;
+}
+
+/**
+ * Read a file's raw bytes from any `IFileSystem`. Prefers the optional
+ * {@link IFileSystem.readFileBytes} method (built-in filesystems implement
+ * it natively), falling back to {@link IFileSystem.readFileBuffer} +
+ * conversion for external/custom filesystems written before
+ * `readFileBytes` existed. Use this from internal commands instead of
+ * calling `fs.readFileBytes` directly so user-supplied filesystems keep
+ * working.
+ */
+export async function readBytesFrom(
+  fs: {
+    readFileBytes?(path: string): Promise<ByteString>;
+    readFileBuffer(path: string): Promise<Uint8Array>;
+  },
+  path: string,
+): Promise<ByteString> {
+  if (typeof fs.readFileBytes === "function") {
+    return fs.readFileBytes(path);
+  }
+  return bytesFromUint8Array(await fs.readFileBuffer(path));
+}

--- a/packages/just-bash/src/encoding.ts
+++ b/packages/just-bash/src/encoding.ts
@@ -1,0 +1,102 @@
+/**
+ * Byte/text boundary types for the shell pipeline.
+ *
+ * Shell pipes carry bytes, not text. Internally we represent a byte buffer as
+ * a JS string where `s.charCodeAt(i)` is the i-th byte (0–255), the same
+ * convention as `Buffer.from(s, "latin1")`. That's a space-cheap byte buffer,
+ * but the type system can't tell it apart from a real `string`, and command
+ * authors keep writing `ctx.stdin.split(...)` / `RegExp.test(ctx.stdin)` /
+ * `JSON.parse(ctx.stdin)` over data that is actually UTF-8 packed in latin1.
+ * The result is silent mojibake — every multibyte codepoint gets misread as
+ * several latin1 chars, then re-encoded as UTF-8 on the way out.
+ *
+ * `ByteString` is opaque (deliberately not assignable to/from `string`) so
+ * you cannot accidentally call string methods on it. The only ways out are
+ * `latin1FromBytes` (passthrough — stay byte-clean) and `decodeBytesToUtf8`
+ * (decode — process as text). Pick one explicitly per call site.
+ */
+
+declare const __byteString: unique symbol;
+export interface ByteString {
+  readonly [__byteString]: true;
+}
+
+const strictUtf8Decoder = new TextDecoder("utf-8", { fatal: true });
+const utf8Encoder = new TextEncoder();
+
+/**
+ * Tag a latin1 byte buffer (each char = one byte) as a `ByteString`. Use at
+ * the pipeline edge: `cmdCtx.stdin = unsafeBytesFromLatin1(prevStdout)`.
+ * Avoid inside command implementations.
+ */
+export function unsafeBytesFromLatin1(s: string): ByteString {
+  return s as unknown as ByteString;
+}
+
+/**
+ * Reveal the underlying latin1 byte buffer. Use when a command intentionally
+ * forwards bytes unchanged (cat, head, tee, base64 -d, gzip, ...). Calling
+ * regex / parse / `.length-as-chars` on the result re-introduces the
+ * mojibake bug — if you need text, use `decodeBytesToUtf8` instead.
+ */
+export function latin1FromBytes(b: ByteString): string {
+  return b as unknown as string;
+}
+
+/**
+ * Decode a `ByteString` as UTF-8. Use when a command interprets stdin as
+ * text (jq, sed, grep, awk, ...). Returns proper Unicode where multibyte
+ * codepoints occupy a single JS char, so regex and parsers work correctly.
+ *
+ * Falls back to the raw latin1 view if the bytes are not valid UTF-8 (e.g.
+ * a binary stream piped into grep). Callers that want hard failure on
+ * invalid UTF-8 should encode + decode manually with `{ fatal: true }`.
+ */
+export function decodeBytesToUtf8(b: ByteString): string {
+  const s = b as unknown as string;
+  if (!s) return s;
+
+  let hasHighByte = false;
+  for (let i = 0; i < s.length; i++) {
+    const code = s.charCodeAt(i);
+    if (code > 0xff) {
+      // Already a real Unicode string — caller passed something that wasn't
+      // produced by the pipeline (e.g. a heredoc literal). Nothing to decode.
+      return s;
+    }
+    if (code > 0x7f) hasHighByte = true;
+  }
+  if (!hasHighByte) return s;
+
+  const bytes = new Uint8Array(s.length);
+  for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+
+  try {
+    return strictUtf8Decoder.decode(bytes);
+  } catch {
+    return s;
+  }
+}
+
+/**
+ * Re-encode UTF-8 text into a `ByteString`. Inverse of `decodeBytesToUtf8`.
+ * Use when a text-processing command emits its result back into the pipeline.
+ */
+export function encodeUtf8ToBytes(s: string): ByteString {
+  let needsEncode = false;
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) > 0x7f) {
+      needsEncode = true;
+      break;
+    }
+  }
+  if (!needsEncode) return s as unknown as ByteString;
+
+  const bytes = utf8Encoder.encode(s);
+  let out = "";
+  for (let i = 0; i < bytes.length; i++) out += String.fromCharCode(bytes[i]);
+  return out as unknown as ByteString;
+}
+
+/** The empty `ByteString`. */
+export const EMPTY_BYTES: ByteString = "" as unknown as ByteString;

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -1,3 +1,4 @@
+import { type ByteString, unsafeBytesFromLatin1 } from "../../encoding.js";
 import { fromBuffer, getEncoding, toBuffer } from "../encoding.js";
 import type {
   BufferEncoding,
@@ -183,6 +184,11 @@ export class InMemoryFs implements IFileSystem {
     const buffer = await this.readFileBuffer(path);
     const encoding = getEncoding(options);
     return fromBuffer(buffer, encoding);
+  }
+
+  async readFileBytes(path: string): Promise<ByteString> {
+    const buffer = await this.readFileBuffer(path);
+    return unsafeBytesFromLatin1(fromBuffer(buffer, "binary"));
   }
 
   async readFileBuffer(path: string): Promise<Uint8Array> {

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -1,3 +1,5 @@
+import type { ByteString } from "../encoding.js";
+
 /**
  * Supported buffer encodings
  */
@@ -116,13 +118,29 @@ export interface CpOptions {
 export interface IFileSystem {
   // Note: Sync method are not supported and must not be added.
   /**
-   * Read the contents of a file as a string (default: utf8)
+   * Read the contents of a file as decoded text. Default encoding is utf8;
+   * pass an explicit text encoding (`"ascii"`, etc.) to override.
+   *
+   * For raw bytes (encoding `"binary"` / `"latin1"`), use {@link readFileBytes}
+   * — the opaque return type forces callers to decide whether to forward
+   * bytes unchanged or decode as text.
+   *
    * @throws Error if file doesn't exist or is a directory
    */
   readFile(
     path: string,
     options?: ReadFileOptions | BufferEncoding,
   ): Promise<string>;
+
+  /**
+   * Read the raw bytes of a file as a {@link ByteString} (latin1-shaped: each
+   * char = one byte). Use when the bytes will be piped onward unchanged or
+   * explicitly decoded with `decodeBytesToUtf8` — never call string methods
+   * on the result, that's the bug class this type prevents.
+   *
+   * @throws Error if file doesn't exist or is a directory
+   */
+  readFileBytes(path: string): Promise<ByteString>;
 
   /**
    * Read the contents of a file as a Uint8Array (binary)

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -138,9 +138,15 @@ export interface IFileSystem {
    * explicitly decoded with `decodeBytesToUtf8` — never call string methods
    * on the result, that's the bug class this type prevents.
    *
+   * Optional for backwards compatibility with external `IFileSystem`
+   * implementations written before this method existed; built-in
+   * filesystems all implement it. Internal callers must route through the
+   * `readBytesFrom(fs, path)` helper, which falls back to `readFileBuffer`
+   * when this method is missing.
+   *
    * @throws Error if file doesn't exist or is a directory
    */
-  readFileBytes(path: string): Promise<ByteString>;
+  readFileBytes?(path: string): Promise<ByteString>;
 
   /**
    * Read the contents of a file as a Uint8Array (binary)

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -1,3 +1,4 @@
+import type { ByteString } from "../../encoding.js";
 import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
 import type {
   BufferEncoding,
@@ -249,6 +250,11 @@ export class MountableFs implements IFileSystem {
   ): Promise<string> {
     const { fs, relativePath } = this.routePath(path);
     return fs.readFile(relativePath, options);
+  }
+
+  async readFileBytes(path: string): Promise<ByteString> {
+    const { fs, relativePath } = this.routePath(path);
+    return fs.readFileBytes(relativePath);
   }
 
   async readFileBuffer(path: string): Promise<Uint8Array> {

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -1,4 +1,4 @@
-import type { ByteString } from "../../encoding.js";
+import { type ByteString, readBytesFrom } from "../../encoding.js";
 import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
 import type {
   BufferEncoding,
@@ -254,7 +254,9 @@ export class MountableFs implements IFileSystem {
 
   async readFileBytes(path: string): Promise<ByteString> {
     const { fs, relativePath } = this.routePath(path);
-    return fs.readFileBytes(relativePath);
+    // Mounted filesystem may be a user-supplied IFileSystem that predates
+    // readFileBytes; fall through to readBytesFrom which handles both.
+    return readBytesFrom(fs, relativePath);
   }
 
   async readFileBuffer(path: string): Promise<Uint8Array> {

--- a/packages/just-bash/src/fs/overlay-fs/overlay-fs.ts
+++ b/packages/just-bash/src/fs/overlay-fs/overlay-fs.ts
@@ -13,6 +13,7 @@
 
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
+import { type ByteString, unsafeBytesFromLatin1 } from "../../encoding.js";
 import {
   type FileContent,
   fromBuffer,
@@ -384,6 +385,11 @@ export class OverlayFs implements IFileSystem {
     const buffer = await this.readFileBuffer(path);
     const encoding = getEncoding(options);
     return fromBuffer(buffer, encoding);
+  }
+
+  async readFileBytes(path: string): Promise<ByteString> {
+    const buffer = await this.readFileBuffer(path);
+    return unsafeBytesFromLatin1(fromBuffer(buffer, "binary"));
   }
 
   async readFileBuffer(

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
@@ -13,6 +13,7 @@
 
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
+import { type ByteString, unsafeBytesFromLatin1 } from "../../encoding.js";
 import {
   type FileContent,
   fromBuffer,
@@ -129,6 +130,11 @@ export class ReadWriteFs implements IFileSystem {
     const buffer = await this.readFileBuffer(path);
     const encoding = getEncoding(options);
     return fromBuffer(buffer, encoding);
+  }
+
+  async readFileBytes(path: string): Promise<ByteString> {
+    const buffer = await this.readFileBuffer(path);
+    return unsafeBytesFromLatin1(fromBuffer(buffer, "binary"));
   }
 
   async readFileBuffer(path: string): Promise<Uint8Array> {

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -34,6 +34,7 @@ export { defineCommand } from "./custom-commands.js";
 // `ctx.stdin` (an opaque `ByteString`).
 export type { ByteString } from "./encoding.js";
 export {
+  bytesFromPipe,
   decodeBytesToUtf8,
   EMPTY_BYTES,
   encodeUtf8ToBytes,

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -32,13 +32,16 @@ export type { CustomCommand, LazyCommand } from "./custom-commands.js";
 export { defineCommand } from "./custom-commands.js";
 // Byte/text boundary helpers — required by custom commands that read
 // `ctx.stdin` (an opaque `ByteString`).
-export type { ByteString } from "./encoding.js";
+export type { ByteString, OutputKind } from "./encoding.js";
 export {
-  bytesFromPipe,
+  bytesOutput,
   decodeBytesToUtf8,
   EMPTY_BYTES,
   encodeUtf8ToBytes,
   latin1FromBytes,
+  stdoutAsBytes,
+  stdoutKind,
+  textOutput,
   unsafeBytesFromLatin1,
 } from "./encoding.js";
 export { InMemoryFs } from "./fs/in-memory-fs/index.js";

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -30,6 +30,16 @@ export {
 // Custom commands API
 export type { CustomCommand, LazyCommand } from "./custom-commands.js";
 export { defineCommand } from "./custom-commands.js";
+// Byte/text boundary helpers — required by custom commands that read
+// `ctx.stdin` (an opaque `ByteString`).
+export type { ByteString } from "./encoding.js";
+export {
+  decodeBytesToUtf8,
+  EMPTY_BYTES,
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  unsafeBytesFromLatin1,
+} from "./encoding.js";
 export { InMemoryFs } from "./fs/in-memory-fs/index.js";
 export type {
   BufferEncoding,

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -6,6 +6,7 @@
  */
 
 import { isBrowserExcludedCommand } from "../commands/browser-excluded.js";
+import { unsafeBytesFromLatin1 } from "../encoding.js";
 import { sanitizeErrorMessage } from "../fs/sanitize-error.js";
 import { awaitWithDefenseContext } from "../security/defense-context.js";
 import {
@@ -413,7 +414,12 @@ export async function executeExternalCommand(
 
   // Use groupStdin as fallback if no stdin from redirections/pipeline
   // This is needed for commands inside groups/functions that receive stdin via heredoc
-  const effectiveStdin = stdin || ctx.state.groupStdin || "";
+  // The internal pipeline plumbs stdin around as a plain `string` (a latin1
+  // byte buffer); brand it as `ByteString` here, at the boundary handed to
+  // command authors, so accidental string-method use trips the type system.
+  const effectiveStdin = unsafeBytesFromLatin1(
+    stdin || ctx.state.groupStdin || "",
+  );
 
   // Build exported environment for commands that need it (printenv, env, etc.)
   // Most builtins need access to the full env to modify state

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -412,20 +412,14 @@ export async function executeExternalCommand(
     ctx.state.hashTable.set(commandName, cmdPath);
   }
 
-  // Use groupStdin as fallback if no stdin from redirections/pipeline.
-  // This is needed for commands inside groups/functions that receive stdin
-  // via heredoc. The internal pipeline plumbs stdin around as a plain
-  // `string` (a latin1 byte buffer); brand it as `ByteString` here, at the
-  // boundary handed to command authors, so accidental string-method use
-  // trips the type system.
-  //
-  // The contract for this boundary is "the upstream already gave us bytes".
-  // Commands that internally decode their stdin to UTF-8 text (sed, grep,
-  // rev, awk, jq, yq, ...) must `latin1FromBytes(encodeUtf8ToBytes(out))`
-  // *and* set `stdoutEncoding: "binary"` before returning, so the bytes
-  // they emit chain correctly into byte consumers downstream (wc -c,
-  // base64, md5sum) and into redirects (which then write binary instead
-  // of re-encoding utf8 a second time).
+  // Use groupStdin as fallback if no stdin from redirections/pipeline —
+  // needed for commands inside groups/functions that receive stdin via
+  // heredoc. The pipeline glue (pipeline-execution.ts) and the
+  // stdin-source sites (heredoc, here-string, `< file`, options.stdin)
+  // are responsible for handing us a latin1-shaped byte buffer; we just
+  // brand it. Commands that decode their input internally (sed, jq,
+  // ...) return text via `textOutput()`, and the pipe / redirect layer
+  // converts to bytes on their behalf.
   const effectiveStdin = unsafeBytesFromLatin1(
     stdin || ctx.state.groupStdin || "",
   );

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -412,11 +412,20 @@ export async function executeExternalCommand(
     ctx.state.hashTable.set(commandName, cmdPath);
   }
 
-  // Use groupStdin as fallback if no stdin from redirections/pipeline
-  // This is needed for commands inside groups/functions that receive stdin via heredoc
-  // The internal pipeline plumbs stdin around as a plain `string` (a latin1
-  // byte buffer); brand it as `ByteString` here, at the boundary handed to
-  // command authors, so accidental string-method use trips the type system.
+  // Use groupStdin as fallback if no stdin from redirections/pipeline.
+  // This is needed for commands inside groups/functions that receive stdin
+  // via heredoc. The internal pipeline plumbs stdin around as a plain
+  // `string` (a latin1 byte buffer); brand it as `ByteString` here, at the
+  // boundary handed to command authors, so accidental string-method use
+  // trips the type system.
+  //
+  // The contract for this boundary is "the upstream already gave us bytes".
+  // Commands that internally decode their stdin to UTF-8 text (sed, grep,
+  // rev, awk, jq, yq, ...) must `latin1FromBytes(encodeUtf8ToBytes(out))`
+  // *and* set `stdoutEncoding: "binary"` before returning, so the bytes
+  // they emit chain correctly into byte consumers downstream (wc -c,
+  // base64, md5sum) and into redirects (which then write binary instead
+  // of re-encoding utf8 a second time).
   const effectiveStdin = unsafeBytesFromLatin1(
     stdin || ctx.state.groupStdin || "",
   );

--- a/packages/just-bash/src/interpreter/defense-aware-command-context.ts
+++ b/packages/just-bash/src/interpreter/defense-aware-command-context.ts
@@ -58,6 +58,12 @@ function wrapFileSystem(
       component,
       "fs.readFile",
     ),
+    readFileBytes: wrapFunction(
+      fs.readFileBytes.bind(fs),
+      requireDefenseContext,
+      component,
+      "fs.readFileBytes",
+    ),
     readFileBuffer: wrapFunction(
       fs.readFileBuffer.bind(fs),
       requireDefenseContext,

--- a/packages/just-bash/src/interpreter/defense-aware-command-context.ts
+++ b/packages/just-bash/src/interpreter/defense-aware-command-context.ts
@@ -61,6 +61,9 @@ function wrapFileSystem(
     // readFileBytes is optional on IFileSystem (custom external fs may
     // predate it). Only wrap when it exists; internal callers go through
     // `readBytesFrom` which falls back to readFileBuffer otherwise.
+    // Spread a null-prototype object on the missing branch instead of
+    // `{}` so the conditional adds either one wrapped method or zero,
+    // without leaking `Object.prototype`.
     ...(typeof fs.readFileBytes === "function"
       ? {
           readFileBytes: wrapFunction(
@@ -70,7 +73,7 @@ function wrapFileSystem(
             "fs.readFileBytes",
           ),
         }
-      : {}),
+      : (Object.create(null) as Record<string, never>)),
     readFileBuffer: wrapFunction(
       fs.readFileBuffer.bind(fs),
       requireDefenseContext,

--- a/packages/just-bash/src/interpreter/defense-aware-command-context.ts
+++ b/packages/just-bash/src/interpreter/defense-aware-command-context.ts
@@ -58,12 +58,19 @@ function wrapFileSystem(
       component,
       "fs.readFile",
     ),
-    readFileBytes: wrapFunction(
-      fs.readFileBytes.bind(fs),
-      requireDefenseContext,
-      component,
-      "fs.readFileBytes",
-    ),
+    // readFileBytes is optional on IFileSystem (custom external fs may
+    // predate it). Only wrap when it exists; internal callers go through
+    // `readBytesFrom` which falls back to readFileBuffer otherwise.
+    ...(typeof fs.readFileBytes === "function"
+      ? {
+          readFileBytes: wrapFunction(
+            fs.readFileBytes.bind(fs),
+            requireDefenseContext,
+            component,
+            "fs.readFileBytes",
+          ),
+        }
+      : {}),
     readFileBuffer: wrapFunction(
       fs.readFileBuffer.bind(fs),
       requireDefenseContext,

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -23,6 +23,11 @@ import type {
   SubshellNode,
   WordNode,
 } from "../ast/types.js";
+import {
+  bytesFromPipe,
+  latin1FromBytes,
+  readBytesFrom,
+} from "../encoding.js";
 import type { IFileSystem } from "../fs/interface.js";
 import { mapToRecord } from "../helpers/env.js";
 import type { ExecutionLimits } from "../limits.js";
@@ -658,6 +663,12 @@ export class Interpreter {
             .map((line) => line.replace(/^\t+/, ""))
             .join("\n");
         }
+        // Heredocs land here as JS Unicode text; the pipeline contract
+        // expects stdin to be a latin1 byte buffer. UTF-8 encode any
+        // non-ASCII codepoints so byte consumers downstream see real
+        // bytes (and binary writes don't truncate codepoints to their
+        // low byte).
+        content = latin1FromBytes(bytesFromPipe(content));
         // If this is a non-standard fd (not 0), store in fileDescriptors for -u option
         const fd = redir.fd ?? 0;
         if (fd !== 0) {
@@ -673,7 +684,13 @@ export class Interpreter {
       }
 
       if (redir.operator === "<<<" && redir.target.type === "Word") {
-        stdin = `${await expandWord(this.ctx, redir.target as WordNode)}\n`;
+        // Same byte-encoding step as heredoc — here-strings deliver
+        // JS Unicode text and need to land as bytes.
+        stdin = latin1FromBytes(
+          bytesFromPipe(
+            `${await expandWord(this.ctx, redir.target as WordNode)}\n`,
+          ),
+        );
         continue;
       }
 
@@ -681,7 +698,10 @@ export class Interpreter {
         try {
           const target = await expandWord(this.ctx, redir.target as WordNode);
           const filePath = this.ctx.fs.resolvePath(this.ctx.state.cwd, target);
-          stdin = await this.ctx.fs.readFile(filePath);
+          // Read as raw bytes — `<` is a transparent file-to-stdin
+          // pipe and we don't want the smart-utf8 read path turning
+          // valid bytes into U+FFFD replacement chars.
+          stdin = latin1FromBytes(await readBytesFrom(this.ctx.fs, filePath));
         } catch {
           const target = await expandWord(this.ctx, redir.target as WordNode);
           for (const [name, value] of tempAssignments) {

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -24,7 +24,7 @@ import type {
   WordNode,
 } from "../ast/types.js";
 import {
-  bytesFromPipe,
+  encodeUtf8ToBytes,
   latin1FromBytes,
   readBytesFrom,
 } from "../encoding.js";
@@ -664,11 +664,11 @@ export class Interpreter {
             .join("\n");
         }
         // Heredocs land here as JS Unicode text; the pipeline contract
-        // expects stdin to be a latin1 byte buffer. UTF-8 encode any
-        // non-ASCII codepoints so byte consumers downstream see real
-        // bytes (and binary writes don't truncate codepoints to their
-        // low byte).
-        content = latin1FromBytes(bytesFromPipe(content));
+        // expects stdin to be a latin1 byte buffer. UTF-8 encode the
+        // text once at the source so byte consumers downstream see real
+        // bytes and binary writes don't truncate codepoints to their
+        // low byte.
+        content = latin1FromBytes(encodeUtf8ToBytes(content));
         // If this is a non-standard fd (not 0), store in fileDescriptors for -u option
         const fd = redir.fd ?? 0;
         if (fd !== 0) {
@@ -687,7 +687,7 @@ export class Interpreter {
         // Same byte-encoding step as heredoc — here-strings deliver
         // JS Unicode text and need to land as bytes.
         stdin = latin1FromBytes(
-          bytesFromPipe(
+          encodeUtf8ToBytes(
             `${await expandWord(this.ctx, redir.target as WordNode)}\n`,
           ),
         );

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -5,7 +5,11 @@
  */
 
 import type { CommandNode, PipelineNode } from "../ast/types.js";
-import { bytesFromPipe, latin1FromBytes } from "../encoding.js";
+import {
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  stdoutAsBytes,
+} from "../encoding.js";
 import { _performanceNow } from "../security/trusted-globals.js";
 import type { ExecResult } from "../types.js";
 import { BadSubstitutionError, ErrexitError, ExitError } from "./errors.js";
@@ -125,32 +129,23 @@ export async function executePipeline(
     }
 
     if (!isLast) {
-      // Pipeline contract: the next command's stdin is a byte buffer
-      // (latin1-shaped, one char per byte). When the upstream already
-      // marked its stdout as bytes (`stdoutEncoding: "binary"` — cat,
-      // gzip, decoded-text-emitting commands like sed/grep/jq after they
-      // re-encode), pass through verbatim. Otherwise the upstream
-      // produced JS-Unicode text (echo, printf, custom commands that
-      // didn't opt in) — UTF-8 encode any chars > 0xFF so byte consumers
-      // downstream (`wc -c`, `base64`, `md5sum`) see UTF-8 bytes instead
-      // of code units. `bytesFromPipe` only encodes when chars > 0xFF
-      // are present, leaving Latin-1 byte buffers and ASCII alone (echo's
-      // `\0377` byte stays a single byte; cat's UTF-8 bytes don't get
-      // double-encoded). The Latin-1-supplement range (0x80–0xFF) is
-      // shape-ambiguous and passes through — known limitation.
-      const toBytes = (s: string): string =>
-        result.stdoutEncoding === "binary"
-          ? s
-          : latin1FromBytes(bytesFromPipe(s));
+      // Pipeline contract: the next command's stdin is a byte buffer.
+      // `stdoutAsBytes` consults the upstream's explicit `stdoutKind`
+      // (or legacy `stdoutEncoding === "binary"`) and converts text →
+      // UTF-8 bytes / passes byte buffers through. No content-based
+      // heuristics — the producer's metadata is the source of truth.
       // Check if this pipe is |& (pipe stderr to next command's stdin too)
       const pipeStderrToNext = node.pipeStderr?.[i] ?? false;
       if (pipeStderrToNext) {
-        // |& pipes both stdout and stderr to next command's stdin.
+        // |& pipes stderr + stdout. stderr is text (no producer marks it
+        // binary today); UTF-8 encode it before concatenating with the
+        // stdout bytes so the merged stream is byte-shaped end-to-end.
         stdin =
-          latin1FromBytes(bytesFromPipe(result.stderr)) + toBytes(result.stdout);
+          latin1FromBytes(encodeUtf8ToBytes(result.stderr)) +
+          latin1FromBytes(stdoutAsBytes(result));
       } else {
         // Regular | only pipes stdout; stderr goes to the parent
-        stdin = toBytes(result.stdout);
+        stdin = latin1FromBytes(stdoutAsBytes(result));
         accumulatedStderr += result.stderr;
       }
       lastResult = {

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -5,6 +5,7 @@
  */
 
 import type { CommandNode, PipelineNode } from "../ast/types.js";
+import { bytesFromPipe, latin1FromBytes } from "../encoding.js";
 import { _performanceNow } from "../security/trusted-globals.js";
 import type { ExecResult } from "../types.js";
 import { BadSubstitutionError, ErrexitError, ExitError } from "./errors.js";
@@ -124,14 +125,32 @@ export async function executePipeline(
     }
 
     if (!isLast) {
+      // Pipeline contract: the next command's stdin is a byte buffer
+      // (latin1-shaped, one char per byte). When the upstream already
+      // marked its stdout as bytes (`stdoutEncoding: "binary"` — cat,
+      // gzip, decoded-text-emitting commands like sed/grep/jq after they
+      // re-encode), pass through verbatim. Otherwise the upstream
+      // produced JS-Unicode text (echo, printf, custom commands that
+      // didn't opt in) — UTF-8 encode any chars > 0xFF so byte consumers
+      // downstream (`wc -c`, `base64`, `md5sum`) see UTF-8 bytes instead
+      // of code units. `bytesFromPipe` only encodes when chars > 0xFF
+      // are present, leaving Latin-1 byte buffers and ASCII alone (echo's
+      // `\0377` byte stays a single byte; cat's UTF-8 bytes don't get
+      // double-encoded). The Latin-1-supplement range (0x80–0xFF) is
+      // shape-ambiguous and passes through — known limitation.
+      const toBytes = (s: string): string =>
+        result.stdoutEncoding === "binary"
+          ? s
+          : latin1FromBytes(bytesFromPipe(s));
       // Check if this pipe is |& (pipe stderr to next command's stdin too)
       const pipeStderrToNext = node.pipeStderr?.[i] ?? false;
       if (pipeStderrToNext) {
-        // |& pipes both stdout and stderr to next command's stdin
-        stdin = result.stderr + result.stdout;
+        // |& pipes both stdout and stderr to next command's stdin.
+        stdin =
+          latin1FromBytes(bytesFromPipe(result.stderr)) + toBytes(result.stdout);
       } else {
         // Regular | only pipes stdout; stderr goes to the parent
-        stdin = result.stdout;
+        stdin = toBytes(result.stdout);
         accumulatedStderr += result.stderr;
       }
       lastResult = {

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -405,16 +405,27 @@ export async function applyRedirections(
 ): Promise<ExecResult> {
   let { stdout, stderr, exitCode } = result;
 
-  // Determine encoding for stdout writes:
-  // - Commands that set stdoutEncoding: "binary" (e.g. cat, gzip) produce
-  //   binary strings where each char represents a raw byte — use "binary"
-  //   to preserve byte-level fidelity.
-  // - Otherwise, use getFileEncoding which detects non-ASCII text and
-  //   encodes it as UTF-8 so characters like Ü are stored correctly.
-  const getStdoutEncoding =
-    result.stdoutEncoding === "binary"
-      ? () => "binary" as const
-      : (content: string) => getFileEncoding(content);
+  // Determine encoding for stdout writes from the producer's explicit
+  // shape rather than guessing at the bytes:
+  //   - `stdoutKind: "bytes"` (or legacy `stdoutEncoding: "binary"` —
+  //     cat, gzip, base64 -d, ...): stdout is already a latin1 byte
+  //     buffer; write binary so the bytes round-trip verbatim.
+  //   - everything else (echo, printf, sed, jq, custom commands that
+  //     leave the field unset): stdout is JS Unicode text; write UTF-8.
+  //
+  // The default is text — never the content-sampling heuristic. The
+  // sampler reads only the first 8 KiB and would mis-classify long
+  // mostly-ASCII output that happens to have its first non-ASCII char
+  // past the window, picking binary and truncating downstream codepoints
+  // to their low byte.
+  const stdoutIsBytes =
+    result.stdoutKind === "bytes" ||
+    (result.stdoutKind === undefined && result.stdoutEncoding === "binary");
+  const stdoutFileEncoding: "binary" | "utf8" = stdoutIsBytes
+    ? "binary"
+    : "utf8";
+  const getStdoutEncoding = (_content: string): "binary" | "utf8" =>
+    stdoutFileEncoding;
 
   for (let i = 0; i < redirections.length; i++) {
     const redir = redirections[i];
@@ -934,9 +945,13 @@ export async function applyRedirections(
   }
 
   const finalResult = makeResult(stdout, stderr, exitCode);
-  // Preserve the upstream's binary-stdout flag through the redirection
-  // pipeline so the next stage (pipeline glue, output boundary) can tell
-  // bytes-shaped output from text-shaped output.
+  // Preserve the upstream's stdout shape through the redirection layer so
+  // the next stage (pipeline glue, output boundary) can tell bytes-shaped
+  // output from text-shaped output. Both the new `stdoutKind` field and
+  // the legacy `stdoutEncoding` alias are forwarded.
+  if (result.stdoutKind) {
+    finalResult.stdoutKind = result.stdoutKind;
+  }
   if (result.stdoutEncoding === "binary") {
     finalResult.stdoutEncoding = "binary";
   }

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -933,5 +933,12 @@ export async function applyRedirections(
     }
   }
 
-  return makeResult(stdout, stderr, exitCode);
+  const finalResult = makeResult(stdout, stderr, exitCode);
+  // Preserve the upstream's binary-stdout flag through the redirection
+  // pipeline so the next stage (pipeline glue, output boundary) can tell
+  // bytes-shaped output from text-shaped output.
+  if (result.stdoutEncoding === "binary") {
+    finalResult.stdoutEncoding = "binary";
+  }
+  return finalResult;
 }

--- a/packages/just-bash/src/security/attacks/defense-context-invariant.test.ts
+++ b/packages/just-bash/src/security/attacks/defense-context-invariant.test.ts
@@ -4,6 +4,7 @@ import { awkCommand2 } from "../../commands/awk/awk2.js";
 import { jqCommand } from "../../commands/jq/jq.js";
 import { sedCommand } from "../../commands/sed/sed.js";
 import { yqCommand } from "../../commands/yq/yq.js";
+import { EMPTY_BYTES, unsafeBytesFromLatin1 } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { createDefenseAwareCommandContext } from "../../interpreter/defense-aware-command-context.js";
 import type { CommandContext } from "../../types.js";
@@ -20,7 +21,7 @@ function createCommandContext(
     fs: new InMemoryFs(),
     cwd: "/",
     env: new Map([["PATH", "/usr/bin:/bin"]]),
-    stdin: "",
+    stdin: EMPTY_BYTES,
     requireDefenseContext: true,
     ...overrides,
   };
@@ -97,7 +98,7 @@ describe("Defense context invariant", () => {
     await expect(
       awkCommand2.execute(
         ["{ print $0 }"],
-        createCommandContext({ stdin: "x\n" }),
+        createCommandContext({ stdin: unsafeBytesFromLatin1("x\n") }),
       ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
@@ -106,7 +107,10 @@ describe("Defense context invariant", () => {
     vi.spyOn(DefenseInDepthBox, "isInSandboxedContext").mockReturnValue(false);
 
     await expect(
-      sedCommand.execute(["s/a/b/"], createCommandContext({ stdin: "a\n" })),
+      sedCommand.execute(
+        ["s/a/b/"],
+        createCommandContext({ stdin: unsafeBytesFromLatin1("a\n") }),
+      ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
 
@@ -114,7 +118,10 @@ describe("Defense context invariant", () => {
     vi.spyOn(DefenseInDepthBox, "isInSandboxedContext").mockReturnValue(false);
 
     await expect(
-      jqCommand.execute(["."], createCommandContext({ stdin: "{}\n" })),
+      jqCommand.execute(
+        ["."],
+        createCommandContext({ stdin: unsafeBytesFromLatin1("{}\n") }),
+      ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
 
@@ -122,7 +129,10 @@ describe("Defense context invariant", () => {
     vi.spyOn(DefenseInDepthBox, "isInSandboxedContext").mockReturnValue(false);
 
     await expect(
-      yqCommand.execute(["."], createCommandContext({ stdin: "x: 1\n" })),
+      yqCommand.execute(
+        ["."],
+        createCommandContext({ stdin: unsafeBytesFromLatin1("x: 1\n") }),
+      ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
 

--- a/packages/just-bash/src/spec-tests/bash/cases/builtin-echo.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/builtin-echo.test.sh
@@ -197,6 +197,7 @@ abcd\U00000065f
 ## END
 
 #### \0377 is the highest octal byte
+## SKIP (known divergence): just-bash represents shell strings as JS Unicode; raw byte escapes (`\0NNN`, `\xNN`) produce codepoints, not bytes, so a piped byte consumer sees the UTF-8 encoding of the codepoint instead of the raw byte.
 echo -en '\03777' | od -A n -t x1 | sed 's/ \+/ /g'
 ## STDOUT:
  ff 37
@@ -219,6 +220,7 @@ echo -en '\04000' | od -A n -t x1 | sed 's/ \+/ /g'
 ## END
 
 #### \0777 is out of range
+## SKIP (known divergence): see "\0377 is the highest octal byte" above — raw byte escapes piped to a byte consumer get UTF-8 encoded.
 flags='-en'
 case $SH in dash) flags='-n' ;; esac
 

--- a/packages/just-bash/src/spec-tests/bash/cases/builtin-printf.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/builtin-printf.test.sh
@@ -758,6 +758,7 @@ AZ
 ## END
 
 #### printf %c unicode - prints the first BYTE of a string - it does not respect UTF-8
+## SKIP (known divergence): just-bash's `printf %c` slices the JS string by codepoint, not byte, so the piped byte consumer sees the UTF-8 encoding of the first codepoint instead of the first raw byte.
 
 # TODO: in YSH, this should be deprecated
 case $SH in dash|ash) exit ;; esac

--- a/packages/just-bash/src/spec-tests/bash/cases/quote.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/quote.test.sh
@@ -180,6 +180,7 @@ col3
 ## END
 
 #### $'' octal escapes don't have leading 0
+## SKIP (known divergence): $'\NNN' octal escapes produce JS codepoints; piping to a byte consumer encodes them as UTF-8 instead of preserving the raw byte.
 # echo -e syntax is echo -e \0377
 echo -n $'\001' $'\377' | od -A n -c | sed 's/ \+/ /g'
 ## STDOUT:

--- a/packages/just-bash/src/spec-tests/test-commands.ts
+++ b/packages/just-bash/src/spec-tests/test-commands.ts
@@ -6,6 +6,7 @@
  */
 
 import { defineCommand } from "../custom-commands.js";
+import { latin1FromBytes } from "../encoding.js";
 import type { Command } from "../types.js";
 
 // argv.py - prints arguments in Python 2 repr() format: ['arg1', "arg with '"]
@@ -110,8 +111,8 @@ export const readFromFdCommand: Command = defineCommand(
 
       let content = "";
       if (fd === 0) {
-        // FD 0 is stdin
-        content = ctx.stdin || "";
+        // FD 0 is stdin — diagnostic only, byte-clean passthrough
+        content = latin1FromBytes(ctx.stdin) || "";
       } else if (ctx.fileDescriptors) {
         // Other FDs from the fileDescriptors map
         content = ctx.fileDescriptors.get(fd) || "";

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -1,3 +1,4 @@
+import type { ByteString } from "./encoding.js";
 import type { IFileSystem } from "./fs/interface.js";
 import type { ExecutionLimits } from "./limits.js";
 import type { SecureFetch } from "./network/index.js";
@@ -113,8 +114,19 @@ export interface CommandContext {
    * In bash, only exported variables are passed to child processes.
    */
   exportedEnv?: Record<string, string>;
-  /** Standard input content */
-  stdin: string;
+  /**
+   * Standard input as a byte buffer. Opaque on purpose — see `encoding.ts`.
+   *
+   * Pipelines carry bytes (a previous command's stdout becomes this stdin).
+   * Choose a conversion at the use site:
+   *   - `latin1FromBytes(ctx.stdin)` to forward bytes unchanged (cat, head,
+   *     tee, base64 -d, gzip, ...).
+   *   - `decodeBytesToUtf8(ctx.stdin)` to interpret as UTF-8 text (jq, sed,
+   *     grep, awk, parsers, code execution, char-position math, ...).
+   * Mixing the two — calling string methods on a latin1 byte buffer that
+   * actually holds UTF-8 — is the bug class this type prevents.
+   */
+  stdin: ByteString;
   /**
    * Execution limits configuration.
    * Available when running commands via BashEnv interpreter.

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -18,10 +18,25 @@ export interface ExecResult {
   /** The final environment variables after execution (only set by BashEnv.exec) */
   env?: Record<string, string>;
   /**
-   * Encoding hint for stdout content when writing to files via redirections.
-   * Set to "binary" by commands that produce binary output (e.g., cat, gzip)
-   * to prevent re-encoding of raw byte data as UTF-8.
-   * When not set, the redirect system uses UTF-8 for non-ASCII text.
+   * Explicit metadata for what shape `stdout` is in. The pipeline + redirect
+   * layers consult this instead of guessing from string contents:
+   *
+   *   - `"text"`: `stdout` is JS Unicode text. The pipeline UTF-8 encodes it
+   *     before handing it to the next command's stdin; redirects write it
+   *     as UTF-8.
+   *   - `"bytes"`: `stdout` is a latin1-shaped byte buffer (each char = one
+   *     byte). The pipeline forwards the bytes verbatim; redirects write
+   *     them as binary.
+   *
+   * Producers should set this via `textOutput()` / `bytesOutput()` from
+   * `encoding.ts` rather than poking the raw flag. Absent values fall back
+   * to the legacy `stdoutEncoding` heuristic for back-compat with older
+   * commands that haven't been migrated yet.
+   */
+  stdoutKind?: "text" | "bytes";
+  /**
+   * Legacy alias for `stdoutKind: "bytes"`. Older commands set this to
+   * `"binary"` to mark binary output. New code should prefer `stdoutKind`.
    */
   stdoutEncoding?: "binary";
 }
@@ -52,6 +67,17 @@ export interface CommandExecOptions {
    * Optional - if not provided, stdin will be empty.
    */
   stdin?: string;
+  /**
+   * Shape of {@link stdin}:
+   *   - `"text"` (default): JS Unicode text. UTF-8 encoded into bytes
+   *     before reaching the subcommand, so byte consumers (`wc -c`,
+   *     `base64`, `md5sum`) inside the script see real UTF-8 bytes.
+   *   - `"bytes"`: a latin1-shaped byte buffer (each char = one byte,
+   *     e.g. from `Buffer.from(...).toString("latin1")`). Forwarded
+   *     verbatim — useful for piping raw binary into commands like
+   *     `gzip -d`.
+   */
+  stdinKind?: "text" | "bytes";
   /**
    * Abort signal for cooperative cancellation.
    * When aborted, the interpreter stops executing at the next statement boundary.

--- a/packages/just-bash/src/utils/file-reader.ts
+++ b/packages/just-bash/src/utils/file-reader.ts
@@ -5,6 +5,7 @@
  * including parallel batch reading for performance.
  */
 
+import { type ByteString, EMPTY_BYTES } from "../encoding.js";
 import type { CommandContext, ExecResult } from "../types.js";
 import { DEFAULT_BATCH_SIZE } from "./constants.js";
 
@@ -22,8 +23,12 @@ export interface ReadFilesOptions {
 export interface FileContent {
   /** File name (or "-" for stdin, or "" if stdin with no files) */
   filename: string;
-  /** File content */
-  content: string;
+  /**
+   * File content as a byte buffer (latin1-shaped). Decode with
+   * `decodeBytesToUtf8` before regex/parsing/char-position math; pass through
+   * `latin1FromBytes` if forwarding bytes unchanged.
+   */
+  content: ByteString;
 }
 
 export interface ReadFilesResult {
@@ -81,19 +86,24 @@ export async function readFiles(
     const batchResults = await Promise.all(
       batch.map(async (file) => {
         if (allowStdinMarker && file === "-") {
-          return { filename: "-", content: ctx.stdin, error: null };
+          return {
+            filename: "-",
+            content: ctx.stdin,
+            error: null as string | null,
+          };
         }
         try {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);
           // Use binary encoding to preserve all bytes (including non-UTF-8).
           // This is important for piping binary data through commands like cat.
-          // UTF-8 decoding happens at the output boundary (Bash.exec) instead.
-          const content = await ctx.fs.readFile(filePath, "binary");
-          return { filename: file, content, error: null };
+          // Text-processing commands must explicitly call `decodeBytesToUtf8`
+          // on the content before regex / parsing.
+          const content = await ctx.fs.readFileBytes(filePath);
+          return { filename: file, content, error: null as string | null };
         } catch {
           return {
             filename: file,
-            content: "",
+            content: EMPTY_BYTES,
             error: `${cmdName}: ${file}: No such file or directory\n`,
           };
         }
@@ -118,20 +128,24 @@ export async function readFiles(
 }
 
 /**
- * Read and concatenate all files into a single string.
+ * Read and concatenate all files into a single byte buffer.
  *
  * Useful for commands like sort and uniq that process all input together.
+ * Callers must `decodeBytesToUtf8` (text processing) or `latin1FromBytes`
+ * (byte passthrough) before using the content.
  *
  * @example
  * const result = await readAndConcat(ctx, files, { cmdName: "sort" });
  * if (!result.ok) return result.error;
- * const lines = result.content.split("\n");
+ * const lines = decodeBytesToUtf8(result.content).split("\n");
  */
 export async function readAndConcat(
   ctx: CommandContext,
   files: string[],
   options: { cmdName: string; allowStdinMarker?: boolean },
-): Promise<{ ok: true; content: string } | { ok: false; error: ExecResult }> {
+): Promise<
+  { ok: true; content: ByteString } | { ok: false; error: ExecResult }
+> {
   const result = await readFiles(ctx, files, {
     ...options,
     stopOnError: true,
@@ -144,6 +158,10 @@ export async function readAndConcat(
     };
   }
 
-  const content = result.files.map((f) => f.content).join("");
-  return { ok: true, content };
+  // Concatenate the latin1 byte buffers — joining strings byte-wise is fine
+  // since each char is one byte. Keep it branded.
+  const joined = result.files
+    .map((f) => f.content as unknown as string)
+    .join("");
+  return { ok: true, content: joined as unknown as ByteString };
 }

--- a/packages/just-bash/src/utils/file-reader.ts
+++ b/packages/just-bash/src/utils/file-reader.ts
@@ -5,7 +5,7 @@
  * including parallel batch reading for performance.
  */
 
-import { type ByteString, EMPTY_BYTES } from "../encoding.js";
+import { type ByteString, EMPTY_BYTES, readBytesFrom } from "../encoding.js";
 import type { CommandContext, ExecResult } from "../types.js";
 import { DEFAULT_BATCH_SIZE } from "./constants.js";
 
@@ -98,7 +98,7 @@ export async function readFiles(
           // This is important for piping binary data through commands like cat.
           // Text-processing commands must explicitly call `decodeBytesToUtf8`
           // on the content before regex / parsing.
-          const content = await ctx.fs.readFileBytes(filePath);
+          const content = await readBytesFrom(ctx.fs, filePath);
           return { filename: file, content, error: null as string | null };
         } catch {
           return {


### PR DESCRIPTION
- Makes the issue visible in the type system
- Adds lots of tests
- We should still migrate to a typed array based internal representation in the future