### PR TITLE
fix(sqlite3): handle Bun structured-clone surfacing null as zero-length ArrayBuffer

### DIFF
--- a/.changeset/sqlite3-coerce-db-buffer.md
+++ b/.changeset/sqlite3-coerce-db-buffer.md
@@ -1,0 +1,15 @@
+---
+"just-bash": patch
+---
+
+fix(sqlite3): handle Bun structured-clone surfacing `null` as zero-length `ArrayBuffer`
+
+Bun's `worker_threads` structured-clone has regressed across versions (notably the build shipped in Trigger.dev's container) and surfaces a host-side `null` `dbBuffer` as a zero-length `ArrayBuffer` inside the worker. The prior `if (data.dbBuffer)` guard treated that as truthy, so `new SQL.Database(arrayBuffer)` ran with a bare `ArrayBuffer` — which sql.js rejects with `Expected ArrayBuffer for the first argument` (it wants `Uint8Array`).
+
+Route the buffer through a `coerceDbBuffer` helper that:
+
+- returns a `Uint8Array` as-is (covers `Buffer` too, which extends `Uint8Array`),
+- wraps a non-empty `ArrayBuffer` in a `Uint8Array`,
+- and returns `null` for `null` / `undefined` / zero-length buffers — letting `executeQuery` fall back to `new SQL.Database()` (fresh in-memory db), which matches the host's intent for `:memory:` databases.
+
+No behavior change under Node; fixes `:memory:` invocations under affected Bun builds.

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
+import { coerceDbBuffer } from "./worker.js";
 
 describe("sqlite3", () => {
   describe("basic operations", () => {
@@ -132,6 +133,50 @@ describe("sqlite3", () => {
       // Full IEEE 754 precision like real sqlite3
       expect(result.stdout).toBe('[{"i":42,"f":3.1400000000000001}]\n');
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  // Regression: Bun's worker_threads structured-clone (notably the build
+  // shipped in Trigger.dev's container) surfaces a host-side `null` dbBuffer
+  // as a zero-length ArrayBuffer at the worker. The pre-fix code used
+  // `if (data.dbBuffer) new SQL.Database(data.dbBuffer)`, which let the empty
+  // ArrayBuffer through and threw "Expected ArrayBuffer for the first
+  // argument" from sql.js (sql.js wants Uint8Array, not bare ArrayBuffer).
+  // coerceDbBuffer must collapse those cases to null so the executeQuery call
+  // site falls back to `new SQL.Database()` (fresh in-memory db).
+  describe("coerceDbBuffer (Bun structured-clone regression)", () => {
+    it("returns null for null", () => {
+      expect(coerceDbBuffer(null)).toBeNull();
+    });
+
+    it("returns null for undefined", () => {
+      expect(coerceDbBuffer(undefined)).toBeNull();
+    });
+
+    it("returns null for a zero-length ArrayBuffer (Bun structured-clone case)", () => {
+      expect(coerceDbBuffer(new ArrayBuffer(0))).toBeNull();
+    });
+
+    it("wraps a non-empty ArrayBuffer into a Uint8Array view", () => {
+      const ab = new ArrayBuffer(4);
+      new Uint8Array(ab).set([1, 2, 3, 4]);
+
+      const result = coerceDbBuffer(ab);
+
+      expect(result).toBeInstanceOf(Uint8Array);
+      expect(Array.from(result as Uint8Array)).toEqual([1, 2, 3, 4]);
+    });
+
+    it("returns the same Uint8Array when given a Uint8Array", () => {
+      const u8 = new Uint8Array([10, 20, 30]);
+      expect(coerceDbBuffer(u8)).toBe(u8);
+    });
+
+    it("returns the same buffer when given a Node Buffer", () => {
+      const buf = Buffer.from([5, 6, 7]);
+      const result = coerceDbBuffer(buf);
+      expect(result).toBe(buf);
+      expect(result).toBeInstanceOf(Uint8Array);
     });
   });
 });

--- a/packages/just-bash/src/commands/sqlite3/worker.ts
+++ b/packages/just-bash/src/commands/sqlite3/worker.ts
@@ -28,6 +28,32 @@ import {
 // Cached SQL.js module (initialized once)
 let cachedSQL: SqlJsStatic | null = null;
 
+/**
+ * Coerce a host-supplied dbBuffer into the form sql.js expects.
+ *
+ * Why: Bun's worker_threads structured-clone has regressed across versions
+ * (notably the build shipped in Trigger.dev's container) and surfaces a
+ * host-side `null` dbBuffer as a zero-length ArrayBuffer here. A truthy
+ * empty ArrayBuffer would slip past `if (data.dbBuffer)` and reach
+ * `new SQL.Database(arrayBuffer)`, which throws "Expected ArrayBuffer for
+ * the first argument" (sql.js wants Uint8Array, not bare ArrayBuffer).
+ * Treat empty/non-Uint8Array values as "no buffer" → fresh in-memory db,
+ * matching the host's intent for :memory: databases.
+ */
+export function coerceDbBuffer(raw: unknown): Uint8Array | null {
+  if (raw instanceof Uint8Array) {
+    return raw;
+  }
+  if (
+    raw &&
+    typeof (raw as { byteLength?: unknown }).byteLength === "number" &&
+    (raw as ArrayBuffer).byteLength > 0
+  ) {
+    return new Uint8Array(raw as ArrayBufferLike);
+  }
+  return null;
+}
+
 // Defense instance (activated after sql.js init)
 let defense: WorkerDefenseInDepth | null = null;
 
@@ -229,11 +255,8 @@ async function executeQuery(data: WorkerInput): Promise<WorkerOutput> {
   try {
     const SQL = await initializeWithDefense(data.protocolToken);
 
-    if (data.dbBuffer) {
-      db = new SQL.Database(data.dbBuffer);
-    } else {
-      db = new SQL.Database();
-    }
+    const buf = coerceDbBuffer(data.dbBuffer);
+    db = buf ? new SQL.Database(buf) : new SQL.Database();
   } catch (e) {
     const message = sanitizeHostErrorMessage((e as Error).message);
     return {


### PR DESCRIPTION
## Summary

Bun's `worker_threads` structured-clone has regressed across versions — most visibly in the build shipped in Trigger.dev's runtime container — and surfaces a host-side `null` `dbBuffer` as a zero-length `ArrayBuffer` inside the worker thread.

The current call site treats any truthy `data.dbBuffer` as a database image:

```ts
if (data.dbBuffer) {
  db = new SQL.Database(data.dbBuffer);
} else {
  db = new SQL.Database();
}
```

An empty `ArrayBuffer` is truthy in JS, so the buggy clone slips past the guard and reaches sql.js — which rejects bare `ArrayBuffer` (it wants `Uint8Array`) with:

```
Expected ArrayBuffer for the first argument
```

Net effect: every `:memory:` `sqlite3` invocation throws under affected Bun builds.

## Change

Introduce `coerceDbBuffer(raw: unknown): Uint8Array | null` in the worker and route the buffer through it:

```ts
const buf = coerceDbBuffer(data.dbBuffer);
db = buf ? new SQL.Database(buf) : new SQL.Database();
```

Behavior:

- `Uint8Array` (and `Buffer`, which extends `Uint8Array`) — returned as-is
- non-empty `ArrayBuffer` — wrapped in a `Uint8Array`
- `null`, `undefined`, zero-length buffers — collapsed to `null`, so `executeQuery` falls back to `new SQL.Database()` (a fresh in-memory db, which is what the host meant for `:memory:`)

No Node-side behavior change. Fixes `:memory:` invocations under affected Bun builds.

## Test plan

- [x] `pnpm --filter just-bash typecheck` — clean
- [x] `pnpm --filter just-bash exec vitest run src/commands/sqlite3/` — **157/157 pass** (6 new unit tests pin each branch of `coerceDbBuffer`, including the zero-length `ArrayBuffer` regression that previously broke)
- [x] `pnpm --filter just-bash check:worker-sync` — clean (`worker.js` rebuilds deterministically; the `.js` is gitignored so it isn't shipped in this diff)

## Background

We've been carrying this in `flowglad/just-bash` since Trigger.dev's container shipped a Bun version that exhibits the regression. The fix is orthogonal to the dot-command preprocessor work in vercel-labs#249; opening as a separate PR for cleaner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)