### PR TITLE
feat(date): use local timezone by default, delegate to strftime

### DIFF
--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -174,6 +174,7 @@ The following components are **trusted** and outside the scope of just-bash's ru
 | process.channel | IPC channel access | Blocked in **worker contexts only** (WorkerDefenseInDepth); main thread skipped for same reason | `src/security/blocked-globals.ts` |
 | Host PID/UID | Expose process identity | Virtualized (processInfo option, defaults: pid=1, uid=1000) | `src/Bash.ts` |
 | hostname/whoami/uname | System enumeration | Return generic/virtual values | `src/commands/hostname/` |
+| Host timezone | `date` leaks host TZ via `%Z`/`%z` or time values | Defaults to UTC; only honored when the host explicitly sets `$TZ` to an IANA zone | `src/commands/date/date.ts` |
 | Error messages | Reveal file paths | `sanitizeError()` in FS layers + `sanitizeErrorMessage()` at all error choke points (builtin-dispatch, Bash.ts, CLI, Python bridge) | `src/fs/real-fs-utils.ts`, `src/interpreter/builtin-dispatch.ts`, `src/Bash.ts`, `src/cli/just-bash.ts` |
 | Timing side-channels | hrtime, cpuUsage, memoryUsage | Blocked by defense-in-depth | `src/security/blocked-globals.ts` |
 | performance.now() | Sub-ms timing for side-channels | Blocked by defense-in-depth; internal uses pre-capture `_performanceNow` | `src/security/blocked-globals.ts`, `src/timers.ts` |

--- a/packages/just-bash/AGENTS.npm.md
+++ b/packages/just-bash/AGENTS.npm.md
@@ -70,6 +70,8 @@ const result = await bash.exec("cat input.txt | grep pattern");
 
 5. **ReadWriteFs root separation**: If you use `ReadWriteFs`, point it at a workspace directory, not at the installed `just-bash` package or other trusted runtime code.
 
+6. **UTC by default**: `date` always shows UTC (`%Z=UTC`, `%z=+0000`) unless the host opts in by passing `TZ` as an env var (e.g. `new Bash({ env: { TZ: "America/New_York" } })`). `-u` always forces UTC; an invalid `$TZ` falls back to UTC.
+
 ## Available Commands
 
 **Text processing**: `awk`, `cat`, `column`, `comm`, `cut`, `egrep`, `expand`, `fgrep`, `fold`, `grep`, `head`, `join`, `nl`, `paste`, `rev`, `rg`, `sed`, `sort`, `strings`, `tac`, `tail`, `tr`, `unexpand`, `uniq`, `wc`, `xargs`

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -141,6 +141,17 @@ await env.exec("while true; do sleep 1; done", { signal: controller.signal });
 await env.exec("cat <<EOF\n  indented\nEOF", { rawScript: true });
 ```
 
+### Timezone
+
+`date` defaults to UTC (`%Z=UTC`, `%z=+0000`) regardless of the host clock, so the sandbox does not leak the host timezone. To opt into a specific zone, pass `TZ` as an initial env var:
+
+```typescript
+const bash = new Bash({ env: { TZ: "America/New_York" } });
+await bash.exec("date"); // Mon Jun  1 09:30:00 EDT 2026
+```
+
+`-u` always forces UTC; an unset or invalid `$TZ` falls back to UTC. Setting `TZ` exposes that timezone to scripts running in the sandbox, so only pass a value you are comfortable revealing — forwarding the host's real `$TZ` (e.g. `process.env.TZ`) reintroduces the disclosure that the UTC default exists to prevent.
+
 `exec()` options:
 
 | Option | Type | Description |

--- a/packages/just-bash/src/commands/date/date.dst.test.ts
+++ b/packages/just-bash/src/commands/date/date.dst.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Regression tests for DST-aware TZ parsing in `parseBareISOInTimezone`.
+ *
+ * Background: a single-pass offset shift uses the TZ offset at the requested
+ * components-as-UTC, which is on the wrong side of the DST transition for
+ * March 10 / November 3 in America/New_York. The fix iterates until the TZ
+ * clock at the candidate equals the requested components.
+ */
+describe("date -d DST handling (America/New_York)", () => {
+  it("spring-forward: 2024-03-10T03:30:00 NY -> 2024-03-10T07:30:00Z (epoch 1710055800)", async () => {
+    // 03:30 local on the spring-forward day is unambiguously EDT (UTC-4),
+    // since the clock has already jumped past 02:00 -> 03:00. EDT 03:30 = 07:30 UTC.
+    const env = new Bash();
+    const result = await env.exec(
+      "export TZ=America/New_York && date -d '2024-03-10T03:30:00' +%s",
+    );
+    expect(result.stdout).toBe("1710055800\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("fall-back: 2024-11-03T01:30:00 NY resolves deterministically to the EDT instant (epoch 1730611800)", async () => {
+    // 01:30 local on the fall-back day occurs twice: once at 05:30 UTC (EDT)
+    // and again at 06:30 UTC (EST). The iterative resolve seeds with the
+    // offset at the requested components-as-UTC (01:30Z), which is before
+    // 06:00Z when DST ends, so it picks the EDT (earlier) instant. Both are
+    // valid; we deterministically prefer the earlier one and document it here.
+    const env = new Bash();
+    const result = await env.exec(
+      "export TZ=America/New_York && date -d '2024-11-03T01:30:00' +%s",
+    );
+    expect(result.stdout).toBe("1730611800\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("non-DST winter day still resolves correctly (regression for the original behaviour)", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "export TZ=America/New_York && date -d '2024-01-15T00:00:00' +%s",
+    );
+    // 2024-01-15T00:00 EST = 2024-01-15T05:00:00Z = 1705294800
+    expect(result.stdout).toBe("1705294800\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("explicit Z suffix is not shifted even on a DST day", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "export TZ=America/New_York && date -d '2024-03-10T03:30:00Z' +%s",
+    );
+    // Z means UTC, regardless of TZ. 2024-03-10T03:30:00Z = 1710041400
+    expect(result.stdout).toBe("1710041400\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -314,6 +314,19 @@ describe("date", () => {
       expect(result.stderr).toContain("invalid date");
       expect(result.exitCode).toBe(1);
     });
+
+    it("should treat bare numeric -d as a year, not epoch seconds (GNU compat)", async () => {
+      // Pre-PR behaviour: -d '2024' falls through to new Date(s), which JS
+      // parses as the year 2024 (YYYY -> 2024-01-01T00:00:00Z). The PR
+      // briefly broke this by short-circuiting on /^\d+$/ and treating it as
+      // epoch seconds (= 1970-01-01T00:33:44Z). Only the `@` prefix should
+      // mean epoch seconds.
+      const env = new Bash();
+      const result = await env.exec("date -u -d '2024' +%Y");
+      expect(result.stdout).toBe("2024\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("TZ-aware -d parsing", () => {

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -159,10 +159,34 @@ describe("date", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("should return 00 for %U when date is before the first Sunday", async () => {
+      const env = new Bash();
+      // 2024-01-01 is Monday — before the first Sunday (Jan 7) so week 00
+      const result = await env.exec("date -u -d '2024-01-01T12:00:00Z' +%U");
+      expect(result.stdout.trim()).toBe("00");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should return 01 for %U on the first Sunday of the year", async () => {
+      const env = new Bash();
+      // 2024-01-07 is Sunday — first Sunday so week 01
+      const result = await env.exec("date -u -d '2024-01-07T12:00:00Z' +%U");
+      expect(result.stdout.trim()).toBe("01");
+      expect(result.exitCode).toBe(0);
+    });
+
     it("should format week number (Monday start) with %W", async () => {
       const env = new Bash();
       const result = await env.exec("date +%W");
       expect(result.stdout).toMatch(/^\d{2}\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should return 00 for %W when date is before the first Monday", async () => {
+      const env = new Bash();
+      // 2023-01-01 is Sunday — before the first Monday (Jan 2) so week 00
+      const result = await env.exec("date -u -d '2023-01-01T12:00:00Z' +%W");
+      expect(result.stdout.trim()).toBe("00");
       expect(result.exitCode).toBe(0);
     });
 
@@ -279,6 +303,36 @@ describe("date", () => {
       const env = new Bash();
       const result = await env.exec("date -u -d '@1705276800' +%F");
       expect(result.stdout.trim()).toBe("2024-01-15");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reject @timestamp with non-numeric suffix", async () => {
+      const env = new Bash();
+      const result = await env.exec("date -d '@0abc' +%s");
+      expect(result.stderr).toContain("invalid date");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("TZ-aware -d parsing", () => {
+    it("should interpret bare ISO string in TZ context when TZ is set", async () => {
+      const env = new Bash();
+      // America/New_York in January is EST = UTC-5.
+      // 2024-01-15T00:00:00 in New York = 2024-01-15T05:00:00Z = timestamp 1705294800.
+      const result = await env.exec(
+        "export TZ=America/New_York && date -d '2024-01-15T00:00:00' +%s",
+      );
+      expect(result.stdout.trim()).toBe("1705294800");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not shift a string that already has an explicit UTC offset", async () => {
+      const env = new Bash();
+      // Z suffix means UTC regardless of TZ env var
+      const result = await env.exec(
+        "export TZ=America/New_York && date -d '2024-01-15T00:00:00Z' +%s",
+      );
+      expect(result.stdout.trim()).toBe("1705276800");
       expect(result.exitCode).toBe(0);
     });
   });

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -279,7 +279,9 @@ describe("date", () => {
     it("should output +0000 in -I format with -u", async () => {
       const env = new Bash();
       const result = await env.exec("date -u -I");
-      expect(result.stdout.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+0000$/);
+      expect(result.stdout.trim()).toMatch(
+        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+0000$/,
+      );
       expect(result.exitCode).toBe(0);
     });
 
@@ -457,9 +459,7 @@ describe("date", () => {
 
     it("UTC date is correct with -u on a fixed timestamp", async () => {
       const env = new Bash();
-      const result = await env.exec(
-        "date -u -d '2024-01-15T23:59:59Z' '+%F'",
-      );
+      const result = await env.exec("date -u -d '2024-01-15T23:59:59Z' '+%F'");
       expect(result.stdout.trim()).toBe("2024-01-15");
       expect(result.exitCode).toBe(0);
     });

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
 
-/** Format date in UTC as YYYY-MM-DD (sandbox always uses UTC) */
-function formatUTCDate(date: Date): string {
-  const year = date.getUTCFullYear();
-  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
-  const day = String(date.getUTCDate()).padStart(2, "0");
+/** Format date in local timezone as YYYY-MM-DD */
+function formatLocalDate(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
@@ -75,18 +75,36 @@ describe("date", () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it("should format weekday name with %a", async () => {
+    it("should format abbreviated weekday name with %a", async () => {
       const env = new Bash();
       const result = await env.exec("date +%a");
       expect(result.stdout).toMatch(/^(Sun|Mon|Tue|Wed|Thu|Fri|Sat)\n$/);
       expect(result.exitCode).toBe(0);
     });
 
-    it("should format month name with %b", async () => {
+    it("should format full weekday name with %A", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%A");
+      expect(result.stdout).toMatch(
+        /^(Sunday|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday)\n$/,
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format abbreviated month name with %b", async () => {
       const env = new Bash();
       const result = await env.exec("date +%b");
       expect(result.stdout).toMatch(
         /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\n$/,
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format full month name with %B", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%B");
+      expect(result.stdout).toMatch(
+        /^(January|February|March|April|May|June|July|August|September|October|November|December)\n$/,
       );
       expect(result.exitCode).toBe(0);
     });
@@ -103,6 +121,48 @@ describe("date", () => {
       const env = new Bash();
       const result = await env.exec("date +%p");
       expect(result.stdout).toMatch(/^(AM|PM)\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format 12-hour time with AM/PM using %r", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%r");
+      expect(result.stdout).toMatch(/^\d{2}:\d{2}:\d{2} (AM|PM)\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format century with %C", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%C");
+      expect(result.stdout).toMatch(/^\d{2}\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format day of year with %j", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%j");
+      expect(result.stdout).toMatch(/^\d{3}\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format ISO week number with %V", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%V");
+      expect(result.stdout).toMatch(/^\d{2}\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format week number (Sunday start) with %U", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%U");
+      expect(result.stdout).toMatch(/^\d{2}\n$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should format week number (Monday start) with %W", async () => {
+      const env = new Bash();
+      const result = await env.exec("date +%W");
+      expect(result.stdout).toMatch(/^\d{2}\n$/);
       expect(result.exitCode).toBe(0);
     });
 
@@ -133,17 +193,29 @@ describe("date", () => {
       expect(result.stdout).toMatch(/^\d{4}\t\d{2}\n$/);
       expect(result.exitCode).toBe(0);
     });
+
+    it("should format known specifiers correctly against a fixed UTC date", async () => {
+      const env = new Bash();
+      // 2024-03-15T14:30:45Z is a Friday in week 11, day 75 of the year
+      const result = await env.exec(
+        "date -u -d '2024-03-15T14:30:45Z' '+%Y %m %d %H %M %S %a %A %b %B %j %V %u %w'",
+      );
+      expect(result.stdout.trim()).toBe(
+        "2024 03 15 14 30 45 Fri Friday Mar March 075 11 5 5",
+      );
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("options", () => {
-    it("should parse date string with -d", async () => {
+    it("should parse date string with -d (local noon stays same day)", async () => {
       const env = new Bash();
       const result = await env.exec("date -d '2024-01-15T12:00:00' +%Y-%m-%d");
       expect(result.stdout).toBe("2024-01-15\n");
       expect(result.exitCode).toBe(0);
     });
 
-    it("should parse date string with --date", async () => {
+    it("should parse date string with --date (local noon stays same day)", async () => {
       const env = new Bash();
       const result = await env.exec("date --date='2024-06-20T12:00:00' +%F");
       expect(result.stdout).toBe("2024-06-20\n");
@@ -166,17 +238,47 @@ describe("date", () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it("should output UTC with -u", async () => {
+    it("should output UTC timezone name with -u", async () => {
       const env = new Bash();
       const result = await env.exec("date -u +%Z");
       expect(result.stdout).toBe("UTC\n");
       expect(result.exitCode).toBe(0);
     });
 
-    it("should output UTC timezone offset with -u", async () => {
+    it("should output +0000 offset with -u", async () => {
       const env = new Bash();
       const result = await env.exec("date -u +%z");
       expect(result.stdout).toBe("+0000\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should output +0000 in -I format with -u", async () => {
+      const env = new Bash();
+      const result = await env.exec("date -u -I");
+      expect(result.stdout.trim()).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+0000$/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should output +0000 in -R format with -u", async () => {
+      const env = new Bash();
+      const result = await env.exec("date -u -R");
+      expect(result.stdout).toContain("+0000");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("@timestamp parsing", () => {
+    it("should parse Unix epoch with @0", async () => {
+      const env = new Bash();
+      const result = await env.exec("date -u -d '@0' '+%Y-%m-%dT%H:%M:%S'");
+      expect(result.stdout.trim()).toBe("1970-01-01T00:00:00");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should parse arbitrary @timestamp", async () => {
+      const env = new Bash();
+      const result = await env.exec("date -u -d '@1705276800' +%F");
+      expect(result.stdout.trim()).toBe("2024-01-15");
       expect(result.exitCode).toBe(0);
     });
   });
@@ -194,8 +296,7 @@ describe("date", () => {
     it("should parse 'today'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d today +%F");
-      // Use local date formatting to match date command behavior
-      const today = formatUTCDate(new Date());
+      const today = formatLocalDate(new Date());
       expect(result.stdout).toBe(`${today}\n`);
       expect(result.exitCode).toBe(0);
     });
@@ -203,16 +304,16 @@ describe("date", () => {
     it("should parse 'yesterday'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d yesterday +%F");
-      const yesterday = new Date(Date.now() - 86400000);
-      expect(result.stdout).toBe(`${formatUTCDate(yesterday)}\n`);
+      const yesterday = formatLocalDate(new Date(Date.now() - 86400000));
+      expect(result.stdout).toBe(`${yesterday}\n`);
       expect(result.exitCode).toBe(0);
     });
 
     it("should parse 'tomorrow'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d tomorrow +%F");
-      const tomorrow = new Date(Date.now() + 86400000);
-      expect(result.stdout).toBe(`${formatUTCDate(tomorrow)}\n`);
+      const tomorrow = formatLocalDate(new Date(Date.now() + 86400000));
+      expect(result.stdout).toBe(`${tomorrow}\n`);
       expect(result.exitCode).toBe(0);
     });
   });
@@ -254,7 +355,7 @@ describe("date", () => {
     it("should output default format without arguments", async () => {
       const env = new Bash();
       const result = await env.exec("date");
-      // Default format includes weekday, month, day, time, timezone, year
+      // Default format: weekday month day HH:MM:SS TZ year
       expect(result.stdout).toMatch(
         /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/,
       );
@@ -262,53 +363,62 @@ describe("date", () => {
     });
   });
 
-  describe("timezone non-disclosure", () => {
-    it("%Z should return UTC, never the host timezone", async () => {
+  describe("timezone", () => {
+    it("should use local timezone for %Z by default", async () => {
       const env = new Bash();
       const result = await env.exec("date +%Z");
-      expect(result.stdout.trim()).toBe("UTC");
-      // Must not contain a real timezone like America/New_York, etc.
-      expect(result.stdout).not.toContain("/");
+      expect(result.stdout.trim()).toBeTruthy();
+      expect(result.exitCode).toBe(0);
     });
 
-    it("%z should return +0000, never the host UTC offset", async () => {
+    it("should use local offset for %z by default", async () => {
       const env = new Bash();
       const result = await env.exec("date +%z");
-      expect(result.stdout.trim()).toBe("+0000");
+      expect(result.stdout.trim()).toMatch(/^[+-]\d{4}$/);
+      expect(result.exitCode).toBe(0);
     });
 
-    it("default output should show UTC timezone", async () => {
-      const env = new Bash();
-      const result = await env.exec("date");
-      // Default format includes %Z which should be UTC
-      expect(result.stdout).toContain("UTC");
-    });
-
-    it("-I (iso) format should use +0000 offset", async () => {
-      const env = new Bash();
-      const result = await env.exec("date -I");
-      expect(result.stdout).toContain("+0000");
-    });
-
-    it("-R (rfc) format should use +0000 offset", async () => {
-      const env = new Bash();
-      const result = await env.exec("date -R");
-      expect(result.stdout).toContain("+0000");
-    });
-
-    it("-u flag should still work (already UTC)", async () => {
+    it("-u should force UTC for %Z", async () => {
       const env = new Bash();
       const result = await env.exec("date -u +%Z");
       expect(result.stdout.trim()).toBe("UTC");
+      expect(result.exitCode).toBe(0);
     });
 
-    it("time values should be UTC (consistent with %Z)", async () => {
+    it("-u should force +0000 for %z", async () => {
       const env = new Bash();
-      // Use a fixed date to verify UTC conversion
+      const result = await env.exec("date -u +%z");
+      expect(result.stdout.trim()).toBe("+0000");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("UTC time values are correct with -u on a fixed timestamp", async () => {
+      const env = new Bash();
       const result = await env.exec(
-        "date -d '2024-01-15T00:00:00Z' '+%H:%M:%S'",
+        "date -u -d '2024-01-15T00:00:00Z' '+%H:%M:%S'",
       );
       expect(result.stdout.trim()).toBe("00:00:00");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("UTC date is correct with -u on a fixed timestamp", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "date -u -d '2024-01-15T23:59:59Z' '+%F'",
+      );
+      expect(result.stdout.trim()).toBe("2024-01-15");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("%Z and %z are consistent (both local or both UTC)", async () => {
+      const env = new Bash();
+      // A UTC+0 environment: %Z=UTC and %z=+0000 match
+      // Any other environment: %Z is a short name for the same offset as %z
+      const tzResult = await env.exec("date +%Z");
+      const offsetResult = await env.exec("date +%z");
+      // Both should be non-empty and the offset format should be correct
+      expect(tzResult.stdout.trim()).toBeTruthy();
+      expect(offsetResult.stdout.trim()).toMatch(/^[+-]\d{4}$/);
     });
   });
 });

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
 
-/** Format date in local timezone as YYYY-MM-DD */
-function formatLocalDate(date: Date): string {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+/** Format date in UTC as YYYY-MM-DD (date defaults to UTC display) */
+function formatUTCDate(date: Date): string {
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(date.getUTCDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
 
@@ -365,7 +365,7 @@ describe("date", () => {
     it("should parse 'today'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d today +%F");
-      const today = formatLocalDate(new Date());
+      const today = formatUTCDate(new Date());
       expect(result.stdout).toBe(`${today}\n`);
       expect(result.exitCode).toBe(0);
     });
@@ -373,7 +373,7 @@ describe("date", () => {
     it("should parse 'yesterday'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d yesterday +%F");
-      const yesterday = formatLocalDate(new Date(Date.now() - 86400000));
+      const yesterday = formatUTCDate(new Date(Date.now() - 86400000));
       expect(result.stdout).toBe(`${yesterday}\n`);
       expect(result.exitCode).toBe(0);
     });
@@ -381,7 +381,7 @@ describe("date", () => {
     it("should parse 'tomorrow'", async () => {
       const env = new Bash();
       const result = await env.exec("date -d tomorrow +%F");
-      const tomorrow = formatLocalDate(new Date(Date.now() + 86400000));
+      const tomorrow = formatUTCDate(new Date(Date.now() + 86400000));
       expect(result.stdout).toBe(`${tomorrow}\n`);
       expect(result.exitCode).toBe(0);
     });
@@ -424,40 +424,43 @@ describe("date", () => {
     it("should output default format without arguments", async () => {
       const env = new Bash();
       const result = await env.exec("date");
-      // Default format: weekday month day HH:MM:SS TZ year
+      // Default format: weekday month day HH:MM:SS TZ year. With no $TZ set
+      // the display defaults to UTC, so the timezone field is "UTC".
       expect(result.stdout).toMatch(
-        /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)/,
+        /^(Sun|Mon|Tue|Wed|Thu|Fri|Sat) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) [ 0-9][0-9] \d{2}:\d{2}:\d{2} UTC \d{4}\n$/,
       );
       expect(result.exitCode).toBe(0);
     });
   });
 
   describe("timezone", () => {
-    it("should use local timezone for %Z by default", async () => {
+    it("should use UTC for %Z by default", async () => {
       const env = new Bash();
       const result = await env.exec("date +%Z");
-      expect(result.stdout.trim()).toBeTruthy();
+      expect(result.stdout).toBe("UTC\n");
+      expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });
 
-    it("should use local offset for %z by default", async () => {
+    it("should use +0000 for %z by default", async () => {
       const env = new Bash();
       const result = await env.exec("date +%z");
-      expect(result.stdout.trim()).toMatch(/^[+-]\d{4}$/);
+      expect(result.stdout).toBe("+0000\n");
+      expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });
 
     it("-u should force UTC for %Z", async () => {
       const env = new Bash();
       const result = await env.exec("date -u +%Z");
-      expect(result.stdout.trim()).toBe("UTC");
+      expect(result.stdout).toBe("UTC\n");
       expect(result.exitCode).toBe(0);
     });
 
     it("-u should force +0000 for %z", async () => {
       const env = new Bash();
       const result = await env.exec("date -u +%z");
-      expect(result.stdout.trim()).toBe("+0000");
+      expect(result.stdout).toBe("+0000\n");
       expect(result.exitCode).toBe(0);
     });
 
@@ -466,57 +469,79 @@ describe("date", () => {
       const result = await env.exec(
         "date -u -d '2024-01-15T00:00:00Z' '+%H:%M:%S'",
       );
-      expect(result.stdout.trim()).toBe("00:00:00");
+      expect(result.stdout).toBe("00:00:00\n");
       expect(result.exitCode).toBe(0);
     });
 
     it("UTC date is correct with -u on a fixed timestamp", async () => {
       const env = new Bash();
       const result = await env.exec("date -u -d '2024-01-15T23:59:59Z' '+%F'");
-      expect(result.stdout.trim()).toBe("2024-01-15");
+      expect(result.stdout).toBe("2024-01-15\n");
       expect(result.exitCode).toBe(0);
     });
 
-    it("%Z and %z are consistent (both local or both UTC)", async () => {
+    it("%Z and %z agree on the UTC default", async () => {
+      // Without $TZ and without -u, display defaults to UTC, so %Z=UTC
+      // and %z=+0000 always agree.
       const env = new Bash();
-      // A UTC+0 environment: %Z=UTC and %z=+0000 match
-      // Any other environment: %Z is a short name for the same offset as %z
       const tzResult = await env.exec("date +%Z");
       const offsetResult = await env.exec("date +%z");
-      // Both should be non-empty and the offset format should be correct
-      expect(tzResult.stdout.trim()).toBeTruthy();
-      expect(offsetResult.stdout.trim()).toMatch(/^[+-]\d{4}$/);
+      expect(tzResult.stdout).toBe("UTC\n");
+      expect(offsetResult.stdout).toBe("+0000\n");
     });
 
-    it("invalid TZ falls back to host-local for both parsing and display", async () => {
-      // When TZ is set to something Intl doesn't understand (e.g. Mars/Olympus),
-      // we treat it as unset so parsing and display agree. Without this, the
-      // displayed time would use local parts while %Z / %z would print "UTC" /
-      // "+0000" — internally inconsistent. We document the choice: fall back
-      // to host-local (matching GNU `date`), not to UTC.
+    it("invalid TZ falls back to UTC for both parsing and display", async () => {
+      // When $TZ is set to a value Intl doesn't understand (e.g. Mars/Olympus),
+      // isValidTimezone() treats it as unset. With the UTC-by-default contract,
+      // an unset $TZ yields UTC display — so %Z is "UTC" and %z is "+0000",
+      // consistent with the displayed time parts (and matching the no-$TZ
+      // baseline).
       const env = new Bash();
       const baseline = await env.exec("date +'%Z %z'");
       const badTz = await env.exec(
         "export TZ=Not/A/Real/Zone && date +'%Z %z'",
       );
-      // Both runs should produce the same local-tz output and the offset
-      // shape must be a real numeric offset, not "+0000" hard-coded.
-      expect(badTz.stdout).toBe(baseline.stdout);
+      expect(baseline.stdout).toBe("UTC +0000\n");
+      expect(badTz.stdout).toBe("UTC +0000\n");
       expect(badTz.stderr).toBe("");
       expect(badTz.exitCode).toBe(0);
-      expect(badTz.stdout.trim()).toMatch(/^.+ [+-]\d{4}$/);
     });
 
     it("invalid TZ does not break -d parsing of bare ISO strings", async () => {
       // Without TZ validation, parseBareISOInTimezone would be called with
-      // "Not/A/Real/Zone" and silently fail or fall back. We now treat the
-      // bad TZ as undefined so the local-time fallback path is taken.
+      // "Not/A/Real/Zone" and silently fail or fall back. We treat the bad
+      // TZ as undefined so parsing falls through to JS `new Date(s)`; an
+      // explicit-Z input is unambiguous regardless of parseTz.
       const env = new Bash();
       const result = await env.exec(
         "export TZ=Not/A/Real/Zone && date -d '2024-06-15T12:00:00Z' +%s",
       );
       // 2024-06-15T12:00:00Z = 1718452800
       expect(result.stdout).toBe("1718452800\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("TZ environment variable opts in to local time", () => {
+    // Per PR #251: UTC is the default (non-disclosure of host timezone);
+    // callers opt in to a specific zone by exporting $TZ.
+    it("TZ=America/Los_Angeles makes %Z print PST or PDT", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "export TZ=America/Los_Angeles && date +%Z",
+      );
+      expect(result.stdout.trim()).toMatch(/^(PST|PDT)$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("TZ=America/Los_Angeles makes %z print -0800 or -0700", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "export TZ=America/Los_Angeles && date +%z",
+      );
+      expect(result.stdout.trim()).toMatch(/^-0[78]00$/);
       expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });

--- a/packages/just-bash/src/commands/date/date.test.ts
+++ b/packages/just-bash/src/commands/date/date.test.ts
@@ -487,5 +487,38 @@ describe("date", () => {
       expect(tzResult.stdout.trim()).toBeTruthy();
       expect(offsetResult.stdout.trim()).toMatch(/^[+-]\d{4}$/);
     });
+
+    it("invalid TZ falls back to host-local for both parsing and display", async () => {
+      // When TZ is set to something Intl doesn't understand (e.g. Mars/Olympus),
+      // we treat it as unset so parsing and display agree. Without this, the
+      // displayed time would use local parts while %Z / %z would print "UTC" /
+      // "+0000" — internally inconsistent. We document the choice: fall back
+      // to host-local (matching GNU `date`), not to UTC.
+      const env = new Bash();
+      const baseline = await env.exec("date +'%Z %z'");
+      const badTz = await env.exec(
+        "export TZ=Not/A/Real/Zone && date +'%Z %z'",
+      );
+      // Both runs should produce the same local-tz output and the offset
+      // shape must be a real numeric offset, not "+0000" hard-coded.
+      expect(badTz.stdout).toBe(baseline.stdout);
+      expect(badTz.stderr).toBe("");
+      expect(badTz.exitCode).toBe(0);
+      expect(badTz.stdout.trim()).toMatch(/^.+ [+-]\d{4}$/);
+    });
+
+    it("invalid TZ does not break -d parsing of bare ISO strings", async () => {
+      // Without TZ validation, parseBareISOInTimezone would be called with
+      // "Not/A/Real/Zone" and silently fail or fall back. We now treat the
+      // bad TZ as undefined so the local-time fallback path is taken.
+      const env = new Bash();
+      const result = await env.exec(
+        "export TZ=Not/A/Real/Zone && date -d '2024-06-15T12:00:00Z' +%s",
+      );
+      // 2024-06-15T12:00:00Z = 1718452800
+      expect(result.stdout).toBe("1718452800\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
   });
 });

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -19,19 +19,65 @@ const dateHelp = {
   ],
 };
 
-function parseDate(s: string): Date | null {
-  // @unix-timestamp (GNU extension: date -d @1234567890)
-  if (s.startsWith("@")) {
-    const ts = Number.parseInt(s.slice(1), 10);
-    if (!Number.isNaN(ts)) return new Date(ts * 1000);
+/**
+ * Interpret a bare ISO datetime string (no explicit offset) as if it were
+ * in the given named timezone, returning the corresponding UTC Date.
+ *
+ * Strategy: treat the components as UTC to get a reference point, ask Intl
+ * what that timezone shows at that moment, then shift by the difference so
+ * the timezone clock reads the original components.
+ */
+function parseBareISOInTimezone(s: string, tz: string): Date | null {
+  const m = s.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:[T ](\d{2}):(\d{2})(?::(\d{2}))?)?$/,
+  );
+  if (!m) return null;
+  const [, yr, mo, dy, hr = "00", mn = "00", sc = "00"] = m;
+  const utcRef = new Date(`${yr}-${mo}-${dy}T${hr}:${mn}:${sc}Z`);
+  if (Number.isNaN(utcRef.getTime())) return null;
+  try {
+    const parts = new Intl.DateTimeFormat("en-US", {
+      timeZone: tz,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    }).formatToParts(utcRef);
+    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
+    const h = Number.parseInt(get("hour"), 10) % 24;
+    const tzShown = new Date(
+      `${get("year")}-${get("month")}-${get("day")}T${String(h).padStart(2, "0")}:${get("minute")}:${get("second")}Z`,
+    );
+    // Shift utcRef by (utcRef − tzShown) so the TZ clock reads the target value
+    return new Date(utcRef.getTime() + (utcRef.getTime() - tzShown.getTime()));
+  } catch {
+    return null;
   }
-  const d = new Date(s);
-  if (!Number.isNaN(d.getTime())) return d;
-  if (/^\d+$/.test(s)) return new Date(Number.parseInt(s, 10) * 1000);
+}
+
+function parseDate(s: string, tz?: string): Date | null {
+  // @unix-timestamp (GNU extension: date -d @1234567890)
+  // Require the entire suffix to be numeric to reject partial matches like @0abc.
+  if (s.startsWith("@")) {
+    const suffix = s.slice(1);
+    if (!/^-?\d+$/.test(suffix)) return null;
+    return new Date(Number.parseInt(suffix, 10) * 1000);
+  }
   const l = s.toLowerCase().trim();
   if (l === "now" || l === "today") return new Date();
   if (l === "yesterday") return new Date(Date.now() - 86400000);
   if (l === "tomorrow") return new Date(Date.now() + 86400000);
+  if (/^\d+$/.test(s)) return new Date(Number.parseInt(s, 10) * 1000);
+  // For bare ISO strings (no explicit offset/Z), interpret in the requested timezone
+  if (tz && !/Z$/i.test(s) && !/[+-]\d{2}:?\d{2}$/.test(s)) {
+    const d = parseBareISOInTimezone(s, tz);
+    if (d) return d;
+  }
+  const d = new Date(s);
+  if (!Number.isNaN(d.getTime())) return d;
   return null;
 }
 
@@ -65,7 +111,12 @@ export const dateCommand: Command = {
       }
     }
 
-    const date = dateStr !== null ? parseDate(dateStr) : new Date();
+    // TZ env var governs how timezone-naive -d strings are interpreted;
+    // -u only overrides the display timezone, not parsing.
+    const parseTz = ctx.env.get("TZ");
+    const displayTz = utc ? "UTC" : parseTz;
+
+    const date = dateStr !== null ? parseDate(dateStr, parseTz) : new Date();
     if (!date)
       return {
         stdout: "",
@@ -73,15 +124,13 @@ export const dateCommand: Command = {
         exitCode: 1,
       };
 
-    // -u forces UTC; otherwise use TZ env var if set, else local timezone
-    const tz = utc ? "UTC" : ctx.env.get("TZ");
     const ts = Math.floor(date.getTime() / 1000);
 
     let out: string;
-    if (fmt) out = formatStrftime(fmt, ts, tz);
-    else if (iso) out = formatStrftime("%Y-%m-%dT%H:%M:%S%z", ts, tz);
-    else if (rfc) out = formatStrftime("%a, %d %b %Y %H:%M:%S %z", ts, tz);
-    else out = formatStrftime("%a %b %e %H:%M:%S %Z %Y", ts, tz);
+    if (fmt) out = formatStrftime(fmt, ts, displayTz);
+    else if (iso) out = formatStrftime("%Y-%m-%dT%H:%M:%S%z", ts, displayTz);
+    else if (rfc) out = formatStrftime("%a, %d %b %Y %H:%M:%S %z", ts, displayTz);
+    else out = formatStrftime("%a %b %e %H:%M:%S %Z %Y", ts, displayTz);
 
     return { stdout: `${out}\n`, stderr: "", exitCode: 0 };
   },

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -98,7 +98,6 @@ function parseDate(s: string, tz?: string): Date | null {
   if (l === "now" || l === "today") return new Date();
   if (l === "yesterday") return new Date(Date.now() - 86400000);
   if (l === "tomorrow") return new Date(Date.now() + 86400000);
-  if (/^\d+$/.test(s)) return new Date(Number.parseInt(s, 10) * 1000);
   // For bare ISO strings (no explicit offset/Z), interpret in the requested timezone
   if (tz && !/Z$/i.test(s) && !/[+-]\d{2}:?\d{2}$/.test(s)) {
     const d = parseBareISOInTimezone(s, tz);

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -152,15 +152,20 @@ export const dateCommand: Command = {
       }
     }
 
-    // TZ env var governs how timezone-naive -d strings are interpreted;
-    // -u only overrides the display timezone, not parsing.
-    // Invalid TZ (e.g. "Mars/Olympus") falls back to host-local for both
-    // parsing and display, matching GNU `date`. Without this, parsing/display
-    // would silently use local parts while %Z / %z would print "UTC" / "+0000",
-    // giving inconsistent output.
+    // Display-timezone contract:
+    //   -u                  -> always UTC.
+    //   no $TZ set          -> UTC by default (sandbox non-disclosure default;
+    //                          host timezone never leaks unless caller opts in).
+    //   $TZ=<valid zone>    -> that zone (validated by isValidTimezone).
+    //   $TZ=<invalid zone>  -> UTC fallback (consistent with no-TZ default;
+    //                          avoids %Z / %z disagreeing with the displayed
+    //                          time parts).
+    // parseTz keeps its raw value (undefined when unset) so timezone-naive -d
+    // strings without $TZ fall through to JS `new Date(s)` — do NOT propagate
+    // the UTC display default into parsing.
     let parseTz = ctx.env.get("TZ");
     if (parseTz && !isValidTimezone(parseTz)) parseTz = undefined;
-    const displayTz = utc ? "UTC" : parseTz;
+    const displayTz = utc ? "UTC" : (parseTz ?? "UTC");
 
     const date = dateStr !== null ? parseDate(dateStr, parseTz) : new Date();
     if (!date)

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -129,7 +129,8 @@ export const dateCommand: Command = {
     let out: string;
     if (fmt) out = formatStrftime(fmt, ts, displayTz);
     else if (iso) out = formatStrftime("%Y-%m-%dT%H:%M:%S%z", ts, displayTz);
-    else if (rfc) out = formatStrftime("%a, %d %b %Y %H:%M:%S %z", ts, displayTz);
+    else if (rfc)
+      out = formatStrftime("%a, %d %b %Y %H:%M:%S %z", ts, displayTz);
     else out = formatStrftime("%a %b %e %H:%M:%S %Z %Y", ts, displayTz);
 
     return { stdout: `${out}\n`, stderr: "", exitCode: 0 };

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -20,12 +20,48 @@ const dateHelp = {
 };
 
 /**
+ * Return what `tz` shows at instant `d`, encoded as a UTC Date whose
+ * UTC components equal the wall-clock components shown in `tz`.
+ * Returns null if Intl rejects the timezone or produces an unparseable date.
+ */
+function tzShownAsUtc(d: Date, tz: string): Date | null {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
+  const h = Number.parseInt(get("hour"), 10) % 24;
+  const shown = new Date(
+    `${get("year")}-${get("month")}-${get("day")}T${String(h).padStart(2, "0")}:${get("minute")}:${get("second")}Z`,
+  );
+  return Number.isNaN(shown.getTime()) ? null : shown;
+}
+
+/**
  * Interpret a bare ISO datetime string (no explicit offset) as if it were
  * in the given named timezone, returning the corresponding UTC Date.
  *
- * Strategy: treat the components as UTC to get a reference point, ask Intl
- * what that timezone shows at that moment, then shift by the difference so
- * the timezone clock reads the original components.
+ * Strategy: treat the requested components as a UTC instant, then iteratively
+ * refine by asking the timezone what wall-clock it shows at the current
+ * candidate and applying the residual delta. Outside DST the loop converges
+ * in one pass; across a DST boundary it converges in two. Bounded at 3
+ * iterations as a safety net.
+ *
+ * DST edge cases:
+ * - Skipped wall times (spring-forward gap, e.g. America/New_York
+ *   2024-03-10T02:30 does not exist): the loop oscillates and we return the
+ *   last candidate. In practice this lands on the post-shift (EDT) instant
+ *   for the gap.
+ * - Ambiguous wall times (fall-back, e.g. America/New_York 2024-11-03T01:30
+ *   occurs twice): the seed's first shift uses the offset at the requested
+ *   components-as-UTC, which is still EDT for the November case, so the
+ *   loop converges on the earlier (EDT) instant.
  */
 function parseBareISOInTimezone(s: string, tz: string): Date | null {
   const m = s.match(
@@ -33,26 +69,18 @@ function parseBareISOInTimezone(s: string, tz: string): Date | null {
   );
   if (!m) return null;
   const [, yr, mo, dy, hr = "00", mn = "00", sc = "00"] = m;
-  const utcRef = new Date(`${yr}-${mo}-${dy}T${hr}:${mn}:${sc}Z`);
-  if (Number.isNaN(utcRef.getTime())) return null;
+  const requested = new Date(`${yr}-${mo}-${dy}T${hr}:${mn}:${sc}Z`);
+  if (Number.isNaN(requested.getTime())) return null;
   try {
-    const parts = new Intl.DateTimeFormat("en-US", {
-      timeZone: tz,
-      year: "numeric",
-      month: "2-digit",
-      day: "2-digit",
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-      hour12: false,
-    }).formatToParts(utcRef);
-    const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
-    const h = Number.parseInt(get("hour"), 10) % 24;
-    const tzShown = new Date(
-      `${get("year")}-${get("month")}-${get("day")}T${String(h).padStart(2, "0")}:${get("minute")}:${get("second")}Z`,
-    );
-    // Shift utcRef by (utcRef − tzShown) so the TZ clock reads the target value
-    return new Date(utcRef.getTime() + (utcRef.getTime() - tzShown.getTime()));
+    let candidate = requested;
+    for (let pass = 0; pass < 3; pass++) {
+      const shown = tzShownAsUtc(candidate, tz);
+      if (shown === null) return null;
+      const drift = shown.getTime() - requested.getTime();
+      if (drift === 0) return candidate;
+      candidate = new Date(candidate.getTime() - drift);
+    }
+    return candidate;
   } catch {
     return null;
   }

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -4,13 +4,14 @@
 
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
+import { formatStrftime } from "../printf/strftime.js";
 
 const dateHelp = {
   name: "date",
   summary: "display the current time in the given FORMAT",
   usage: "date [OPTION]... [+FORMAT]",
   options: [
-    "-d, --date=STRING   display time described by STRING",
+    "-d, --date=STRING   display time described by STRING, not 'now'",
     "-u, --utc           print Coordinated Universal Time (UTC)",
     "-I, --iso-8601      output date/time in ISO 8601 format",
     "-R, --rfc-email     output RFC 5322 date format",
@@ -18,134 +19,16 @@ const dateHelp = {
   ],
 };
 
-const DAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const MONTHS = [
-  "Jan",
-  "Feb",
-  "Mar",
-  "Apr",
-  "May",
-  "Jun",
-  "Jul",
-  "Aug",
-  "Sep",
-  "Oct",
-  "Nov",
-  "Dec",
-];
-
-function pad(n: number, w = 2): string {
-  return String(n).padStart(w, "0");
-}
-
-function formatDate(d: Date, fmt: string, _utc: boolean): string {
-  // Always use UTC in the sandbox to prevent leaking the host timezone
-  // through %Z, %z, or the time values themselves.
-  const g = {
-    Y: d.getUTCFullYear(),
-    m: d.getUTCMonth(),
-    D: d.getUTCDate(),
-    H: d.getUTCHours(),
-    M: d.getUTCMinutes(),
-    S: d.getUTCSeconds(),
-    w: d.getUTCDay(),
-  };
-
-  let r = "",
-    i = 0;
-  while (i < fmt.length) {
-    if (fmt[i] === "%" && i + 1 < fmt.length) {
-      const s = fmt[++i];
-      switch (s) {
-        case "%":
-          r += "%";
-          break;
-        case "a":
-          r += DAYS[g.w];
-          break;
-        case "b":
-        case "h":
-          r += MONTHS[g.m];
-          break;
-        case "d":
-          r += pad(g.D);
-          break;
-        case "e":
-          r += String(g.D).padStart(2, " ");
-          break;
-        case "F":
-          r += `${g.Y}-${pad(g.m + 1)}-${pad(g.D)}`;
-          break;
-        case "H":
-          r += pad(g.H);
-          break;
-        case "I":
-          r += pad(g.H % 12 || 12);
-          break;
-        case "m":
-          r += pad(g.m + 1);
-          break;
-        case "M":
-          r += pad(g.M);
-          break;
-        case "n":
-          r += "\n";
-          break;
-        case "p":
-          r += g.H < 12 ? "AM" : "PM";
-          break;
-        case "P":
-          r += g.H < 12 ? "am" : "pm";
-          break;
-        case "R":
-          r += `${pad(g.H)}:${pad(g.M)}`;
-          break;
-        case "s":
-          r += Math.floor(d.getTime() / 1000);
-          break;
-        case "S":
-          r += pad(g.S);
-          break;
-        case "t":
-          r += "\t";
-          break;
-        case "T":
-          r += `${pad(g.H)}:${pad(g.M)}:${pad(g.S)}`;
-          break;
-        case "u":
-          r += g.w || 7;
-          break;
-        case "w":
-          r += g.w;
-          break;
-        case "y":
-          r += pad(g.Y % 100);
-          break;
-        case "Y":
-          r += g.Y;
-          break;
-        case "z":
-          r += "+0000";
-          break;
-        case "Z":
-          r += "UTC";
-          break;
-        default:
-          r += `%${s}`;
-      }
-    } else {
-      r += fmt[i];
-    }
-    i++;
-  }
-  return r;
-}
-
 function parseDate(s: string): Date | null {
+  // @unix-timestamp (GNU extension: date -d @1234567890)
+  if (s.startsWith("@")) {
+    const ts = Number.parseInt(s.slice(1), 10);
+    if (!Number.isNaN(ts)) return new Date(ts * 1000);
+  }
   const d = new Date(s);
   if (!Number.isNaN(d.getTime())) return d;
   if (/^\d+$/.test(s)) return new Date(Number.parseInt(s, 10) * 1000);
-  const l = s.toLowerCase();
+  const l = s.toLowerCase().trim();
   if (l === "now" || l === "today") return new Date();
   if (l === "yesterday") return new Date(Date.now() - 86400000);
   if (l === "tomorrow") return new Date(Date.now() + 86400000);
@@ -154,7 +37,7 @@ function parseDate(s: string): Date | null {
 
 export const dateCommand: Command = {
   name: "date",
-  async execute(args: string[], _ctx: CommandContext): Promise<ExecResult> {
+  async execute(args: string[], ctx: CommandContext): Promise<ExecResult> {
     if (hasHelpFlag(args)) return showHelp(dateHelp);
 
     let utc = false,
@@ -190,11 +73,15 @@ export const dateCommand: Command = {
         exitCode: 1,
       };
 
+    // -u forces UTC; otherwise use TZ env var if set, else local timezone
+    const tz = utc ? "UTC" : ctx.env.get("TZ");
+    const ts = Math.floor(date.getTime() / 1000);
+
     let out: string;
-    if (fmt) out = formatDate(date, fmt, utc);
-    else if (iso) out = formatDate(date, "%Y-%m-%dT%H:%M:%S%z", utc);
-    else if (rfc) out = formatDate(date, "%a, %d %b %Y %H:%M:%S %z", utc);
-    else out = formatDate(date, "%a %b %e %H:%M:%S %Z %Y", utc);
+    if (fmt) out = formatStrftime(fmt, ts, tz);
+    else if (iso) out = formatStrftime("%Y-%m-%dT%H:%M:%S%z", ts, tz);
+    else if (rfc) out = formatStrftime("%a, %d %b %Y %H:%M:%S %z", ts, tz);
+    else out = formatStrftime("%a %b %e %H:%M:%S %Z %Y", ts, tz);
 
     return { stdout: `${out}\n`, stderr: "", exitCode: 0 };
   },

--- a/packages/just-bash/src/commands/date/date.ts
+++ b/packages/just-bash/src/commands/date/date.ts
@@ -20,6 +20,20 @@ const dateHelp = {
 };
 
 /**
+ * True iff `tz` is a timezone Intl understands. Used to fall back to host-local
+ * when `TZ` is set to a value Node's ICU build can't resolve, matching GNU
+ * `date` (which silently uses local time on invalid `TZ`).
+ */
+function isValidTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat(undefined, { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Return what `tz` shows at instant `d`, encoded as a UTC Date whose
  * UTC components equal the wall-clock components shown in `tz`.
  * Returns null if Intl rejects the timezone or produces an unparseable date.
@@ -140,7 +154,12 @@ export const dateCommand: Command = {
 
     // TZ env var governs how timezone-naive -d strings are interpreted;
     // -u only overrides the display timezone, not parsing.
-    const parseTz = ctx.env.get("TZ");
+    // Invalid TZ (e.g. "Mars/Olympus") falls back to host-local for both
+    // parsing and display, matching GNU `date`. Without this, parsing/display
+    // would silently use local parts while %Z / %z would print "UTC" / "+0000",
+    // giving inconsistent output.
+    let parseTz = ctx.env.get("TZ");
+    if (parseTz && !isValidTimezone(parseTz)) parseTz = undefined;
     const displayTz = utc ? "UTC" : parseTz;
 
     const date = dateStr !== null ? parseDate(dateStr, parseTz) : new Date();

--- a/packages/just-bash/src/commands/printf/strftime.ts
+++ b/packages/just-bash/src/commands/printf/strftime.ts
@@ -381,7 +381,7 @@ function getWeekNumberForParts(
   const doy = getDayOfYearForParts(year, month, day);
   const jan1dow = new Date(year, 0, 1).getDay(); // 0=Sun
   // Day-of-year (1-based) of the first startDay on or after Jan 1
-  const firstWeekStart = 1 + (7 + startDay - jan1dow) % 7;
+  const firstWeekStart = 1 + ((7 + startDay - jan1dow) % 7);
   const days = doy - firstWeekStart;
   return days < 0 ? 0 : Math.floor(days / 7) + 1;
 }

--- a/packages/just-bash/src/commands/printf/strftime.ts
+++ b/packages/just-bash/src/commands/printf/strftime.ts
@@ -368,28 +368,22 @@ function getDayOfYearForParts(
 
 /**
  * Calculate week number from date parts.
+ * startDay: 0 = Sunday (%U), 1 = Monday (%W)
+ * Days before the first occurrence of startDay are week 00.
  */
 function getWeekNumberForParts(
   year: number,
   month: number,
   day: number,
-  weekday: number,
+  _weekday: number,
   startDay: number,
 ): number {
-  const dayOfYear = getDayOfYearForParts(year, month, day);
-  // Find day of week of Jan 1
-  const jan1 = new Date(year, 0, 1);
-  const jan1Weekday = jan1.getDay();
-
-  // Adjust for start day
-  const adjustedJan1 = (jan1Weekday - startDay + 7) % 7;
-  const adjustedWeekday = (weekday - startDay + 7) % 7;
-
-  // Days from start of first week
-  const daysIntoYear = dayOfYear - 1 + adjustedJan1;
-  const weekNum = Math.floor((daysIntoYear - adjustedWeekday + 7) / 7);
-
-  return weekNum;
+  const doy = getDayOfYearForParts(year, month, day);
+  const jan1dow = new Date(year, 0, 1).getDay(); // 0=Sun
+  // Day-of-year (1-based) of the first startDay on or after Jan 1
+  const firstWeekStart = 1 + (7 + startDay - jan1dow) % 7;
+  const days = doy - firstWeekStart;
+  return days < 0 ? 0 : Math.floor(days / 7) + 1;
 }
 
 /**

--- a/packages/just-bash/src/commands/printf/strftime.ts
+++ b/packages/just-bash/src/commands/printf/strftime.ts
@@ -87,13 +87,20 @@ function getDatePartsInTimezone(
     ]);
     const weekdayStr = getValue("weekday");
 
+    // Use NaN-safe parsing so zero-valued fields (hour/minute/second = 0)
+    // don't incorrectly fall back to local time via the || operator.
+    const parseField = (val: string, fallback: number): number => {
+      const n = Number.parseInt(val, 10);
+      return Number.isNaN(n) ? fallback : n;
+    };
     return {
-      year: Number.parseInt(getValue("year"), 10) || date.getFullYear(),
-      month: Number.parseInt(getValue("month"), 10) || date.getMonth() + 1,
-      day: Number.parseInt(getValue("day"), 10) || date.getDate(),
-      hour: Number.parseInt(getValue("hour"), 10) || date.getHours(),
-      minute: Number.parseInt(getValue("minute"), 10) || date.getMinutes(),
-      second: Number.parseInt(getValue("second"), 10) || date.getSeconds(),
+      year: parseField(getValue("year"), date.getFullYear()),
+      month: parseField(getValue("month"), date.getMonth() + 1),
+      day: parseField(getValue("day"), date.getDate()),
+      // % 24 normalises the rare browser quirk of returning 24 for midnight
+      hour: parseField(getValue("hour"), date.getHours()) % 24,
+      minute: parseField(getValue("minute"), date.getMinutes()),
+      second: parseField(getValue("second"), date.getSeconds()),
       weekday: weekdayMap.get(weekdayStr) ?? date.getDay(),
     };
   } catch {

--- a/packages/just-bash/src/security/sandbox/information-disclosure.test.ts
+++ b/packages/just-bash/src/security/sandbox/information-disclosure.test.ts
@@ -443,23 +443,43 @@ describe("Information Disclosure Prevention", () => {
     });
   });
 
-  describe("Timezone Non-Disclosure", () => {
-    it("date should not leak host timezone name", async () => {
-      const result = await bash.exec("date +%Z");
-      const tz = result.stdout.trim();
-      expect(tz).toBe("UTC");
-      // Must not contain slash-separated timezone like America/New_York
-      expect(tz).not.toContain("/");
+  // Per PR #251 (vercel-labs/just-bash#251), `date` follows GNU `date` and
+  // reflects the host (or `$TZ`) timezone by default; timezone is no longer
+  // treated as host-secret. Only `-u` is a contractual UTC guarantee.
+  describe("Timezone behavior", () => {
+    it("date -u +%Z outputs UTC", async () => {
+      const result = await bash.exec("date -u +%Z");
+      expect(result.stdout).toBe("UTC\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
     });
 
-    it("date should not leak host UTC offset", async () => {
-      const result = await bash.exec("date +%z");
-      expect(result.stdout.trim()).toBe("+0000");
+    it("date -u +%z outputs +0000", async () => {
+      const result = await bash.exec("date -u +%z");
+      expect(result.stdout).toBe("+0000\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
     });
 
-    it("date default output should use UTC", async () => {
-      const result = await bash.exec("date");
+    it("date -u default output contains UTC", async () => {
+      const result = await bash.exec("date -u");
+      // Partial match is unavoidable here: default `date -u` output includes
+      // the current weekday/time, so we can only assert the UTC zone marker.
       expect(result.stdout).toContain("UTC");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("without -u, %z is a numeric offset and %Z is non-empty", async () => {
+      const zResult = await bash.exec("date +%z");
+      expect(zResult.stderr).toBe("");
+      expect(zResult.exitCode).toBe(0);
+      expect(zResult.stdout.trim()).toMatch(/^[+-][0-9]{4}$/);
+
+      const upperZResult = await bash.exec("date +%Z");
+      expect(upperZResult.stderr).toBe("");
+      expect(upperZResult.exitCode).toBe(0);
+      expect(upperZResult.stdout.trim().length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/just-bash/src/security/sandbox/information-disclosure.test.ts
+++ b/packages/just-bash/src/security/sandbox/information-disclosure.test.ts
@@ -443,43 +443,42 @@ describe("Information Disclosure Prevention", () => {
     });
   });
 
-  // Per PR #251 (vercel-labs/just-bash#251), `date` follows GNU `date` and
-  // reflects the host (or `$TZ`) timezone by default; timezone is no longer
-  // treated as host-secret. Only `-u` is a contractual UTC guarantee.
-  describe("Timezone behavior", () => {
-    it("date -u +%Z outputs UTC", async () => {
-      const result = await bash.exec("date -u +%Z");
+  // Default behaviour is UTC (non-disclosure of host TZ). Callers can opt in
+  // to a specific timezone by setting `$TZ` in the sandbox environment — see
+  // PR #251.
+  describe("Timezone Non-Disclosure", () => {
+    it("date +%Z outputs UTC by default", async () => {
+      const result = await bash.exec("date +%Z");
       expect(result.stdout).toBe("UTC\n");
       expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });
 
-    it("date -u +%z outputs +0000", async () => {
-      const result = await bash.exec("date -u +%z");
+    it("date +%z outputs +0000 by default", async () => {
+      const result = await bash.exec("date +%z");
       expect(result.stdout).toBe("+0000\n");
       expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });
 
-    it("date -u default output contains UTC", async () => {
-      const result = await bash.exec("date -u");
-      // Partial match is unavoidable here: default `date -u` output includes
+    it("default date output contains UTC", async () => {
+      const result = await bash.exec("date");
+      // Partial match is unavoidable here: default `date` output includes
       // the current weekday/time, so we can only assert the UTC zone marker.
       expect(result.stdout).toContain("UTC");
       expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
     });
+  });
 
-    it("without -u, %z is a numeric offset and %Z is non-empty", async () => {
-      const zResult = await bash.exec("date +%z");
-      expect(zResult.stderr).toBe("");
-      expect(zResult.exitCode).toBe(0);
-      expect(zResult.stdout.trim()).toMatch(/^[+-][0-9]{4}$/);
-
-      const upperZResult = await bash.exec("date +%Z");
-      expect(upperZResult.stderr).toBe("");
-      expect(upperZResult.exitCode).toBe(0);
-      expect(upperZResult.stdout.trim().length).toBeGreaterThan(0);
+  describe("Timezone opt-in via $TZ", () => {
+    it("TZ=America/Los_Angeles date +%Z prints PST or PDT", async () => {
+      const result = await bash.exec(
+        "export TZ=America/Los_Angeles && date +%Z",
+      );
+      expect(result.stdout.trim()).toMatch(/^(PST|PDT)$/);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
     });
   });
 


### PR DESCRIPTION
~~The comments in the code indicated that using UTC in the sandbox is desirable, but I'm not sure if that is actually what you want, @cramforce or just agent cope.~~

As the UTC masking is desired, I've updated the PR to default on that. Set $TZ to something to get local time.

I'm running `just-bash` in the browser and get annoyed by my agent being unable to tell the hour (it always gets the minute right), so this PR aligns it more closely with `date` on Linux.

Replace the hand-rolled UTC-only format loop with a call to the existing `formatStrftime()` from `printf/strftime.ts`, which already handles local timezone, TZ env var, and the full set of Linux format specifiers.

- `date` now shows time from `$TZ` as local time by default; `-u` still forces UTC, if no `$TZ` env var is set, stay with UTC.
- TZ env var is respected for per-command timezone override
- Adds @timestamp parsing (`date -d @1705276800`, GNU extension)
- Gains `%A %B %C %D %G %g %j %k %l %N %r %U %V %W %x %X` at no cost
- Fixes `strftime.ts`: hour/minute/second = 0 would fall back to local time via `||` operator instead of using the `Intl`-resolved value