### PR TITLE
fix(curl): interpret @file for --data, --data-binary, --data-urlencode

### DIFF
--- a/.changeset/curl-data-at-file.md
+++ b/.changeset/curl-data-at-file.md
@@ -1,0 +1,14 @@
+---
+"just-bash": patch
+---
+
+curl: interpret `@file` for `-d`/`--data`, `--data-binary`, and `--data-urlencode`
+
+Real curl reads file contents when these flags are passed `@filename`:
+
+- `-d @file` / `--data @file` — read file contents, strip CR/LF.
+- `--data-binary @file` — read file contents verbatim (newlines preserved).
+- `--data-urlencode @file` — read file, URL-encode the contents.
+- `--data-urlencode name@file` — prefix the URL-encoded contents with `name=`.
+
+just-bash's curl previously passed `@filename` through verbatim as the HTTP body. Posting JSON or any non-trivial payload via `curl --data-binary @payload.json https://…` sent the literal string `@payload.json` instead of the file. The new behavior matches upstream curl; `--data-raw` keeps the documented "no `@` interpretation" semantics.

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from "../../interpreter/helpers/errors.js";
 import { _Headers } from "../../security/trusted-globals.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
-import { encodeFormData, generateMultipartBody } from "./form.js";
+import { generateMultipartBody } from "./form.js";
 import { curlHelp } from "./help.js";
 import { parseOptions } from "./parse.js";
 import {
@@ -48,6 +48,13 @@ async function resolveDataBody(
  * Append `--data-urlencode @file` and `--data-urlencode name@file` payloads
  * to the existing inline urlencode payload. File contents are URL-encoded
  * after read and joined with `&`, matching real curl's behavior.
+ *
+ * Note: file contents are passed through `encodeURIComponent` directly
+ * rather than the inline-form helper. The inline helper (`encodeFormData`)
+ * splits on the first `=` to separate `name=value` arguments, which would
+ * mis-encode any `=` byte inside the file. For `@file` (and `name@file`)
+ * forms the entire file body is the value — `=` bytes must be percent-
+ * encoded like every other reserved character.
  */
 async function resolveUrlencodeFiles(
   options: CurlOptions,
@@ -59,7 +66,7 @@ async function resolveUrlencodeFiles(
   for (const entry of options.urlencodeFiles) {
     const filePath = ctx.fs.resolvePath(ctx.cwd, entry.path);
     const content = await ctx.fs.readFile(filePath);
-    const encoded = encodeFormData(content);
+    const encoded = encodeURIComponent(content);
     parts.push(
       entry.name ? `${encodeURIComponent(entry.name)}=${encoded}` : encoded,
     );

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from "../../interpreter/helpers/errors.js";
 import { _Headers } from "../../security/trusted-globals.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
-import { generateMultipartBody } from "./form.js";
+import { encodeFormData, generateMultipartBody } from "./form.js";
 import { curlHelp } from "./help.js";
 import { parseOptions } from "./parse.js";
 import {
@@ -19,6 +19,53 @@ import {
   formatHeaders,
 } from "./response-formatting.js";
 import type { CurlOptions } from "./types.js";
+
+/**
+ * Resolve the body for `-d`/`--data`/`--data-binary` (and their `@file`
+ * forms). Real curl strips CR and LF from `-d @file` reads (ascii mode);
+ * `--data-binary @file` is sent verbatim. Inline values are returned as-is.
+ */
+async function resolveDataBody(
+  options: CurlOptions,
+  ctx: CommandContext,
+): Promise<string | undefined> {
+  if (options.dataFile) {
+    const filePath = ctx.fs.resolvePath(ctx.cwd, options.dataFile.path);
+    let content = await ctx.fs.readFile(filePath);
+    if (options.dataFile.mode === "ascii") {
+      content = content.replace(/[\r\n]/g, "");
+    }
+    // `--data-urlencode` arguments that appear *after* a `-d @file` keep
+    // accumulating into `options.data`; preserve that concatenation so a
+    // mixed invocation like `-d @file --data-urlencode "x=1"` still emits
+    // both payloads joined with `&`.
+    return options.data ? `${content}&${options.data}` : content;
+  }
+  return options.data;
+}
+
+/**
+ * Append `--data-urlencode @file` and `--data-urlencode name@file` payloads
+ * to the existing inline urlencode payload. File contents are URL-encoded
+ * after read and joined with `&`, matching real curl's behavior.
+ */
+async function resolveUrlencodeFiles(
+  options: CurlOptions,
+  ctx: CommandContext,
+  base: string | undefined,
+): Promise<string | undefined> {
+  if (options.urlencodeFiles.length === 0) return base;
+  const parts: string[] = base ? [base] : [];
+  for (const entry of options.urlencodeFiles) {
+    const filePath = ctx.fs.resolvePath(ctx.cwd, entry.path);
+    const content = await ctx.fs.readFile(filePath);
+    const encoded = encodeFormData(content);
+    parts.push(
+      entry.name ? `${encodeURIComponent(entry.name)}=${encoded}` : encoded,
+    );
+  }
+  return parts.join("&");
+}
 
 /**
  * Prepare request body from options, reading files if needed
@@ -62,9 +109,14 @@ async function prepareRequestBody(
     };
   }
 
-  // Handle -d/--data variants
-  if (options.data !== undefined) {
-    return { body: options.data };
+  // Handle -d/--data/--data-binary/--data-raw (inline + @file) and
+  // accumulated --data-urlencode files. The two flavors are merged with `&`
+  // because real curl lets you mix `-d foo --data-urlencode @file` and
+  // concatenates the payloads.
+  let body = await resolveDataBody(options, ctx);
+  body = await resolveUrlencodeFiles(options, ctx, body);
+  if (body !== undefined) {
+    return { body };
   }
 
   // @banned-pattern-ignore: returns typed object with known keys (body, contentType), not user data

--- a/packages/just-bash/src/commands/curl/help.ts
+++ b/packages/just-bash/src/commands/curl/help.ts
@@ -14,10 +14,10 @@ export const curlHelp: {
   options: [
     "-X, --request METHOD  HTTP method (GET, POST, PUT, DELETE, etc.)",
     "-H, --header HEADER   Add header (can be used multiple times)",
-    "-d, --data DATA       HTTP POST data",
+    "-d, --data DATA       HTTP POST data (DATA=@file reads from file, strips newlines)",
     "    --data-raw DATA   HTTP POST data (no @ interpretation)",
-    "    --data-binary DATA  HTTP POST binary data",
-    "    --data-urlencode DATA  URL-encode and POST data",
+    "    --data-binary DATA  HTTP POST binary data (DATA=@file reads file verbatim)",
+    "    --data-urlencode DATA  URL-encode and POST data (supports @file and name@file)",
     "-F, --form NAME=VALUE  Multipart form data",
     "-u, --user USER:PASS  HTTP authentication",
     "-A, --user-agent STR  Set User-Agent header",

--- a/packages/just-bash/src/commands/curl/parse.ts
+++ b/packages/just-bash/src/commands/curl/parse.ts
@@ -15,8 +15,14 @@ import type { CurlOptions } from "./types.js";
  * and `--data-binary`, but NOT for `--data-raw`. When `allowFile` is true
  * and the value begins with `@`, the path is recorded for execute-time
  * resolution and inline `data` is cleared; otherwise the value is taken
- * verbatim. The two paths are mutually exclusive — last write wins, which
- * matches real curl's single-payload behavior for these flags.
+ * verbatim.
+ *
+ * `dataFile` and `data` are mutually exclusive: each `-d`/`--data*`
+ * occurrence overwrites the previous one. This is the just-bash status quo
+ * for these flags and intentionally differs from real curl, which combines
+ * repeated `-d` flags with `&`. The narrower scope avoids changing
+ * established behavior for inline values while still fixing the `@file`
+ * gap. `--data-urlencode` retains its own per-flag accumulation path.
  */
 function applyDataArg(
   options: CurlOptions,

--- a/packages/just-bash/src/commands/curl/parse.ts
+++ b/packages/just-bash/src/commands/curl/parse.ts
@@ -9,6 +9,66 @@ import { encodeFormData, parseFormField } from "./form.js";
 import type { CurlOptions } from "./types.js";
 
 /**
+ * Apply `-d`/`--data`/`--data-binary`/`--data-raw` value.
+ *
+ * Real curl interprets a leading `@` as "read from file" for `-d`/`--data`
+ * and `--data-binary`, but NOT for `--data-raw`. When `allowFile` is true
+ * and the value begins with `@`, the path is recorded for execute-time
+ * resolution and inline `data` is cleared; otherwise the value is taken
+ * verbatim. The two paths are mutually exclusive — last write wins, which
+ * matches real curl's single-payload behavior for these flags.
+ */
+function applyDataArg(
+  options: CurlOptions,
+  value: string,
+  spec: { binary: boolean; allowFile: boolean },
+): void {
+  if (spec.allowFile && value.startsWith("@")) {
+    options.dataFile = {
+      mode: spec.binary ? "binary" : "ascii",
+      path: value.slice(1),
+    };
+    options.data = undefined;
+  } else {
+    options.data = value;
+    options.dataFile = undefined;
+  }
+  if (spec.binary) {
+    options.dataBinary = true;
+  }
+}
+
+/**
+ * Apply a `--data-urlencode` value. Real curl supports five forms:
+ *   content       → encode content
+ *   =content      → encode content (no `name=`)
+ *   name=content  → `name=` + encode(content)
+ *   @filename     → encode contents of file
+ *   name@filename → `name=` + encode(contents of file)
+ *
+ * File forms are deferred to execute time so the VFS read is async-safe;
+ * the inline forms keep the existing eager encoding behavior so multiple
+ * `--data-urlencode` flags continue to concatenate with `&`.
+ */
+function applyUrlencodeArg(options: CurlOptions, value: string): void {
+  if (value.startsWith("@")) {
+    options.urlencodeFiles.push({ path: value.slice(1) });
+    return;
+  }
+  const atIndex = value.indexOf("@");
+  const eqIndex = value.indexOf("=");
+  if (atIndex > 0 && (eqIndex < 0 || atIndex < eqIndex)) {
+    options.urlencodeFiles.push({
+      name: value.slice(0, atIndex),
+      path: value.slice(atIndex + 1),
+    });
+    return;
+  }
+  options.data =
+    (options.data ? `${options.data}&` : "") + encodeFormData(value);
+}
+
+/**
  * Parse curl command line arguments
  */
 export function parseOptions(args: string[]): CurlOptions | ExecResult {
@@ -16,6 +76,7 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
     method: "GET",
     headers: new _Headers(),
     dataBinary: false,
+    urlencodeFiles: [],
     formFields: [],
     useRemoteName: false,
     headOnly: false,
@@ -56,35 +117,41 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
         const value = header.slice(colonIndex + 1).trim();
         options.headers.append(name, value);
       }
-    } else if (arg === "-d" || arg === "--data" || arg === "--data-raw") {
-      options.data = args[++i] ?? "";
+    } else if (arg === "-d" || arg === "--data") {
+      applyDataArg(options, args[++i] ?? "", {
+        binary: false,
+        allowFile: true,
+      });
+      impliesPost = true;
+    } else if (arg === "--data-raw") {
+      applyDataArg(options, args[++i] ?? "", {
+        binary: false,
+        allowFile: false,
+      });
       impliesPost = true;
     } else if (arg.startsWith("-d")) {
-      options.data = arg.slice(2);
+      applyDataArg(options, arg.slice(2), { binary: false, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data=")) {
-      options.data = arg.slice(7);
+      applyDataArg(options, arg.slice(7), { binary: false, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data-raw=")) {
-      options.data = arg.slice(11);
+      applyDataArg(options, arg.slice(11), {
+        binary: false,
+        allowFile: false,
+      });
       impliesPost = true;
     } else if (arg === "--data-binary") {
-      options.data = args[++i] ?? "";
-      options.dataBinary = true;
+      applyDataArg(options, args[++i] ?? "", { binary: true, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data-binary=")) {
-      options.data = arg.slice(14);
-      options.dataBinary = true;
+      applyDataArg(options, arg.slice(14), { binary: true, allowFile: true });
       impliesPost = true;
     } else if (arg === "--data-urlencode") {
-      const value = args[++i] ?? "";
-      options.data =
-        (options.data ? `${options.data}&` : "") + encodeFormData(value);
+      applyUrlencodeArg(options, args[++i] ?? "");
       impliesPost = true;
     } else if (arg.startsWith("--data-urlencode=")) {
-      const value = arg.slice(17);
-      options.data =
-        (options.data ? `${options.data}&` : "") + encodeFormData(value);
+      applyUrlencodeArg(options, arg.slice(17));
       impliesPost = true;
     } else if (arg === "-F" || arg === "--form") {
       const formData = args[++i] ?? "";

--- a/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
@@ -185,6 +185,28 @@ describe("curl @file interpretation", () => {
       expect(lastRequest?.options.body).toBe("a=1&note=from%20file");
     });
 
+    it("percent-encodes `=` inside file contents (no name=value split)", async () => {
+      // Real file contents may contain `=` bytes that must NOT be treated as
+      // a name/value separator. encodeFormData would split on `=` and emit
+      // `a=b%26c`; the @file form must treat the whole body as one value:
+      // every `=` percent-encodes to %3D.
+      const env = createEnv({ "/note.txt": "a=b&c" });
+      const result = await env.exec(
+        "curl --data-urlencode @/note.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("a%3Db%26c");
+    });
+
+    it("percent-encodes `=` inside file contents for the name@file form", async () => {
+      const env = createEnv({ "/note.txt": "k=v" });
+      const result = await env.exec(
+        "curl --data-urlencode payload@/note.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("payload=k%3Dv");
+    });
+
     it("supports --data-urlencode=@file form", async () => {
       const env = createEnv({ "/note.txt": "hi there" });
       const result = await env.exec(

--- a/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Tests for `@file` interpretation in curl's --data, --data-binary,
+ * --data-urlencode, and --data-raw flags.
+ *
+ * Behavior parity goals with real curl:
+ *   -d @file              → read file; strip CR + LF.
+ *   --data @file          → same as -d @file.
+ *   --data-binary @file   → read file; preserve newlines.
+ *   --data-raw @file      → literal string "@file" (no file read).
+ *   --data-urlencode @file       → read file, URL-encode contents.
+ *   --data-urlencode name@file   → "name=" + URL-encode(file contents).
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Bash } from "../../../Bash.js";
+
+const originalFetch = global.fetch;
+let lastRequest: { url: string; options: RequestInit } | null = null;
+
+const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+  lastRequest = { url, options: options ?? {} };
+  return new Response("OK", {
+    status: 200,
+    headers: { "content-type": "text/plain" },
+  });
+});
+
+beforeAll(() => {
+  global.fetch = mockFetch as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+const createEnv = (files: Record<string, string> = {}) =>
+  new Bash({
+    files,
+    network: {
+      allowedUrlPrefixes: ["https://api.example.com"],
+      allowedMethods: ["GET", "POST", "PUT", "DELETE"],
+    },
+  });
+
+describe("curl @file interpretation", () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    lastRequest = null;
+  });
+
+  describe("-d / --data @file", () => {
+    it("-d @file reads the file contents as the body", async () => {
+      const env = createEnv({ "/payload.json": '{"hello":"world"}' });
+      const result = await env.exec(
+        "curl -d @/payload.json https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.method).toBe("POST");
+      expect(lastRequest?.options.body).toBe('{"hello":"world"}');
+    });
+
+    it("--data @file reads the file contents", async () => {
+      const env = createEnv({ "/payload.txt": "first=1&second=2" });
+      const result = await env.exec(
+        "curl --data @/payload.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("first=1&second=2");
+    });
+
+    it("--data=@file reads the file contents", async () => {
+      const env = createEnv({ "/payload.json": '{"a":1}' });
+      const result = await env.exec(
+        "curl --data=@/payload.json https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe('{"a":1}');
+    });
+
+    it("-d@file (no space) reads the file contents", async () => {
+      const env = createEnv({ "/payload.txt": "x=1" });
+      const result = await env.exec(
+        "curl -d@/payload.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("x=1");
+    });
+
+    it("-d @file strips CR and LF from the file contents", async () => {
+      const env = createEnv({
+        "/payload.txt": "line1\nline2\r\nline3",
+      });
+      const result = await env.exec(
+        "curl -d @/payload.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("line1line2line3");
+    });
+
+    it("fails cleanly when the file does not exist", async () => {
+      const env = createEnv();
+      const result = await env.exec(
+        "curl -d @/missing.json https://api.example.com/test",
+      );
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toMatch(/curl/);
+    });
+  });
+
+  describe("--data-binary @file", () => {
+    it("reads the file contents as the body", async () => {
+      const env = createEnv({ "/blob.bin": "binary payload contents" });
+      const result = await env.exec(
+        "curl --data-binary @/blob.bin https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.method).toBe("POST");
+      expect(lastRequest?.options.body).toBe("binary payload contents");
+    });
+
+    it("preserves newlines in the file (unlike --data)", async () => {
+      const env = createEnv({ "/multiline.txt": "line1\nline2\r\nline3" });
+      const result = await env.exec(
+        "curl --data-binary @/multiline.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("line1\nline2\r\nline3");
+    });
+
+    it("supports --data-binary=@file form", async () => {
+      const env = createEnv({ "/blob.txt": "hello" });
+      const result = await env.exec(
+        "curl --data-binary=@/blob.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("hello");
+    });
+  });
+
+  describe("--data-raw treats @ literally", () => {
+    it("does NOT read the file when value starts with @", async () => {
+      const env = createEnv({ "/payload.json": '{"a":1}' });
+      const result = await env.exec(
+        "curl --data-raw @/payload.json https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      // Body is the literal string "@/payload.json", not the file contents.
+      expect(lastRequest?.options.body).toBe("@/payload.json");
+    });
+  });
+
+  describe("--data-urlencode @file", () => {
+    it("URL-encodes the file contents when value is @file", async () => {
+      const env = createEnv({ "/note.txt": "hello world & friends" });
+      const result = await env.exec(
+        "curl --data-urlencode @/note.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("hello%20world%20%26%20friends");
+    });
+
+    it("URL-encodes the file contents with name when value is name@file", async () => {
+      const env = createEnv({ "/note.txt": "value with space" });
+      const result = await env.exec(
+        "curl --data-urlencode note@/note.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("note=value%20with%20space");
+    });
+
+    it("concatenates inline and @file urlencode values with &", async () => {
+      const env = createEnv({ "/note.txt": "from file" });
+      const result = await env.exec(
+        'curl --data-urlencode "a=1" --data-urlencode note@/note.txt https://api.example.com/test',
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("a=1&note=from%20file");
+    });
+
+    it("supports --data-urlencode=@file form", async () => {
+      const env = createEnv({ "/note.txt": "hi there" });
+      const result = await env.exec(
+        "curl --data-urlencode=@/note.txt https://api.example.com/test",
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("hi%20there");
+    });
+  });
+
+  describe("mixed inline + file payloads", () => {
+    it("merges -d @file with a trailing --data-urlencode inline", async () => {
+      const env = createEnv({ "/payload.txt": "from=file" });
+      const result = await env.exec(
+        'curl -d @/payload.txt --data-urlencode "x=1" https://api.example.com/test',
+      );
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("from=file&x=1");
+    });
+  });
+});

--- a/packages/just-bash/src/commands/curl/types.ts
+++ b/packages/just-bash/src/commands/curl/types.ts
@@ -33,8 +33,10 @@ export interface CurlOptions {
   /**
    * File backing the `data` payload when `-d`/`--data`/`--data-binary` was
    * given as `@filename`. Mutually exclusive with `data` — whichever form
-   * appears last on the command line wins, matching real curl's
-   * last-write-wins for these single-shot options.
+   * appears last on the command line wins. This last-write-wins shape is
+   * the established just-bash behavior for `-d`/`--data*` inline values
+   * and intentionally differs from real curl, which combines repeated
+   * `-d` payloads with `&`. The `@file` work here preserves that scope.
    */
   dataFile?: DataFile;
   /**

--- a/packages/just-bash/src/commands/curl/types.ts
+++ b/packages/just-bash/src/commands/curl/types.ts
@@ -9,11 +9,40 @@ export interface FormField {
   contentType?: string;
 }
 
+export interface UrlencodeFile {
+  /** Optional field name; emits `name=` prefix before the encoded file contents. */
+  name?: string;
+  /** Path to read; resolved against ctx.cwd at execute time. */
+  path: string;
+}
+
+export interface DataFile {
+  /**
+   * `ascii` matches `-d`/`--data` semantics: CR and LF are stripped after
+   * reading. `binary` matches `--data-binary`: file bytes are sent verbatim.
+   */
+  mode: "ascii" | "binary";
+  path: string;
+}
+
 export interface CurlOptions {
   method: string;
   headers: Headers;
   data?: string;
   dataBinary: boolean;
+  /**
+   * File backing the `data` payload when `-d`/`--data`/`--data-binary` was
+   * given as `@filename`. Mutually exclusive with `data` — whichever form
+   * appears last on the command line wins, matching real curl's
+   * last-write-wins for these single-shot options.
+   */
+  dataFile?: DataFile;
+  /**
+   * `--data-urlencode @file` and `--data-urlencode name@file` accumulate
+   * here. Each entry is encoded at execute time and joined with `&`
+   * alongside any inline urlencode payload accumulated in `data`.
+   */
+  urlencodeFiles: UrlencodeFile[];
   formFields: FormField[];
   user?: string;
   uploadFile?: string;


### PR DESCRIPTION
## Summary

Real curl reads the contents of a file when the `-d`/`--data`, `--data-binary`, or `--data-urlencode` flag is passed `@filename`. just-bash's curl previously sent the literal `@filename` string as the HTTP body, breaking any agent workflow that tries the very normal `curl --data-binary @payload.json https://…` pattern. `-T/--upload-file` and `-F/--form` already honored `@file`; the `-d`-family did not.

This PR brings the four data flags to parity with upstream curl:

| Flag | Old behavior | New behavior |
| --- | --- | --- |
| `-d @file` / `--data @file` | sent `"@file"` as body | reads file, strips CR + LF (per `man curl`) |
| `--data-binary @file` | sent `"@file"` as body | reads file verbatim, newlines preserved |
| `--data-urlencode @file` | URL-encoded the string `"@file"` | reads file, URL-encodes contents |
| `--data-urlencode name@file` | unrecognized form | `name=` + URL-encode(file contents) |
| `--data-raw @file` | sent `"@file"` literally | **unchanged** — documented "no `@` interpretation" |

## Implementation

- `parse.ts`: factor a small `applyDataArg(value, {binary, allowFile})` helper and a `applyUrlencodeArg(value)` helper. `--data-raw` is parsed with `allowFile: false`. File references for `-d`/`--data-binary` are recorded in a new `dataFile: { mode: 'ascii' | 'binary'; path: string }` field so the async read is deferred to execute time. `--data-urlencode` `@file` and `name@file` accumulate into a new `urlencodeFiles: { name?: string; path: string }[]` list.
- `curl.ts`: `prepareRequestBody` resolves `dataFile` (with CR/LF stripping for ascii mode) and walks `urlencodeFiles`, joining everything with `&`. A mixed invocation like `curl -d @file --data-urlencode "x=1"` still concatenates the two payloads, matching real curl's behavior of letting you mix the flavors.
- `help.ts`: tighten the one-liners so the `@file` form is discoverable from `curl --help`.

`options.data` is left in place; nothing observable changes for inline values, so the existing 190 curl tests continue to pass unchanged.

## Tests

`packages/just-bash/src/commands/curl/tests/data-at-file.test.ts` (15 new cases) covers:

- All six `-d @file` syntax variants (space, `=`, no-space) including CR/LF stripping.
- `--data-binary @file` newline preservation + `=@file` form.
- `--data-raw` continues to treat `@` as literal.
- `--data-urlencode @file`, `name@file`, `=@file`, and inline+file concatenation.
- Missing-file error path.
- Mixed `-d @file --data-urlencode "x=1"` merge.

```
Test Files  16 passed (16)
     Tests  205 passed (205)
```

Plus a changeset (`patch`) describing the behavior change for downstream consumers.

## Test plan

- [ ] `pnpm typecheck`
- [ ] `pnpm --filter just-bash test:run src/commands/curl/`
- [ ] Smoke test with the interactive shell: `echo '{"hello":"world"}' > /tmp/p.json && pnpm shell` then `curl --data-binary @/tmp/p.json https://httpbin.org/post`