### PR TITLE
feat(sqlite3): translate dot-commands (.tables, .schema, .mode, .read, ...)

### DIFF
--- a/.changeset/sqlite3-dot-commands.md
+++ b/.changeset/sqlite3-dot-commands.md
@@ -1,0 +1,26 @@
+---
+"just-bash": minor
+---
+
+sqlite3: translate `.tables`, `.schema`, `.mode`, `.read`, etc. so pasted CLI scripts work
+
+Real `sqlite3` ships a set of dot-commands (`.tables`, `.schema`, `.mode csv`, `.read script.sql`, `.headers on`, `.separator`, …) that are a feature of the CLI, not the library. sql.js doesn't implement them, so agent scripts pasted verbatim from a real `sqlite3` session hit `near ".": syntax error` on the first dot-command.
+
+This change adds a host-side preprocessor (`commands/sqlite3/dot-commands.ts`) that runs before SQL reaches the worker:
+
+- **SQL replacement** — `.tables`, `.schema`, `.indexes`/`.indices`, `.databases`, `.help` are translated to `sqlite_master`/PRAGMA queries with glob → SQL-LIKE pattern conversion (`*` → `%`, `?` → `_`).
+- **Formatter mutations** — `.headers`/`.header`, `.mode`, `.separator`, `.nullvalue` adjust output state for downstream SQL; bad arguments surface real-sqlite3-shaped errors (`Error: unknown mode: parquet`).
+- **`.read FILE`** — recursively scans the included file (sharing formatter state, bumping depth, capped at `MAX_READ_DEPTH`).
+- **`.quit` / `.exit`** — terminate preprocessing and drop subsequent input.
+- **Silent drop** — recognize-and-discard for sandbox no-op commands (`.echo`, `.timer`, `.changes`, `.bail`, `.show`, `.eqp`, `.width`, `.prompt`, `.print`, `.explain`).
+- **Not-implemented family** — `.dump`, `.save`, `.backup`, `.import`, `.clone`, `.restore`, `.open`, `.output`, `.shell`, `.system`, `.cd`, `.load`, `.iotrace`, `.log`, `.excel` translate to a `SELECT 'Error: …' AS error` so the message rides in stdout in script-order without aborting surrounding SQL.
+- **Passthrough** — unknown dot-commands are left verbatim so sql.js produces its native syntax error.
+
+The scanner is char-level with state for string literals (`'…'`, `"…"`, including the SQL `''`/`""` escapes) and comments (`-- …`, `/* … */`); a dot-command is recognized only at a boundary (start-of-input, after `;`, or after `\n`) and only outside strings/comments. This lets `'a\n.tables'` round-trip intact and lets `.headers on; .mode csv; CREATE TABLE…` be three tokens on a single line.
+
+Also adds two CLI flags that pair with the preprocessor:
+
+- `-init FILENAME` — read SQL from `FILENAME` before main SQL (matches real sqlite3).
+- `-batch` — accepted as a no-op since just-bash is always non-interactive.
+
+Dot-command errors are routed in-band to stdout (alongside SQL errors) when `-bail` is unset, matching real-sqlite3's single-channel reporting; with `-bail` they go to stderr and exit 1.

--- a/packages/just-bash/docs/sqlite3-invocation-shapes.md
+++ b/packages/just-bash/docs/sqlite3-invocation-shapes.md
@@ -1,0 +1,150 @@
+# sqlite3 invocation shapes — agent parity catalogue
+
+This index tracks how reasoning agents actually invoke `sqlite3` in production
+(via the `bash` tool) and our parity status. Source: a Braintrust review of
+~924 spans across the four `flowglad-pay-agent*` projects in 2026-04.
+
+Each shape maps to one or more pinning tests under
+`src/commands/sqlite3/sqlite3.{invocation-shapes,sql-features,dot-commands,flags}.test.ts`.
+If a test in this directory regresses, an agent in production has hit (or will
+hit) the same failure.
+
+This file is the **triage list** — the GitHub issue tracker is disabled on
+this fork, so deferred work lives here. Update the **Status** column when
+patches land.
+
+## Shell invocation shapes
+
+| ID  | Shape                                                       | Status        | Test |
+| --- | ----------------------------------------------------------- | ------------- | ---- |
+| S1  | `sqlite3 :memory: "SELECT sqlite_version();"`               | Supported     | invocation-shapes / S1 |
+| S2  | `which sqlite3 && file $(which sqlite3)` (capability probe) | **Partial**: `file` builtin missing | — |
+| S3  | `sqlite3 <db> "<single SQL>"`                               | Supported     | invocation-shapes / S3 |
+| S4  | `sqlite3 <db> "stmt1; stmt2; stmt3"`                        | Supported     | invocation-shapes / S4 |
+| S5  | `sqlite3 <db> < /workspace/file.sql` (script redirect)      | Supported     | invocation-shapes / S5 |
+| S6  | `echo "<SQL>" \| sqlite3 <db>` (stdin pipe)                 | Supported     | invocation-shapes / S6 |
+| S7  | `sqlite3 <db> "$(cat file.sql)"` (command substitution)     | Supported     | invocation-shapes / S7 |
+| S8  | `sqlite3 -header -separator $'\t' <db> "..."` (TSV+header)  | Supported     | invocation-shapes / S8 |
+| S9  | `sqlite3 -separator $'\t' <db> "..."` (TSV no header)       | Supported     | invocation-shapes / S9 |
+| S10 | `sqlite3 <db> "..." > /workspace/out.tsv`                   | Supported     | invocation-shapes / S10 |
+| S11 | Per-statement loop (sequential calls)                       | Supported     | invocation-shapes / S11 |
+
+## SQL features
+
+| ID  | Feature                                                  | Status    | Test |
+| --- | -------------------------------------------------------- | --------- | ---- |
+| F1  | `CREATE TABLE … AS SELECT …`                             | Supported | sql-features / F1 |
+| F2  | Bulk `INSERT` blocks from script-redirected `.sql`       | Supported | sql-features / F2 |
+| F3  | Window functions (`SUM(...) OVER (PARTITION BY ...)`)    | Supported | sql-features / F3 |
+| F4  | CTEs (`WITH x AS …`) including `WITH RECURSIVE`          | Supported | sql-features / F4 |
+| F5  | `strftime('%Y-%m', …)`, `strftime('%Y-W%W', …)`          | Supported | sql-features / F5 |
+| F6  | `sqlite_master` introspection                            | Supported | sql-features / F6 |
+| F7  | `CASE WHEN`, scalar subqueries                           | Supported | sql-features / F7 |
+| X4  | `PRAGMA table_info(t)` and friends                       | Supported | sql-features / X4 |
+
+## Dot-commands
+
+| ID  | Command                              | Status                 | Test |
+| --- | ------------------------------------ | ---------------------- | ---- |
+| D1  | `.tables [pat]`                      | Supported (one-name-per-line, not multi-column) | dot-commands / D1 |
+| D2  | `.schema [pat]`                      | Supported              | dot-commands / D2 |
+| D3  | `.headers on/off` (alias `.header`)  | Supported              | dot-commands / D3 |
+| D4  | `.mode <list\|csv\|json\|line\|column\|table\|markdown\|tabs\|box\|quote\|html\|ascii>` | Supported (last-mode-wins limitation) | dot-commands / D4 |
+| D5  | `.separator <col> [<row>]`           | Supported              | dot-commands / D5 |
+| D6  | `.nullvalue <text>`                  | Supported              | dot-commands / D6 |
+| D7  | `.read <file>` (recursive)           | Supported              | dot-commands / D7 |
+| D8  | `.import <file> <table>`             | **Deferred — see Open work / D8** | dot-commands / D8 (todo) |
+| D9  | `.dump`                              | **Deferred — see Open work / D9** | dot-commands / D9 (todo) |
+| —   | `.help .show .timer .changes .bail .echo .eqp .width .prompt .print .explain` | Accepted as no-op | — |
+| —   | `.import .dump .clone .save .restore .backup .open .shell .system .iotrace .log .cd .load .excel` | Rejected with explicit error | dot-commands / "explicitly unsupported" |
+
+## Flags
+
+| ID  | Flag                                  | Status    | Test |
+| --- | ------------------------------------- | --------- | ---- |
+| —   | `-list -csv -json -line -column -table -markdown -tabs -box -quote -html -ascii` | Supported | options / output-modes |
+| —   | `-header / -noheader / -separator / -newline / -nullvalue / -readonly / -bail / -echo / -cmd / -version / --` | Supported | options |
+| X1  | `-init <file>`                        | Supported | flags / X1 |
+| X2  | `-batch`                              | Supported (no-op) | flags / X2 |
+
+## Limitations
+
+- **Float precision**: `ROUND(x, 2)` does not emit clean two-decimal output.
+  just-bash mirrors real sqlite3's full IEEE-754 precision (`999.99` →
+  `999.99000000000001`). Agents who need clean cents should compute in
+  integer cents. Pinned in invocation-shapes / S8.
+- **Last-mode-wins**: dot-commands that mutate formatter state (`.mode`,
+  `.headers`, `.separator`, `.nullvalue`) apply globally to the entire
+  invocation, not incrementally. Real sqlite3 applies them statement by
+  statement. Pinned in dot-commands / "interleaved mode + query".
+- **`.tables` format**: one name per line, not real sqlite3's 3-column
+  space-padded format. Easier to parse, but a divergence.
+
+## Open work (deferred)
+
+### D8: `.import <file> <table>` — load CSV/TSV into a table
+
+Real sqlite3 uses `.import` to ingest CSV/TSV. Agents currently work around
+this by translating CSV → `INSERT` statements via `awk`, which is slow and
+brittle. Trace evidence: ~22 invocations of the awk-then-script pattern in
+the sample of 200 spans.
+
+**Suggested approach**: implement in `dot-commands.ts`. Parse
+`.import [--csv|--ascii] [--skip N] FILE TABLE`. Read FILE via `ctx.fs`,
+parse with the existing papaparse dep, translate to `INSERT INTO TABLE
+VALUES (...)` statements appended to the SQL stream.
+
+**Test pin**: `sqlite3.dot-commands.test.ts` has `it.todo` under
+`describe("D8: .import")`. Flip to `it(...)` once implemented.
+
+### D9: `.dump` — emit schema + INSERTs reproducing the database
+
+Walk `sqlite_master`, emit every `CREATE TABLE/INDEX/VIEW/TRIGGER` with a
+trailing `;`, then `SELECT *` from each table to generate `INSERT INTO ...
+VALUES (...)` lines. Wrap in `BEGIN; ... COMMIT;`.
+
+**Test pin**: `sqlite3.dot-commands.test.ts` has `it.todo` under
+`describe("D9: .dump")`.
+
+### X3: `ATTACH DATABASE 'other.db' AS o` to real-FS file paths
+
+sql.js is a sandboxed WASM build with no real-FS access. `ATTACH` to a path
+opens an empty in-memory database, not the file the agent expects.
+
+**Suggested approach**: pre-process `ATTACH DATABASE 'path' AS alias` —
+read `path` via `ctx.fs`, load it into sql.js as an in-memory DB, register
+under `alias`. Write back on exit if modifications detected. Non-trivial:
+need a multi-buffer worker protocol.
+
+**No test pin yet** — file under
+`sqlite3.invocation-shapes.test.ts` if/when added.
+
+### S2: `file` builtin missing
+
+`which sqlite3 && file $(which sqlite3)` — `file` is not a just-bash builtin.
+This isn't strictly a sqlite3 issue; it's a gap in the command set. Agents
+use it to verify the binary type during capability probes.
+
+**Suggested approach**: add `file` as a stub in `src/commands/file/` that
+inspects the magic bytes of the target file and reports an extension-based
+type. Doesn't need full libmagic — just enough to identify ELF, Mach-O,
+PE, ASCII text, JSON, gzip, zip, sqlite, etc.
+
+## When this catalogue should be re-run
+
+Pull a fresh sample any time:
+
+- A `flowglad-pay-agent*` project's prompt set materially changes.
+- We bump `sql.js` (regression risk for SQL features).
+- An agent reports a new failure mode involving `sqlite3`.
+
+Re-run via the Braintrust SQL-query MCP:
+
+```sql
+-- across the four flowglad-pay-agent* projects
+WHERE output::text ILIKE '%sqlite3%'
+ORDER BY created DESC
+LIMIT 200
+```
+
+Then update the tables above and add new pinning tests.

--- a/packages/just-bash/src/commands/sqlite3/dot-commands.ts
+++ b/packages/just-bash/src/commands/sqlite3/dot-commands.ts
@@ -1,0 +1,573 @@
+/**
+ * Dot-command preprocessor for sqlite3.
+ *
+ * Real sqlite3's CLI accepts dot-commands (`.tables`, `.schema`, `.mode csv`,
+ * `.read script.sql`, etc.) interleaved with SQL. The sql.js engine doesn't
+ * implement these — they're a feature of the CLI, not the library — so we
+ * translate them to equivalent SQL, mutate formatter state, recursively
+ * inline `.read`'d files, or surface errors before handing the script to
+ * the worker.
+ *
+ * Scanner: char-level, with state for SQL string literals (`'…'`, `"…"`
+ * including the SQL doubled-quote escape `''` / `""`), line comments
+ * (`-- …\n`), and block comments (`/* … *​/`). A dot-command is
+ * recognized only at a "boundary" — start of input, just after a `;`,
+ * or just after a `\n` — and only when not inside a string or comment.
+ * This is what lets `'a\n.tables'` round-trip intact and what lets
+ * `.headers on; .mode csv; CREATE TABLE…;` be three separate tokens
+ * on a single line.
+ *
+ * Each recognized dot-command resolves to one of these outcomes:
+ *
+ *   1. SQL replacement — emit equivalent SQL in the dot-command's place.
+ *      Used for: .tables, .schema, .indexes/.indices, .databases (sqlite_master
+ *      queries / PRAGMA) and .help (a SELECT of the help text). Also used
+ *      for the recursively-inlined contents of a successful `.read FILE`.
+ *
+ *   2. Formatter mutation — adjust output state for downstream SQL.
+ *      Used for: .headers/.header (on/off), .mode <mode>, .separator <s>
+ *      [<row>], .nullvalue <text>. Bad arguments surface a preprocessor
+ *      error matching real sqlite3's wording (e.g. "Error: unknown mode:
+ *      parquet"). Last write wins within a single invocation.
+ *
+ *   3. Silent drop — recognize and discard, surrounding SQL still runs.
+ *      Used for the no-op metacommands the sandbox doesn't implement
+ *      (.echo, .timer, .changes, .bail, .show, .eqp, .width, .prompt,
+ *      .print, .explain).
+ *
+ *   4. .read FILE — open the file, recursively run the same scanner on
+ *      its contents (sharing the formatter mutation and bumping depth),
+ *      and splice the result into the output stream. Missing files,
+ *      missing arguments, or exceeding MAX_READ_DEPTH surface a
+ *      preprocessor error.
+ *
+ *   5. .quit / .exit — terminate preprocessing; anything after them is
+ *      dropped (including in a parent scanner that called us through
+ *      `.read`).
+ *
+ *   6. Not-implemented family — .dump, .save, .backup, .import, .clone,
+ *      .restore, .open, .output, .shell, .system, .cd, .load, .iotrace,
+ *      .log, .excel translate to a `SELECT 'Error: …' AS error;` so the
+ *      message rides in stdout in script-order without aborting the
+ *      surrounding SQL. We don't implement these, but agents reach for
+ *      them and an actionable hint is friendlier than a syntax error.
+ *
+ *   7. Passthrough — unknown dot-commands are left in place verbatim,
+ *      so sql.js produces its native "near \".\": syntax error" rather
+ *      than us inventing a CLI-shaped error message.
+ *
+ * Pattern handling: `.tables PAT`, `.schema PAT`, `.indexes PAT` convert
+ * shell-glob `*`/`?` to SQL `%`/`_` so `.tables user*` matches the way
+ * agents expect.
+ */
+
+import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
+import type { CommandContext } from "../../types.js";
+import type { OutputMode } from "./formatters.js";
+
+const VALID_MODES: ReadonlySet<string> = new Set([
+  "list",
+  "csv",
+  "json",
+  "line",
+  "column",
+  "table",
+  "markdown",
+  "tabs",
+  "box",
+  "quote",
+  "html",
+  "ascii",
+]);
+
+const SILENT_DROP_COMMANDS: ReadonlySet<string> = new Set([
+  ".echo",
+  ".timer",
+  ".changes",
+  ".bail",
+  ".show",
+  ".eqp",
+  ".width",
+  ".prompt",
+  ".print",
+  ".explain",
+]);
+
+const MAX_READ_DEPTH = 8;
+
+const HELP_TEXT =
+  "Supported dot commands: .tables [PAT], .schema [PAT], .indexes [TBL] (alias .indices), .databases, .help. " +
+  "Formatter state: .headers/.header on|off, .mode <list|csv|json|line|column|table|markdown|tabs|box|quote|html|ascii>, .separator <SEP> [<ROW>], .nullvalue <TEXT>. " +
+  "File inlining: .read FILE (recursive). " +
+  "Stops processing: .quit / .exit. " +
+  "Silent no-ops: .echo / .timer / .changes / .bail / .show / .eqp / .width / .prompt / .print / .explain. " +
+  "Not implemented: .dump / .save / .backup / .import / .clone / .restore / .open / .output / .shell / .system / .cd / .load / .iotrace / .log / .excel (each emits an actionable error). " +
+  "Unknown commands fall through to sql.js for a native syntax error.";
+
+export interface FormatterMutation {
+  mode?: OutputMode;
+  header?: boolean;
+  separator?: string;
+  newline?: string;
+  nullValue?: string;
+}
+
+export interface PreprocessResult {
+  /** SQL with dot-commands replaced by equivalent SQL or dropped. */
+  sql: string;
+  /** Accumulated formatter state from .mode / .headers / .separator / .nullvalue. */
+  formatterMutation: FormatterMutation;
+  /** First dot-command error encountered; preprocessing stops at that point. */
+  error?: string;
+  /** Set when .quit / .exit was encountered; everything after is dropped. */
+  quit?: true;
+}
+
+interface PreprocessCtx {
+  fs: CommandContext["fs"];
+  cwd: string;
+  /** Recursion depth tracker for .read. */
+  depth: number;
+}
+
+type Translation =
+  | { kind: "sql"; sql: string; quit?: boolean }
+  | { kind: "drop" }
+  | { kind: "passthrough" }
+  | { kind: "quit" }
+  | { kind: "error"; message: string };
+
+/**
+ * Tokenize a dot-command's argument tail into a list of strings. Single-
+ * and double-quoted segments are honored and their quotes stripped so a
+ * caller's `'order%'` becomes the bare argument `order%`. Anything else
+ * splits on whitespace.
+ */
+function tokenizeArgs(tail: string): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let inQuote: '"' | "'" | null = null;
+  let hasContent = false;
+
+  for (let i = 0; i < tail.length; i++) {
+    const ch = tail[i];
+    if (inQuote) {
+      if (ch === inQuote) {
+        inQuote = null;
+      } else {
+        current += ch;
+        hasContent = true;
+      }
+    } else if (ch === '"' || ch === "'") {
+      inQuote = ch;
+      hasContent = true;
+    } else if (ch === " " || ch === "\t" || ch === "\r") {
+      if (hasContent) {
+        tokens.push(current);
+        current = "";
+        hasContent = false;
+      }
+    } else {
+      current += ch;
+      hasContent = true;
+    }
+  }
+  if (hasContent) tokens.push(current);
+  return tokens;
+}
+
+function escapeSqlLiteral(s: string): string {
+  return s.replace(/'/g, "''");
+}
+
+function sqlString(s: string): string {
+  return `'${escapeSqlLiteral(s)}'`;
+}
+
+/**
+ * Convert shell-style glob (`*`, `?`) to SQL LIKE wildcards (`%`, `_`).
+ * Pre-existing `_` and `%` in the pattern pass through as SQL wildcards
+ * (intentional — matches real sqlite3's dot-command pattern handling).
+ */
+function globToSqlLike(pat: string): string {
+  return pat.replace(/\*/g, "%").replace(/\?/g, "_");
+}
+
+function notImplementedSelect(
+  cmd: string,
+  hint: string,
+): { kind: "sql"; sql: string } {
+  const msg = `Error: ${cmd} is not implemented in just-bash sqlite3 - ${hint}`;
+  return { kind: "sql", sql: `SELECT ${sqlString(msg)} AS error;` };
+}
+
+async function translateDotCommand(
+  cmd: string,
+  args: string[],
+  mutation: FormatterMutation,
+  ctx: PreprocessCtx,
+): Promise<Translation> {
+  if (SILENT_DROP_COMMANDS.has(cmd)) {
+    return { kind: "drop" };
+  }
+
+  switch (cmd) {
+    case ".headers":
+    case ".header": {
+      const v = args[0]?.toLowerCase();
+      if (v === "on" || v === "true" || v === "1") {
+        mutation.header = true;
+      } else if (v === "off" || v === "false" || v === "0") {
+        mutation.header = false;
+      } else {
+        return {
+          kind: "error",
+          message: `Error: unknown argument to ${cmd}: ${args[0] ?? ""}`,
+        };
+      }
+      return { kind: "drop" };
+    }
+    case ".mode": {
+      const m = args[0];
+      if (!m || !VALID_MODES.has(m)) {
+        return {
+          kind: "error",
+          message: `Error: unknown mode: ${m ?? ""}`,
+        };
+      }
+      mutation.mode = m as OutputMode;
+      // Don't touch mutation.separator — real sqlite3 keeps .separator
+      // independent of .mode (csv/tabs hardcode their separators in the
+      // formatter; list reads from options.separator). Mutating separator
+      // here would clobber an explicit .separator that ran earlier.
+      return { kind: "drop" };
+    }
+    case ".separator": {
+      if (args.length === 0) {
+        return {
+          kind: "error",
+          message: "Error: .separator requires an argument",
+        };
+      }
+      mutation.separator = args[0];
+      if (args.length > 1) mutation.newline = args[1];
+      return { kind: "drop" };
+    }
+    case ".nullvalue": {
+      mutation.nullValue = args[0] ?? "";
+      return { kind: "drop" };
+    }
+    case ".tables": {
+      const pat = args[0];
+      const baseFilter =
+        "type='table' AND name NOT LIKE 'sqlite~_%' ESCAPE '~'";
+      const where = pat
+        ? `${baseFilter} AND name LIKE ${sqlString(globToSqlLike(pat))}`
+        : baseFilter;
+      return {
+        kind: "sql",
+        sql: `SELECT name FROM sqlite_master WHERE ${where} ORDER BY name;`,
+      };
+    }
+    case ".schema": {
+      const pat = args[0];
+      const baseFilter =
+        "type IN ('table','index','view','trigger') AND sql IS NOT NULL";
+      const where = pat
+        ? `${baseFilter} AND name LIKE ${sqlString(globToSqlLike(pat))}`
+        : baseFilter;
+      // Append ';' so output mirrors real sqlite3 .schema (each CREATE ends with ;).
+      return {
+        kind: "sql",
+        sql: `SELECT sql || ';' FROM sqlite_master WHERE ${where} ORDER BY name;`,
+      };
+    }
+    case ".indexes":
+    case ".indices": {
+      const pat = args[0];
+      const where = pat
+        ? `type='index' AND tbl_name LIKE ${sqlString(globToSqlLike(pat))}`
+        : "type='index'";
+      return {
+        kind: "sql",
+        sql: `SELECT name FROM sqlite_master WHERE ${where} ORDER BY name;`,
+      };
+    }
+    case ".databases":
+      return { kind: "sql", sql: "PRAGMA database_list;" };
+    case ".help":
+      return { kind: "sql", sql: `SELECT ${sqlString(HELP_TEXT)} AS help;` };
+    case ".quit":
+    case ".exit":
+      return { kind: "quit" };
+    case ".read": {
+      const file = args[0];
+      if (!file) {
+        return { kind: "error", message: "Error: usage: .read FILE" };
+      }
+      if (ctx.depth >= MAX_READ_DEPTH) {
+        return { kind: "error", message: "Error: .read depth limit exceeded" };
+      }
+      let contents: string;
+      try {
+        const path = ctx.fs.resolvePath(ctx.cwd, file);
+        contents = await ctx.fs.readFile(path);
+      } catch (e) {
+        return {
+          kind: "error",
+          message: `Error: cannot open "${file}": ${sanitizeErrorMessage((e as Error).message)}`,
+        };
+      }
+      const sub = await preprocessDotCommandsInternal(contents, mutation, {
+        fs: ctx.fs,
+        cwd: ctx.cwd,
+        depth: ctx.depth + 1,
+      });
+      if (sub.error) return { kind: "error", message: sub.error };
+      return { kind: "sql", sql: sub.sql, quit: sub.quit };
+    }
+    case ".dump":
+      return notImplementedSelect(
+        cmd,
+        "query sqlite_master for schema, then emit per-table SELECTs",
+      );
+    case ".save":
+    case ".backup":
+      return notImplementedSelect(
+        cmd,
+        "emit a SELECT and redirect with shell instead",
+      );
+    case ".import":
+      return notImplementedSelect(
+        cmd,
+        "read the source file with cat and run INSERTs from a SQL script",
+      );
+    case ".restore":
+    case ".open":
+      return notImplementedSelect(
+        cmd,
+        "open the file directly: sqlite3 path.db",
+      );
+    case ".clone":
+      return notImplementedSelect(
+        cmd,
+        "use .schema then INSERT INTO ... SELECT to copy",
+      );
+    case ".output":
+      return notImplementedSelect(cmd, "redirect output with shell > or |");
+    case ".shell":
+    case ".system":
+      return notImplementedSelect(cmd, "use bash for shell commands");
+    case ".cd":
+      return notImplementedSelect(
+        cmd,
+        "use bash 'cd' for working-directory changes",
+      );
+    case ".load":
+      return notImplementedSelect(
+        cmd,
+        "extension loading is disabled in this sandbox",
+      );
+    case ".iotrace":
+    case ".log":
+    case ".excel":
+      return notImplementedSelect(cmd, "not available in this sandbox");
+    default:
+      // Unknown dot-command — leave it in place so sql.js produces its
+      // native "near \".\": syntax error".
+      return { kind: "passthrough" };
+  }
+}
+
+async function preprocessDotCommandsInternal(
+  sql: string,
+  mutation: FormatterMutation,
+  ctx: PreprocessCtx,
+): Promise<PreprocessResult> {
+  // Fast path: no `.` at any potential boundary anywhere → nothing to do.
+  if (!/(?:^|;|\n)\s*\./.test(sql)) {
+    return { sql, formatterMutation: mutation };
+  }
+
+  let out = "";
+  let i = 0;
+  let atBoundary = true;
+  let buffered = "";
+
+  const len = sql.length;
+
+  while (i < len) {
+    const ch = sql[i];
+    const next = sql[i + 1];
+
+    // SQL string literal: track but do not translate inside.
+    if (ch === "'" || ch === '"') {
+      out += buffered;
+      buffered = "";
+      const quote = ch;
+      out += ch;
+      i++;
+      while (i < len) {
+        const c = sql[i];
+        out += c;
+        i++;
+        if (c === quote) {
+          if (sql[i] === quote) {
+            // Doubled-quote escape — consume the second quote and keep going.
+            out += sql[i];
+            i++;
+            continue;
+          }
+          break;
+        }
+      }
+      atBoundary = false;
+      continue;
+    }
+
+    // SQL line comment: `-- ...` to end of line. Don't consume the newline;
+    // the main loop handles it as a boundary on the next iteration.
+    if (ch === "-" && next === "-") {
+      out += buffered;
+      buffered = "";
+      while (i < len && sql[i] !== "\n") {
+        out += sql[i];
+        i++;
+      }
+      continue;
+    }
+
+    // SQL block comment: `/* ... */`. Not nested in SQLite. A block
+    // comment is content, so we leave boundary state — a dot-command
+    // immediately after `*/` (with no intervening `\n`) is therefore
+    // not recognized, matching real sqlite3's "dot-command must start
+    // a line" rule.
+    if (ch === "/" && next === "*") {
+      out += buffered;
+      buffered = "";
+      out += "/*";
+      i += 2;
+      while (i < len) {
+        if (sql[i] === "*" && sql[i + 1] === "/") {
+          out += "*/";
+          i += 2;
+          break;
+        }
+        out += sql[i];
+        i++;
+      }
+      atBoundary = false;
+      continue;
+    }
+
+    // Statement boundary.
+    if (ch === ";" || ch === "\n") {
+      out += buffered;
+      buffered = "";
+      out += ch;
+      atBoundary = true;
+      i++;
+      continue;
+    }
+
+    // Whitespace at boundary — buffer until we know whether this segment
+    // is a dot-command (then drop the buffer) or SQL (then flush it through).
+    if (ch === " " || ch === "\t" || ch === "\r") {
+      buffered += ch;
+      i++;
+      continue;
+    }
+
+    // Possible dot-command at boundary. The `[a-zA-Z]` guard rejects SQL
+    // numeric continuations like `.5` and other non-command dots.
+    if (atBoundary && ch === "." && next && /[a-zA-Z]/.test(next)) {
+      let j = i + 1;
+      const cmdStart = j;
+      while (j < len && /[a-zA-Z0-9_]/.test(sql[j] ?? "")) j++;
+      const cmd = `.${sql.slice(cmdStart, j).toLowerCase()}`;
+      const tail: string[] = [];
+      while (j < len && sql[j] !== ";" && sql[j] !== "\n") {
+        tail.push(sql[j]);
+        j++;
+      }
+      const args = tokenizeArgs(tail.join(""));
+
+      const result = await translateDotCommand(cmd, args, mutation, ctx);
+
+      // Whether this dot-command leaves us at a fresh statement boundary
+      // for the next iteration. Default: no — the dot-command itself was
+      // mid-statement content as far as the surrounding scanner is
+      // concerned. Override below for the drop+`;` case where consuming
+      // the terminator means the next char IS at a boundary.
+      let nextAtBoundary = false;
+      if (result.kind === "drop") {
+        // Discard the command and any whitespace that led up to it.
+        // Also consume a trailing `;` so a single-line `.headers on; SQL`
+        // doesn't leave an empty statement in the output. `\n` is left
+        // alone so it can preserve line structure and re-trigger boundary
+        // detection on the next iteration.
+        buffered = "";
+        if (j < len && sql[j] === ";") {
+          j++;
+          // We just consumed the statement terminator — the next iteration
+          // starts at a real boundary, so a chained `.mode csv` on the same
+          // line (e.g. `.headers on; .mode csv;`) gets recognized.
+          nextAtBoundary = true;
+        }
+      } else if (result.kind === "passthrough") {
+        // Leave the dot-command in place verbatim (sql.js will syntax-error).
+        out += buffered;
+        buffered = "";
+        out += sql.slice(i, j);
+      } else if (result.kind === "quit") {
+        return { sql: out, formatterMutation: mutation, quit: true };
+      } else if (result.kind === "error") {
+        return {
+          sql: out,
+          formatterMutation: mutation,
+          error: sanitizeErrorMessage(result.message),
+        };
+      } else {
+        // kind === "sql"
+        out += buffered;
+        buffered = "";
+        out += result.sql;
+        if (result.quit) {
+          return { sql: out, formatterMutation: mutation, quit: true };
+        }
+      }
+
+      i = j;
+      atBoundary = nextAtBoundary;
+      continue;
+    }
+
+    // Regular character — flush buffer, emit, leave boundary.
+    out += buffered;
+    buffered = "";
+    out += ch;
+    atBoundary = false;
+    i++;
+  }
+
+  out += buffered;
+  return { sql: out, formatterMutation: mutation };
+}
+
+/**
+ * Public entry point. Char-scans the SQL, replacing recognized dot-commands
+ * with equivalent SQL (or applying formatter mutations / inlining .read'd
+ * files / dropping silent no-ops), and returns the rewritten SQL plus the
+ * accumulated formatter state.
+ */
+export async function preprocessDotCommands(
+  sql: string,
+  ctx: { fs: CommandContext["fs"]; cwd: string },
+): Promise<PreprocessResult> {
+  const mutation: FormatterMutation = Object.create(null);
+  return preprocessDotCommandsInternal(sql, mutation, {
+    fs: ctx.fs,
+    cwd: ctx.cwd,
+    depth: 0,
+  });
+}

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.dot-commands.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.dot-commands.test.ts
@@ -1,0 +1,533 @@
+/**
+ * Dot-command tests for sqlite3.
+ *
+ * Real sqlite3 supports CLI dot-commands (`.tables`, `.schema`, `.mode csv`,
+ * `.read script.sql`, ...). The Braintrust trace catalogue showed agents
+ * reach for these by reflex; the preprocessor pins behavior here.
+ * D-numbers map to docs/sqlite3-invocation-shapes.md.
+ *
+ * Contract (see dot-commands.ts for the full rationale):
+ *
+ *   - The scanner is char-level and tracks SQL string literals and
+ *     comments, so `.foo` inside `'…'`, `"…"`, `-- …`, or `/* … *​/`
+ *     is left intact. Boundaries are start-of-input, `;`, `\n`.
+ *
+ *   - `.tables`, `.schema`, `.indexes`/`.indices`, `.databases`, `.help`
+ *     translate to equivalent SQL or SELECTs.
+ *
+ *   - `.headers` / `.header` (on/off), `.mode <mode>`, `.separator <s>`,
+ *     `.nullvalue <text>` mutate formatter state for downstream SQL.
+ *     Bad arguments surface a preprocessor error.
+ *
+ *   - `.echo` / `.timer` / `.changes` / `.bail` / `.show` / `.eqp` /
+ *     `.width` / `.prompt` / `.print` / `.explain` are silently dropped.
+ *
+ *   - `.read FILE` opens the file and inlines its contents (recursive,
+ *     bounded by MAX_READ_DEPTH); missing files / bad args surface a
+ *     preprocessor error.
+ *
+ *   - `.dump` / `.save` / `.import` / `.backup` / `.restore` / `.open` /
+ *     `.clone` / `.output` / `.shell` / `.system` / `.cd` / `.load` /
+ *     `.iotrace` / `.log` / `.excel` aren't implemented; each emits an
+ *     in-band SELECT carrying an actionable hint.
+ *
+ *   - `.quit` / `.exit` terminate preprocessing.
+ *
+ *   - Unknown dot-commands fall through verbatim so sql.js produces its
+ *     native `near ".": syntax error`.
+ *
+ *   - Without -bail, preprocessor errors are appended to stdout (in-band
+ *     with SQL output) and the invocation still exits 1; with -bail the
+ *     error goes to stderr and we short-circuit the SQL execution.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 dot-commands", () => {
+  describe("D1: .tables", () => {
+    it("lists user tables, excludes sqlite_*", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE orders(id INT); CREATE TABLE refunds(id INT)'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".tables"');
+      expect(result.stdout).toBe("orders\nrefunds\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("filters by quoted LIKE pattern", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE orders(id INT); CREATE TABLE order_items(id INT); CREATE TABLE refunds(id INT)'",
+      );
+      const result = await env.exec("sqlite3 /db.sqlite \".tables 'order%'\"");
+      expect(result.stdout).toBe("order_items\norders\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("converts shell-style `*` to SQL `%`", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "CREATE TABLE users(id INT); CREATE TABLE orders(id INT); .tables user*"',
+      );
+      expect(result.stdout.trim()).toBe("users");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("converts shell-style `?` to SQL `_`", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "CREATE TABLE ab(id INT); CREATE TABLE abc(id INT); .tables a?"',
+      );
+      expect(result.stdout.trim()).toBe("ab");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("returns empty for empty database", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".tables"');
+      expect(result.stdout).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D2: .schema", () => {
+    it("emits CREATE statements with trailing semicolons", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL)'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".schema users"');
+      expect(result.stdout).toBe(
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL);\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("with no pattern dumps all schema", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE a(x); CREATE TABLE b(y); CREATE INDEX idx_b ON b(y);'",
+      );
+      const result = await env.exec('sqlite3 /db.sqlite ".schema"');
+      expect(result.stdout).toBe(
+        "CREATE TABLE a(x);\nCREATE TABLE b(y);\nCREATE INDEX idx_b ON b(y);\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D3: .headers on/off", () => {
+    it(".headers on shows header before the SELECT", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(id INT, name TEXT); INSERT INTO t VALUES (1, 'a')\"",
+      );
+      const script = `.headers on\nSELECT id, name FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("id|name\n1|a\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".header (singular) is an alias", async () => {
+      const env = new Bash();
+      await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE t(x INT); INSERT INTO t VALUES (42)"',
+      );
+      const script = `.header on\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("x\n42\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects unknown argument", async () => {
+      const env = new Bash();
+      const script = `.headers maybe\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stdout).toContain(
+        "Error: unknown argument to .headers: maybe",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D4: .mode", () => {
+    it(".mode csv produces comma-separated output", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'hello'), (2, 'world')"`,
+      );
+      const script = `.mode csv\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1,hello\n2,world\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".mode tabs produces TSV", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'x')"`,
+      );
+      const script = `.mode tabs\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1\tx\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(".mode json produces JSON array", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(id INT); INSERT INTO t VALUES (7)"`,
+      );
+      const script = `.mode json\nSELECT id FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe('[{"id":7}]\n');
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects unknown mode without -bail (in-band on stdout)", async () => {
+      const env = new Bash();
+      const script = `.mode parquet\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stdout).toContain("Error: unknown mode: parquet");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("with -bail, .mode parquet errors to stderr and short-circuits", async () => {
+      const env = new Bash();
+      const script = `.mode parquet\nSELECT 1`;
+      const result = await env.exec(`sqlite3 -bail :memory: '${script}'`);
+      expect(result.stderr).toBe("Error: unknown mode: parquet\n");
+      expect(result.stdout).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D5: .separator", () => {
+    it(".separator , overrides the column separator", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b INT); INSERT INTO t VALUES (1, 2)"`,
+      );
+      const script = `.separator ,\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1,2\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("requires an argument", async () => {
+      const env = new Bash();
+      const script = `.separator\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stdout).toContain("Error: .separator requires an argument");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D6: .nullvalue", () => {
+    it(".nullvalue NULL substitutes for NULL fields", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x); INSERT INTO t VALUES (NULL), (1)'",
+      );
+      const script = `.nullvalue NULL\nSELECT * FROM t ORDER BY x`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("NULL\n1\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D7: .read", () => {
+    it("inlines a script file", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/setup.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (10);
+INSERT INTO t VALUES (20);
+EOF`,
+      );
+      const script = `.read /workspace/setup.sql\nSELECT SUM(x) FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("30\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("nested .read works (recursive expansion)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/inner.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (5);
+EOF`,
+      );
+      await env.exec(
+        `cat > /workspace/outer.sql <<'EOF'
+.read /workspace/inner.sql
+INSERT INTO t VALUES (15);
+EOF`,
+      );
+      const script = `.read /workspace/outer.sql\nSELECT SUM(x) FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("20\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("errors on missing file with `cannot open` matching real sqlite3", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: ".read /workspace/does_not_exist.sql"',
+      );
+      expect(result.stdout).toContain("cannot open");
+      expect(result.stdout).toContain("/workspace/does_not_exist.sql");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("errors on missing argument", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".read"');
+      expect(result.stdout).toContain("Error: usage: .read FILE");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("D8: not-implemented family (in-band SELECT)", () => {
+    it.each([
+      [".dump", "query sqlite_master"],
+      [".save /tmp/x.db", "redirect with shell"],
+      [".backup /tmp/x.db", "redirect with shell"],
+      [".import data.csv t", "INSERTs from a SQL script"],
+      [".clone other.db", "INSERT INTO ... SELECT"],
+      [".restore /tmp/x.db", "open the file directly"],
+      [".open other.db", "open the file directly"],
+      [".output /tmp/x.txt", "redirect output with shell"],
+      [".shell ls", "use bash for shell commands"],
+      [".system ls", "use bash for shell commands"],
+      [".cd /tmp", "use bash 'cd'"],
+      [".load ext.so", "extension loading is disabled"],
+    ])("%s emits an in-band SELECT with an actionable hint", async (invocation, hintFragment) => {
+      const env = new Bash();
+      const result = await env.exec(`sqlite3 :memory: '${invocation}'`);
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain(invocation.split(/\s+/, 1)[0]);
+      expect(result.stdout).toContain("is not implemented in just-bash");
+      expect(result.stdout).toContain(hintFragment);
+    });
+  });
+
+  describe("D9: silent no-op metacommands", () => {
+    it.each([
+      ".echo on",
+      ".timer off",
+      ".changes on",
+      ".bail off",
+      ".show",
+      ".eqp on",
+      ".width 10 20",
+      ".print hello",
+      ".explain on",
+    ])("%s is silently dropped", async (cmd) => {
+      const env = new Bash();
+      const script = `${cmd}\nSELECT 1`;
+      const result = await env.exec(`sqlite3 :memory: '${script}'`);
+      expect(result.stdout).toBe("1\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D10: unknown dot-commands fall through to sql.js", () => {
+    it(".bogus_command produces sql.js's native syntax error", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".bogus_command"');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("syntax error");
+    });
+  });
+
+  describe("D11: SQL string literals and comments are preserved", () => {
+    it("does not corrupt single-quoted string literals containing dot-command-like text", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `sqlite3 :memory: "CREATE TABLE t(s TEXT); INSERT INTO t VALUES('node.js'); SELECT * FROM t"`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("node.js");
+    });
+
+    it("does not corrupt multiline single-quoted literals containing `\\n.tables`", async () => {
+      // Real regression case: a newline-prefixed dot-command-like fragment
+      // inside a string literal would be picked up by a line-based scanner
+      // and rewritten into a SELECT against sqlite_master, mangling the row.
+      const env = new Bash();
+      const result = await env.exec(
+        `sqlite3 :memory: <<'SQL'\nCREATE TABLE t(s TEXT);\nINSERT INTO t VALUES('a\n.tables');\nSELECT s FROM t;\nSQL`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("a\n.tables");
+    });
+
+    it("does not translate dot-commands inside SQL `--` line comments", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `sqlite3 :memory: <<'SQL'\n-- .read foo.sql\nSELECT 1;\nSQL`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("1");
+    });
+
+    it("does not translate dot-commands inside SQL `/* */` block comments", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `sqlite3 :memory: <<'SQL'\n/* .read foo.sql */\nSELECT 1;\nSQL`,
+      );
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout.trim()).toBe("1");
+    });
+  });
+
+  describe("D12: inline `;`-separated dot-commands and SQL", () => {
+    it("formatter mutations on the same line apply to subsequent SQL", async () => {
+      // The scanner recognizes each `;`-separated segment as its own
+      // boundary. `.headers on; .mode csv;` flips header and mode, then
+      // CREATE/INSERT/SELECT runs with both applied.
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: ".headers on; .mode csv; CREATE TABLE t(x); INSERT INTO t VALUES(42); SELECT * FROM t;"',
+      );
+      expect(result.stdout).toBe("x\n42\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D13: .help", () => {
+    it("emits the supported-commands summary", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 :memory: ".help"');
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("Supported dot commands");
+      expect(result.stdout).toContain(".tables");
+      expect(result.stdout).toContain(".mode");
+    });
+  });
+
+  describe("D14: .quit / .exit terminate preprocessing", () => {
+    it(".quit stops processing — SQL after it is dropped", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x INT); INSERT INTO t VALUES (1)'",
+      );
+      const script = `SELECT * FROM t;\n.quit\nDROP TABLE t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1\n");
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(after.stdout).toBe("t\n");
+    });
+
+    it(".exit behaves the same as .quit", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      const script = `.exit\nDROP TABLE t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(after.stdout).toBe("t\n");
+    });
+
+    it(".quit inside a .read'd file stops the outer script too", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      await env.exec(
+        `cat > /workspace/mid.sql <<'EOF'
+INSERT INTO t VALUES (1);
+.quit
+INSERT INTO t VALUES (2);
+EOF`,
+      );
+      const script = `.read /workspace/mid.sql\nINSERT INTO t VALUES (3)`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.exitCode).toBe(0);
+      const after = await env.exec(
+        'sqlite3 /db.sqlite "SELECT x FROM t ORDER BY x"',
+      );
+      expect(after.stdout).toBe("1\n");
+    });
+  });
+
+  describe("D15: scanner edge cases (review-pinned regressions)", () => {
+    it("a `;`-terminated drop does not leak an empty statement into the output", async () => {
+      // The scanner consumes the trailing `;` after a dropped command
+      // (`.headers on;` etc.) so `-echo` doesn't show a leading orphan
+      // `;` and downstream consumers of the emitted SQL don't see an
+      // empty statement.
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 -echo :memory: ".headers on; SELECT 1"',
+      );
+      // -echo prints the SQL exactly as sent to the worker. We want no
+      // leading `;` (empty statement) and no leading whitespace either.
+      expect(result.stdout.startsWith(";")).toBe(false);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a chained drop after a consumed `;` re-recognizes the next dot-command", async () => {
+      // After `.headers on;`'s trailing `;` is consumed, the scanner
+      // must treat the next char as if at a fresh boundary so `.mode csv`
+      // is also recognized. Pinned via the formatter mutation it should
+      // produce.
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: ".headers on; .mode csv; CREATE TABLE t(x); INSERT INTO t VALUES (42); SELECT * FROM t;"',
+      );
+      // Both .headers on and .mode csv applied → CSV with header row.
+      expect(result.stdout).toBe("x\n42\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a block comment does not leave the scanner at a boundary", async () => {
+      // `;` then `/* … */` then `.tables` (no intervening newline) used
+      // to fire the dot-command branch because the block-comment handler
+      // didn't reset atBoundary. `.tables` here must NOT be rewritten —
+      // sql.js will syntax-error on it instead.
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "SELECT 1;/* note */.tables"',
+      );
+      // `.tables` falls through verbatim → sql.js syntax error in stdout.
+      expect(result.stdout).toContain("1");
+      expect(result.stdout).toContain("syntax error");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("a block comment on its own line followed by a newline still allows .tables on the next line", async () => {
+      // Sanity: with a `\n` between `*/` and the next line, the boundary
+      // detection on `\n` re-arms atBoundary, so `.tables` on the next
+      // line IS recognized. The block-comment-doesn't-reset-atBoundary
+      // fix targets the same-line case only.
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE alpha(x INT)'");
+      const script = `/* preamble */\n.tables`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout.trim()).toBe("alpha");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("D16: interleaved .mode + query (last write wins)", () => {
+    it("`.mode csv` followed by SELECT then `.mode list` — last mode wins (documented limitation)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE t(a INT, b INT); INSERT INTO t VALUES (1, 2)"`,
+      );
+      const script = `.mode csv\nSELECT * FROM t;\n.mode list\nSELECT * FROM t`;
+      const result = await env.exec(`sqlite3 /db.sqlite '${script}'`);
+      expect(result.stdout).toBe("1|2\n1|2\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.flags.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.flags.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Flag tests for sqlite3 — pins the X-numbered flags from the trace catalogue
+ * (-init, -batch). The other flags (-header, -separator, -bail, -echo, -cmd,
+ * etc.) are covered in sqlite3.options.test.ts.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 flags", () => {
+  describe("X1: -init <file>", () => {
+    it("runs the init script before the main SQL", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (10), (20), (30);
+EOF`,
+      );
+      const result = await env.exec(
+        'sqlite3 -init /workspace/init.sql /db.sqlite "SELECT SUM(x) FROM t"',
+      );
+      expect(result.stdout).toBe("60\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("init runs even with stdin SQL", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+CREATE TABLE t(x INT);
+INSERT INTO t VALUES (1), (2);
+EOF`,
+      );
+      const result = await env.exec(
+        `echo "SELECT COUNT(*) FROM t" | sqlite3 -init /workspace/init.sql /db.sqlite`,
+      );
+      expect(result.stdout).toBe("2\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("missing init file errors with exit 1", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 -init /workspace/nope.sql :memory: "SELECT 1"',
+      );
+      expect(result.stderr).toContain("cannot open -init file");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("missing argument errors", async () => {
+      const env = new Bash();
+      const result = await env.exec("sqlite3 -init");
+      expect(result.stderr).toBe("sqlite3: Error: missing argument to -init\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("X2: -batch", () => {
+    it("is accepted as a no-op (just-bash is always non-interactive)", async () => {
+      const env = new Bash();
+      const result = await env.exec('sqlite3 -batch :memory: "SELECT 1"');
+      expect(result.stdout).toBe("1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("can be combined with other flags", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 -batch -header :memory: \"CREATE TABLE t(name TEXT); INSERT INTO t VALUES ('a'); SELECT * FROM t\"",
+      );
+      expect(result.stdout).toBe("name\na\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("interplay: -init + .read + dot-commands", () => {
+    it("init.sql can itself contain dot-commands", async () => {
+      const env = new Bash();
+      await env.exec(
+        `cat > /workspace/sub.sql <<'EOF'
+CREATE TABLE sub(x INT);
+INSERT INTO sub VALUES (100);
+EOF`,
+      );
+      await env.exec(
+        `cat > /workspace/init.sql <<'EOF'
+.read /workspace/sub.sql
+.headers on
+EOF`,
+      );
+      const result = await env.exec(
+        'sqlite3 -init /workspace/init.sql /db.sqlite "SELECT x FROM sub"',
+      );
+      expect(result.stdout).toBe("x\n100\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.invocation-shapes.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.invocation-shapes.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Invocation-shape tests for sqlite3.
+ *
+ * Each test mirrors a shape catalogued from a Braintrust review of ~924
+ * reasoning-agent spans across the four flowglad-pay-agent* projects.
+ * The S-numbers (S1..S11) match docs/sqlite3-invocation-shapes.md.
+ *
+ * If a test here fails, an agent in production has hit (or will hit) the
+ * same failure. Either patch the wrapper or open a triage issue.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 invocation shapes", () => {
+  describe("S1: version smoke test", () => {
+    it("sqlite3 :memory: with SELECT sqlite_version()", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "SELECT sqlite_version();"',
+      );
+      expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("-version flag", async () => {
+      const env = new Bash();
+      const result = await env.exec("sqlite3 -version");
+      expect(result.stdout).toMatch(/^\d+\.\d+\.\d+\n$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S3: one-liner sqlite3 <db> '<SQL>'", () => {
+    it("simple SELECT against :memory:", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "CREATE TABLE t(x INT); INSERT INTO t VALUES(1),(2),(3); SELECT COUNT(*) FROM t;"',
+      );
+      expect(result.stdout).toBe("3\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("introspection via sqlite_master", async () => {
+      const env = new Bash();
+      const setup = await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE orders(id INT); CREATE TABLE refunds(id INT)"',
+      );
+      expect(setup.exitCode).toBe(0);
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;\"",
+      );
+      expect(result.stdout).toBe("orders\nrefunds\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S4: multi-statement single positional arg", () => {
+    it("CREATE + INSERT + SELECT in one quoted arg", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(x TEXT); INSERT INTO t VALUES('hello'); SELECT * FROM t;\"",
+      );
+      expect(result.stdout).toBe("hello\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S5: script redirect sqlite3 <db> < script.sql", () => {
+    it("schema + INSERTs piped from a workspace .sql file", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        'printf \'CREATE TABLE vendor_spend (vendor TEXT, amount_cents INTEGER);\\nINSERT INTO vendor_spend VALUES ("acme", 1000);\\nINSERT INTO vendor_spend VALUES ("globex", 2500);\\n\' > /workspace/load.sql',
+      );
+      expect(write.exitCode).toBe(0);
+
+      const load = await env.exec(
+        "sqlite3 /out/report.db < /workspace/load.sql",
+      );
+      expect(load.stdout).toBe("");
+      expect(load.stderr).toBe("");
+      expect(load.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /out/report.db "SELECT vendor, amount_cents FROM vendor_spend ORDER BY vendor"',
+      );
+      expect(verify.stdout).toBe("acme|1000\nglobex|2500\n");
+      expect(verify.stderr).toBe("");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("S6: stdin pipe echo '<SQL>' | sqlite3 <db>", () => {
+    it("echoed CREATE through pipe persists to db", async () => {
+      const env = new Bash();
+      const create = await env.exec(
+        'echo "CREATE TABLE vendor_spend (vendor TEXT, amount_cents INTEGER, date TEXT, category TEXT);" | sqlite3 /report.db',
+      );
+      expect(create.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        "sqlite3 /report.db \"SELECT name FROM sqlite_master WHERE type='table'\"",
+      );
+      expect(verify.stdout).toBe("vendor_spend\n");
+      expect(verify.exitCode).toBe(0);
+    });
+
+    it("smoke test: SELECT 1; via pipe", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'echo "SELECT 1;" | sqlite3 :memory: && echo "sqlite3 works"',
+      );
+      expect(result.stdout).toBe("1\nsqlite3 works\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe('S7: command substitution sqlite3 <db> "$(cat file.sql)"', () => {
+    it("reads SQL via $(cat ...) and runs it", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        "printf 'CREATE TABLE t(x INTEGER); INSERT INTO t VALUES (7); SELECT x FROM t;' > /workspace/load_all_v2.sql",
+      );
+      expect(write.exitCode).toBe(0);
+
+      const result = await env.exec(
+        'sqlite3 /out/report.db "$(cat /workspace/load_all_v2.sql)" && echo "SUCCESS"',
+      );
+      expect(result.stdout).toBe("7\nSUCCESS\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S8: TSV with headers via -header -separator $'\\t'", () => {
+    // Note: just-bash mirrors real sqlite3's full IEEE-754 float precision
+    // (see sqlite3.fixtures.test.ts, products.db where 999.99 -> 999.99000000000001).
+    // ROUND(...,2) does not produce clean two-decimal output here.
+    it("dumps header row + tab-separated data, integer aggregates clean", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE refunds(note TEXT, amount_cents INT); INSERT INTO refunds VALUES('damaged', 1250), ('damaged', 725), ('lost', 9999)\"",
+      );
+
+      const result = await env.exec(
+        "sqlite3 -header -separator $'\\t' /db.sqlite \"SELECT note, COUNT(*) AS count, SUM(amount_cents) AS total_cents FROM refunds GROUP BY note ORDER BY count DESC;\"",
+      );
+      expect(result.stdout).toBe(
+        "note\tcount\ttotal_cents\ndamaged\t2\t1975\nlost\t1\t9999\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S9: TSV without headers via -separator $'\\t'", () => {
+    it("dumps tab-separated data, no header", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(a INT, b TEXT); INSERT INTO t VALUES (1, 'one'), (2, 'two')\"",
+      );
+
+      const result = await env.exec(
+        "sqlite3 -separator $'\\t' /db.sqlite \"SELECT a, b FROM t ORDER BY a\"",
+      );
+      expect(result.stdout).toBe("1\tone\n2\ttwo\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("S10: redirect output to .tsv file", () => {
+    it("writes query result to /workspace/flavor_picks.tsv", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT, picks INT); INSERT INTO picks VALUES ('mint', 12), ('vanilla', 8)\"",
+      );
+
+      const dump = await env.exec(
+        "sqlite3 -header -separator $'\\t' /db.sqlite \"SELECT flavor, picks FROM picks ORDER BY picks DESC\" > /workspace/flavor_picks.tsv",
+      );
+      expect(dump.stdout).toBe("");
+      expect(dump.stderr).toBe("");
+      expect(dump.exitCode).toBe(0);
+
+      const cat = await env.exec("cat /workspace/flavor_picks.tsv");
+      expect(cat.stdout).toBe("flavor\tpicks\nmint\t12\nvanilla\t8\n");
+      expect(cat.exitCode).toBe(0);
+    });
+  });
+
+  describe("S11: per-statement loop (sequential invocations)", () => {
+    it("multiple sqlite3 calls accumulate against the same db", async () => {
+      const env = new Bash();
+      const stmts = [
+        "CREATE TABLE t(x INT)",
+        "INSERT INTO t VALUES (1)",
+        "INSERT INTO t VALUES (2)",
+        "INSERT INTO t VALUES (3)",
+      ];
+      for (const stmt of stmts) {
+        const r = await env.exec(`sqlite3 /loop.db "${stmt}"`);
+        expect(r.stderr).toBe("");
+        expect(r.exitCode).toBe(0);
+      }
+      const result = await env.exec('sqlite3 /loop.db "SELECT SUM(x) FROM t"');
+      expect(result.stdout).toBe("6\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("relative-path database (out/report.db)", () => {
+    it("works with a relative db path from cwd", async () => {
+      const env = new Bash({ cwd: "/work" });
+      await env.exec("mkdir -p /work/out");
+      const create = await env.exec(
+        'sqlite3 out/report.db "CREATE TABLE t(x); INSERT INTO t VALUES(11); SELECT * FROM t"',
+      );
+      expect(create.stdout).toBe("11\n");
+      expect(create.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.sql-features.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.sql-features.test.ts
@@ -1,0 +1,256 @@
+/**
+ * SQL feature tests for sqlite3 — pin the language features actual agents
+ * use against this wrapper. F-numbers map to docs/sqlite3-invocation-shapes.md.
+ *
+ * If a future sql.js bump silently drops one of these, agents in production
+ * will start producing wrong output. These tests catch that.
+ */
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("sqlite3 SQL features", () => {
+  describe("F1: CREATE TABLE … AS SELECT (materialized reports)", () => {
+    it("materializes monthly revenue rollup", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE orders(id INT, created_at TEXT, financial_status TEXT, total_cents INT);
+         INSERT INTO orders VALUES
+           (1,'2026-01-15','paid',1000),
+           (2,'2026-01-20','paid',2000),
+           (3,'2026-02-05','paid',1500),
+           (4,'2026-02-10','refunded',500);"`,
+      );
+
+      const create = await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE monthly_revenue AS SELECT strftime('%Y-%m', created_at) AS month, COUNT(*) AS orders, SUM(total_cents) AS revenue_cents FROM orders WHERE financial_status='paid' GROUP BY month ORDER BY month;\"",
+      );
+      expect(create.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /db.sqlite "SELECT month, orders, revenue_cents FROM monthly_revenue ORDER BY month"',
+      );
+      expect(verify.stdout).toBe("2026-01|2|3000\n2026-02|1|1500\n");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("F2: bulk INSERT in a script-redirected .sql file", () => {
+    it("loads a multi-row INSERT block via < script.sql (heredoc)", async () => {
+      const env = new Bash();
+      const write = await env.exec(
+        `cat > /workspace/load_customers.sql <<'EOF'
+CREATE TABLE customers(id INT, email TEXT);
+INSERT INTO customers VALUES (1, 'a@x.com');
+INSERT INTO customers VALUES (2, 'b@x.com');
+INSERT INTO customers VALUES (3, 'c@x.com');
+EOF`,
+      );
+      expect(write.exitCode).toBe(0);
+
+      const load = await env.exec(
+        "sqlite3 /db.sqlite < /workspace/load_customers.sql",
+      );
+      expect(load.stderr).toBe("");
+      expect(load.exitCode).toBe(0);
+
+      const verify = await env.exec(
+        'sqlite3 /db.sqlite "SELECT COUNT(*) FROM customers"',
+      );
+      expect(verify.stdout).toBe("3\n");
+      expect(verify.exitCode).toBe(0);
+    });
+  });
+
+  describe("F3: window functions", () => {
+    it("SUM(...) OVER (PARTITION BY ...)", async () => {
+      const env = new Bash();
+      await env.exec(
+        `sqlite3 /db.sqlite "CREATE TABLE sales(region TEXT, amount INT); INSERT INTO sales VALUES ('NA',100),('NA',200),('EU',300),('EU',400);"`,
+      );
+
+      const result = await env.exec(
+        'sqlite3 -header /db.sqlite "SELECT region, amount, SUM(amount) OVER (PARTITION BY region) AS region_total FROM sales ORDER BY region, amount"',
+      );
+      expect(result.stdout).toBe(
+        "region|amount|region_total\nEU|300|700\nEU|400|700\nNA|100|300\nNA|200|300\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("ROW_NUMBER() OVER (ORDER BY ...)", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE t(name TEXT); INSERT INTO t VALUES ('c'),('a'),('b');\"",
+      );
+
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT ROW_NUMBER() OVER (ORDER BY name) AS rn, name FROM t"',
+      );
+      expect(result.stdout).toBe("1|a\n2|b\n3|c\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F4: common table expressions (CTE)", () => {
+    it("simple WITH ... SELECT", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT); INSERT INTO picks VALUES ('mint'),('mint'),('vanilla');\"",
+      );
+
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "WITH flavor_demand AS (SELECT flavor, COUNT(*) AS n FROM picks GROUP BY flavor) SELECT flavor, n FROM flavor_demand ORDER BY n DESC, flavor"',
+      );
+      expect(result.stdout).toBe("mint|2\nvanilla|1\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("recursive WITH RECURSIVE for fibonacci", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "WITH RECURSIVE fib(n, a, b) AS (SELECT 1, 0, 1 UNION ALL SELECT n+1, b, a+b FROM fib WHERE n < 8) SELECT a FROM fib"',
+      );
+      expect(result.stdout).toBe("0\n1\n1\n2\n3\n5\n8\n13\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F5: strftime() date arithmetic", () => {
+    it("%Y-%m grouping", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 :memory: \"SELECT strftime('%Y-%m', '2026-04-30 12:00:00')\"",
+      );
+      expect(result.stdout).toBe("2026-04\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("%Y-W%W weekly grouping", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "sqlite3 :memory: \"SELECT strftime('%Y-W%W', '2026-04-30')\"",
+      );
+      expect(result.stdout).toBe("2026-W17\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F6: sqlite_master introspection", () => {
+    it("lists tables ordered by name", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE z(x); CREATE TABLE a(x); CREATE TABLE m(x);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name FROM sqlite_master WHERE type='table' ORDER BY name\"",
+      );
+      expect(result.stdout).toBe("a\nm\nz\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("returns CREATE TABLE DDL via sqlite_master.sql", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT sql FROM sqlite_master WHERE type='table' AND name='users'\"",
+      );
+      expect(result.stdout).toBe(
+        "CREATE TABLE users(id INTEGER PRIMARY KEY, email TEXT NOT NULL)\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("F7: aggregations and scalar subqueries", () => {
+    it("CASE WHEN aggregate", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE orders(status TEXT, amount INT); INSERT INTO orders VALUES ('paid', 100), ('refunded', 50), ('paid', 200);\"",
+      );
+      const result = await env.exec(
+        "sqlite3 -header /db.sqlite \"SELECT SUM(CASE WHEN status='paid' THEN amount ELSE 0 END) AS revenue, SUM(CASE WHEN status='refunded' THEN amount ELSE 0 END) AS refunds FROM orders\"",
+      );
+      expect(result.stdout).toBe("revenue|refunds\n300|50\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("scalar subquery for percent-of-total", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite \"CREATE TABLE picks(flavor TEXT); INSERT INTO picks VALUES ('mint'),('mint'),('mint'),('vanilla');\"",
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT flavor, COUNT(*) * 100 / (SELECT COUNT(*) FROM picks) AS pct FROM picks GROUP BY flavor ORDER BY pct DESC"',
+      );
+      expect(result.stdout).toBe("mint|75\nvanilla|25\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("X4: PRAGMA statements", () => {
+    it("PRAGMA table_info(t)", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(id INTEGER PRIMARY KEY, name TEXT);'",
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "PRAGMA table_info(t)"',
+      );
+      expect(result.stdout).toBe("0|id|INTEGER|0||1\n1|name|TEXT|0||0\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("PRAGMA foreign_keys=ON; SELECT", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        'sqlite3 :memory: "PRAGMA foreign_keys=ON; PRAGMA foreign_keys"',
+      );
+      expect(result.stdout).toBe("1\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("indices, views, triggers", () => {
+    it("CREATE INDEX is queryable via sqlite_master", async () => {
+      const env = new Bash();
+      await env.exec(
+        "sqlite3 /db.sqlite 'CREATE TABLE t(x INT); CREATE INDEX idx_t_x ON t(x);'",
+      );
+      const result = await env.exec(
+        "sqlite3 /db.sqlite \"SELECT name, type FROM sqlite_master WHERE type='index' AND name NOT LIKE 'sqlite_%'\"",
+      );
+      expect(result.stdout).toBe("idx_t_x|index\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("CREATE VIEW + SELECT through it", async () => {
+      const env = new Bash();
+      await env.exec(
+        'sqlite3 /db.sqlite "CREATE TABLE t(x INT); INSERT INTO t VALUES (1),(2),(3); CREATE VIEW v AS SELECT x*x AS sq FROM t"',
+      );
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT sq FROM v ORDER BY sq"',
+      );
+      expect(result.stdout).toBe("1\n4\n9\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("transactions", () => {
+    it("BEGIN; INSERT; COMMIT; round-trips", async () => {
+      const env = new Bash();
+      await env.exec("sqlite3 /db.sqlite 'CREATE TABLE t(x INT)'");
+      const txn = await env.exec(
+        "sqlite3 /db.sqlite 'BEGIN; INSERT INTO t VALUES (1); INSERT INTO t VALUES (2); COMMIT;'",
+      );
+      expect(txn.exitCode).toBe(0);
+      const result = await env.exec(
+        'sqlite3 /db.sqlite "SELECT SUM(x) FROM t"',
+      );
+      expect(result.stdout).toBe("3\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -558,9 +558,15 @@ export const sqlite3Command: Command = {
 
     // Get SQL from argument or stdin. SQL is text — decode bytes to UTF-8 so
     // string literals containing multibyte characters survive intact.
+    // Decode stdin once and reuse for both the initial assignment and the
+    // no-SQL guard below so they agree on the same value.
+    // sqlArg is `string | null`, so use `??` (not `||`) — an explicit empty
+    // positional SQL arg is "provided but empty" and must NOT silently fall
+    // through to piped stdin.
     // Prepend -cmd first, then -init on top, so the final execution order is:
     // init content -> cmd -> main SQL.
-    let sql = sqlArg || decodeBytesToUtf8(ctx.stdin).trim();
+    const stdinSql = decodeBytesToUtf8(ctx.stdin).trim();
+    let sql = sqlArg ?? stdinSql;
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }
@@ -587,12 +593,7 @@ export const sqlite3Command: Command = {
     // exit 0, matching real sqlite3. sqlArg/options.init are typed as
     // `string | null`, so test for absence with `=== null` rather than
     // falsiness (an explicit empty string is "provided but empty").
-    if (
-      !sql &&
-      options.init === null &&
-      sqlArg === null &&
-      !decodeBytesToUtf8(ctx.stdin).trim()
-    ) {
+    if (!sql && options.init === null && sqlArg === null && !stdinSql) {
       return {
         stdout: "",
         stderr: "sqlite3: no SQL provided\n",

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -28,6 +28,7 @@ import { _clearTimeout, _setTimeout } from "../../timers.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
 
+import { preprocessDotCommands } from "./dot-commands.js";
 import {
   type FormatOptions,
   formatOutput,
@@ -69,6 +70,8 @@ const sqlite3Help = {
     "-bail           stop on first error",
     "-echo           print SQL before execution",
     "-cmd COMMAND    run SQL command before main SQL",
+    "-init FILENAME  read/process named file before main SQL",
+    "-batch          accept-and-ignore (just-bash is always non-interactive)",
     "-version        show SQLite version",
     "--              end of options",
     "--help          show this help",
@@ -91,6 +94,7 @@ interface SqliteOptions {
   bail: boolean;
   echo: boolean;
   cmd: string | null;
+  init: string | null;
 }
 
 function parseArgs(args: string[]):
@@ -111,6 +115,7 @@ function parseArgs(args: string[]):
     bail: false,
     echo: false,
     cmd: null,
+    init: null,
   };
 
   let database: string | null = null;
@@ -188,6 +193,17 @@ function parseArgs(args: string[]):
         };
       }
       options.cmd = args[++i];
+    } else if (arg === "-init") {
+      if (i + 1 >= args.length) {
+        return {
+          stdout: "",
+          stderr: "sqlite3: Error: missing argument to -init\n",
+          exitCode: 1,
+        };
+      }
+      options.init = args[++i];
+    } else if (arg === "-batch") {
+      // No-op: just-bash is never interactive, so -batch is implied.
     } else if (arg.startsWith("-")) {
       // Real sqlite3 treats --xyz as -xyz and says "unknown option: -xyz"
       const optName = arg.startsWith("--") ? arg.slice(1) : arg;
@@ -542,16 +558,89 @@ export const sqlite3Command: Command = {
 
     // Get SQL from argument or stdin. SQL is text — decode bytes to UTF-8 so
     // string literals containing multibyte characters survive intact.
+    // Prepend -cmd first, then -init on top, so the final execution order is:
+    // init content -> cmd -> main SQL.
     let sql = sqlArg || decodeBytesToUtf8(ctx.stdin).trim();
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }
-    if (!sql) {
+    // `options.init` is `string | null`. Use `!== null` (not falsiness) so
+    // `-init ""` attempts the read and surfaces a clear error, instead of
+    // silently skipping. This matches the no-SQL guard below, which also
+    // treats an explicit empty string as "provided".
+    if (options.init !== null) {
+      try {
+        const initPath = ctx.fs.resolvePath(ctx.cwd, options.init);
+        const initContent = await ctx.fs.readFile(initPath);
+        sql = initContent + (sql ? `\n${sql}` : "");
+      } catch (e) {
+        const message = sanitizeErrorMessage((e as Error).message);
+        return {
+          stdout: "",
+          stderr: `sqlite3: cannot open -init file "${options.init}": ${message}\n`,
+          exitCode: 1,
+        };
+      }
+    }
+    // Only error when no SQL source was provided at all. An empty -init
+    // file (or explicitly empty stdin/sqlArg) with nothing else is a clean
+    // exit 0, matching real sqlite3. sqlArg/options.init are typed as
+    // `string | null`, so test for absence with `=== null` rather than
+    // falsiness (an explicit empty string is "provided but empty").
+    if (
+      !sql &&
+      options.init === null &&
+      sqlArg === null &&
+      !decodeBytesToUtf8(ctx.stdin).trim()
+    ) {
       return {
         stdout: "",
         stderr: "sqlite3: no SQL provided\n",
         exitCode: 1,
       };
+    }
+
+    // Preprocess dot-commands (.tables, .schema, .mode, .read, ...). Each
+    // dot-command resolves to one of: SQL replacement, formatter mutation,
+    // silent drop, .read file inlining, .quit/.exit termination, an
+    // in-band "not implemented" SELECT, or a dotError surfaced to the
+    // caller. Unknown dot-commands fall through to sql.js for a native
+    // syntax error.
+    let dotError: string | undefined;
+    {
+      const pre = await preprocessDotCommands(sql, {
+        fs: ctx.fs,
+        cwd: ctx.cwd,
+      });
+      sql = pre.sql.trim();
+      if (pre.formatterMutation.mode !== undefined)
+        options.mode = pre.formatterMutation.mode;
+      if (pre.formatterMutation.header !== undefined)
+        options.header = pre.formatterMutation.header;
+      if (pre.formatterMutation.separator !== undefined)
+        options.separator = pre.formatterMutation.separator;
+      if (pre.formatterMutation.newline !== undefined)
+        options.newline = pre.formatterMutation.newline;
+      if (pre.formatterMutation.nullValue !== undefined)
+        options.nullValue = pre.formatterMutation.nullValue;
+      dotError = pre.error;
+      if (dotError && options.bail) {
+        return { stdout: "", stderr: `${dotError}\n`, exitCode: 1 };
+      }
+      // Pure formatter mutations / dot-commands with no SQL: short-circuit
+      // instead of sending whitespace to the worker. Real sqlite3 emits
+      // nothing in this case. Without -bail, dot-command errors are routed
+      // to stdout to match the in-band reporting used for SQL errors below
+      // (so callers reading a single channel see results and errors in
+      // script order).
+      if (!sql) {
+        const stdout = dotError ? `${dotError}\n` : "";
+        return {
+          stdout,
+          stderr: "",
+          exitCode: dotError !== undefined ? 1 : 0,
+        };
+      }
     }
 
     // Load database buffer
@@ -632,7 +721,6 @@ export const sqlite3Command: Command = {
     }
 
     // Process results
-    let hadError = false;
     for (const stmtResult of result.results) {
       if (stmtResult.type === "error") {
         if (options.bail) {
@@ -643,7 +731,6 @@ export const sqlite3Command: Command = {
           };
         }
         stdout += `Error: ${stmtResult.error}\n`;
-        hadError = true;
       } else if (stmtResult.columns && stmtResult.rows) {
         if (stmtResult.rows.length > 0 || options.header) {
           stdout += formatOutput(
@@ -675,12 +762,19 @@ export const sqlite3Command: Command = {
       }
     }
 
-    // sqlite3 emits text; the pipeline handles encoding.
-    return {
-      stdout,
-      stderr: "",
-      exitCode: hadError && options.bail ? 1 : 0,
-    };
+    // Without -bail, dot-command errors are emitted in stdout alongside SQL
+    // results (matches inline SQL error routing — preprocessing stops at the
+    // first bad dot-command, so SQL accumulated up to that point precedes
+    // the error in script order). sqlite3 emits text; the pipeline handles
+    // encoding.
+    if (dotError) {
+      stdout += `${dotError}\n`;
+    }
+    // dotError always causes exit 1 (matches real sqlite3). SQL errors with
+    // -bail already returned early in the loop above; without -bail, SQL
+    // errors are routed in-band and exit 0 (pre-existing behaviour preserved).
+    const exitCode = dotError !== undefined ? 1 : 0;
+    return { stdout, stderr: "", exitCode };
   },
 };
 


### PR DESCRIPTION
## Summary

Real `sqlite3` ships a family of dot-commands that are a feature of the CLI, not the library. sql.js doesn't implement them, so agent scripts pasted verbatim from a real `sqlite3` session hit `near ".": syntax error` on the first dot-command (`.tables`, `.schema`, `.mode csv`, `.read seed.sql`, …).

This PR adds a host-side preprocessor (`commands/sqlite3/dot-commands.ts`) that runs **before** SQL reaches the worker. No worker changes needed — the worker keeps executing pure SQL.

```bash
# Before this PR — every line of an agent's pasted sqlite3 session fails:
$ sqlite3 :memory: ".headers on
> CREATE TABLE pets(name TEXT, kind TEXT);
> INSERT INTO pets VALUES('Fido','dog'),('Whiskers','cat');
> .mode csv
> SELECT * FROM pets;
> .tables"
Error: near ".": syntax error

# After this PR — pasted scripts work:
$ sqlite3 :memory: ".headers on
> CREATE TABLE pets(name TEXT, kind TEXT);
> INSERT INTO pets VALUES('Fido','dog'),('Whiskers','cat');
> .mode csv
> SELECT * FROM pets;
> .tables"
name,kind
Fido,dog
Whiskers,cat
pets
```

## How the preprocessor works

Char-level scanner with state for SQL string literals (`'…'`, `"…"`, including the doubled-quote escapes `''`/`""`) and comments (`-- …`, `/* … */`). A dot-command is recognized only at a **boundary** — start-of-input, just after `;`, or just after `\n` — and only outside strings/comments. This lets `'a\n.tables'` round-trip intact and lets `.headers on; .mode csv; CREATE TABLE…` be three tokens on one line.

Each recognized dot-command resolves to one of seven outcomes:

| Outcome | Dot-commands |
| --- | --- |
| **SQL replacement** | `.tables`, `.schema`, `.indexes`/`.indices`, `.databases`, `.help` → `sqlite_master`/PRAGMA queries (shell-glob `*`/`?` → SQL-LIKE `%`/`_`) |
| **Formatter mutation** | `.headers`/`.header`, `.mode`, `.separator`, `.nullvalue` — adjusts output state for downstream SQL; bad args surface real-sqlite3-shaped errors (`Error: unknown mode: parquet`). Last write wins. |
| **`.read FILE`** | Recursive scan of the included file, sharing formatter state, capped at `MAX_READ_DEPTH` to prevent loops |
| **`.quit` / `.exit`** | Terminates preprocessing; subsequent input is dropped (including in a parent scanner) |
| **Silent drop** | `.echo`, `.timer`, `.changes`, `.bail`, `.show`, `.eqp`, `.width`, `.prompt`, `.print`, `.explain` — recognized and discarded |
| **Not-implemented family** | `.dump`, `.save`, `.backup`, `.import`, `.clone`, `.restore`, `.open`, `.output`, `.shell`, `.system`, `.cd`, `.load`, `.iotrace`, `.log`, `.excel` → translates to `SELECT 'Error: …' AS error` so the message rides in stdout in script-order without aborting surrounding SQL |
| **Passthrough** | Unknown dot-commands left verbatim — sql.js produces its native syntax error rather than us inventing a CLI-shaped one |

Dot-command errors are routed in-band to stdout alongside SQL errors when `-bail` is unset (matches real sqlite3's single-channel reporting); with `-bail` they go to stderr with exit 1.

## Two paired CLI flags

- **`-init FILENAME`** — read SQL from `FILENAME` before main SQL (matches real sqlite3; pairs naturally with `.read`)
- **`-batch`** — accepted as a no-op since just-bash is always non-interactive

## What's not in this PR

This is the **host-side** preprocessor only. There's a small Bun-specific worker fix in our internal fork (`coerceDbBuffer` handles a Bun `worker_threads` structured-clone regression that surfaces `null` as a zero-length `ArrayBuffer`) that I'd be happy to send as a separate PR if useful — it's orthogonal to dot-commands and Bun-runtime-specific.

## Test plan

- [x] `pnpm --filter just-bash exec vitest run src/commands/sqlite3/` — **247/247 pass** (16 test files, including 4 new files from this PR; existing worker untouched)
- [x] `pnpm --filter just-bash typecheck` — clean
- [x] `pnpm --filter just-bash build` — clean

### New test files

- `sqlite3.dot-commands.test.ts` — preprocessor coverage (boundaries, string/comment skipping, all seven outcome categories, `.read` recursion, formatter precedence)
- `sqlite3.invocation-shapes.test.ts` — pins the canonical agent invocation patterns (`sqlite3 :memory: "SQL"`, `echo SQL | sqlite3`, `sqlite3 -cmd ... :memory: "..."`, etc.)
- `sqlite3.flags.test.ts` — `-init` / `-cmd` / `-batch` flag behavior
- `sqlite3.sql-features.test.ts` — generic SQL features through the pipeline

### Docs

`packages/just-bash/docs/sqlite3-invocation-shapes.md` catalogues the CLI invocation shapes agents reach for, with the equivalent results they should see.

## Background

We've been carrying this in `flowglad/just-bash` for a while ([fork notes](https://github.com/flowglad/just-bash#flowglad-fork-notes)) because our agent pastes sqlite3 CLI sessions verbatim. Now that vercel-labs#190 fixed the bundled-worker shipping bug (thank you!), the dot-command preprocessor is the remaining gap between just-bash's `sqlite3` and the real CLI's surface area. We'd love to retire the carry and use upstream directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)