### PR TITLE
feat(jq): add raw input mode (-R/--raw-input)

### DIFF
--- a/packages/just-bash/src/commands/jq/jq.raw-input.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.raw-input.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("jq raw input (-R)", () => {
+  it("should read stdin lines as strings with -R", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\nb\\n' | jq -R '.'");
+    expect(result.stdout).toBe('"a"\n"b"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should preserve blank lines with -R", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\n\\nb' | jq -R '.'");
+    expect(result.stdout).toBe('"a"\n""\n"b"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp raw stdin into a single string with -Rs", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\nb\\n' | jq -Rs '.'");
+    expect(result.stdout).toBe('"a\\nb\\n"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should read raw input from files line by line", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "first\n",
+        "/b.txt": "second",
+      },
+    });
+    const result = await env.exec("jq -R '.' /a.txt /b.txt");
+    expect(result.stdout).toBe('"first"\n"second"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should join a line across a file boundary when no trailing newline", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "first",
+        "/b.txt": "second\n",
+      },
+    });
+    const result = await env.exec("jq -R '.' /a.txt /b.txt");
+    expect(result.stdout).toBe('"firstsecond"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp raw input across files without inserting separators", async () => {
+    const env = new Bash({
+      files: {
+        "/a.txt": "first\n",
+        "/b.txt": "second",
+      },
+    });
+    const result = await env.exec("jq -Rs '.' /a.txt /b.txt");
+    expect(result.stdout).toBe('"first\\nsecond"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should handle stdin marker together with files in raw mode", async () => {
+    const env = new Bash({
+      files: {
+        "/file.txt": "file\n",
+      },
+    });
+    const result = await env.exec("printf 'stdin\\n' | jq -R '.' - /file.txt");
+    expect(result.stdout).toBe('"stdin"\n"file"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should allow raw input with raw output", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'hello\\n' | jq -Rr '.'");
+    expect(result.stdout).toBe("hello\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should keep carriage returns inside raw lines", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'a\\r\\nb\\r\\n' | jq -R '.'");
+    expect(result.stdout).toBe('"a\\r"\n"b\\r"\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should produce no output for empty raw input", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf '' | jq -R '.'");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should slurp empty raw input into an empty string", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf '' | jq -Rs '.'");
+    expect(result.stdout).toBe('""\n');
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should build an object from raw slurped input", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'console.log(1)\\n' | jq -Rs '{action:\"load-code\", code: .}'",
+    );
+    expect(result.stdout).toBe(
+      '{\n  "action": "load-code",\n  "code": "console.log(1)\\n"\n}\n',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/jq/jq.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.test.ts
@@ -335,6 +335,7 @@ describe("jq", () => {
       const env = new Bash();
       const result = await env.exec("jq --help");
       expect(result.stdout).toMatch(/jq.*JSON/);
+      expect(result.stdout).toContain("-R, --raw-input");
       expect(result.exitCode).toBe(0);
     });
   });

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -178,11 +178,11 @@ function parseJsonStream(input: string): unknown[] {
 const jqHelp = {
   name: "jq",
   summary: "command-line JSON processor",
-  usage: "jq [OPTIONS] FILTER [FILE]",
+  usage: "jq [OPTIONS] FILTER [FILE...]",
   options: [
-    "-R, --raw-input   read input as raw strings, not JSON",
+    "-R, --raw-input   read each line as string instead of JSON",
     "-r, --raw-output  output strings without quotes",
-    "-c, --compact     compact output (no pretty printing)",
+    "-c, --compact-output  compact instead of pretty-printed output",
     "-e, --exit-status set exit status based on output",
     "-s, --slurp       read entire input into array",
     "-n, --null-input  don't read any input",
@@ -376,15 +376,25 @@ export const jqCommand: Command = {
       } else if (rawInput) {
         // Raw input: real jq concatenates all inputs into a single stream and
         // splits on newlines, so a line can span a file boundary when a file
-        // lacks a trailing newline. A trailing newline does not yield a final
-        // empty string, but interior blank lines are preserved.
-        const combined = inputs.map(({ content }) => content).join("");
-        const lines = combined.split("\n");
-        if (lines.length > 0 && lines.at(-1) === "") {
-          lines.pop();
+        // lacks a trailing newline. Scan incrementally, carrying only the
+        // unterminated trailing fragment across inputs, instead of building the
+        // full concatenated string and a complete array of lines. A trailing
+        // newline does not yield a final empty string, but interior blank
+        // lines are preserved.
+        let remainder = "";
+        for (const { content } of inputs) {
+          const text = remainder + content;
+          let start = 0;
+          let nl = text.indexOf("\n", start);
+          while (nl !== -1) {
+            values.push(...evaluate(text.slice(start, nl), ast, evalOptions));
+            start = nl + 1;
+            nl = text.indexOf("\n", start);
+          }
+          remainder = text.slice(start);
         }
-        for (const line of lines) {
-          values.push(...evaluate(line, ast, evalOptions));
+        if (remainder !== "") {
+          values.push(...evaluate(remainder, ast, evalOptions));
         }
       } else if (slurp) {
         // Slurp mode: combine all inputs into single array

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -180,6 +180,7 @@ const jqHelp = {
   summary: "command-line JSON processor",
   usage: "jq [OPTIONS] FILTER [FILE]",
   options: [
+    "-R, --raw-input   read input as raw strings, not JSON",
     "-r, --raw-output  output strings without quotes",
     "-c, --compact     compact output (no pretty printing)",
     "-e, --exit-status set exit status based on output",
@@ -267,6 +268,7 @@ export const jqCommand: Command = {
     if (hasHelpFlag(args)) return showHelp(jqHelp);
 
     let raw = false;
+    let rawInput = false;
     let compact = false;
     let exitStatus = false;
     let slurp = false;
@@ -280,7 +282,8 @@ export const jqCommand: Command = {
 
     for (let i = 0; i < args.length; i++) {
       const a = args[i];
-      if (a === "-r" || a === "--raw-output") raw = true;
+      if (a === "-R" || a === "--raw-input") rawInput = true;
+      else if (a === "-r" || a === "--raw-output") raw = true;
       else if (a === "-c" || a === "--compact-output") compact = true;
       else if (a === "-e" || a === "--exit-status") exitStatus = true;
       else if (a === "-s" || a === "--slurp") slurp = true;
@@ -298,7 +301,8 @@ export const jqCommand: Command = {
       else if (a.startsWith("--")) return unknownOption("jq", a);
       else if (a.startsWith("-")) {
         for (const c of a.slice(1)) {
-          if (c === "r") raw = true;
+          if (c === "R") rawInput = true;
+          else if (c === "r") raw = true;
           else if (c === "c") compact = true;
           else if (c === "e") exitStatus = true;
           else if (c === "s") slurp = true;
@@ -365,6 +369,23 @@ export const jqCommand: Command = {
 
       if (nullInput) {
         values = evaluate(null, ast, evalOptions);
+      } else if (rawInput && slurp) {
+        // Raw slurp: the entire concatenated input becomes one JSON string.
+        const rawText = inputs.map(({ content }) => content).join("");
+        values = evaluate(rawText, ast, evalOptions);
+      } else if (rawInput) {
+        // Raw input: real jq concatenates all inputs into a single stream and
+        // splits on newlines, so a line can span a file boundary when a file
+        // lacks a trailing newline. A trailing newline does not yield a final
+        // empty string, but interior blank lines are preserved.
+        const combined = inputs.map(({ content }) => content).join("");
+        const lines = combined.split("\n");
+        if (lines.length > 0 && lines.at(-1) === "") {
+          lines.pop();
+        }
+        for (const line of lines) {
+          values.push(...evaluate(line, ast, evalOptions));
+        }
       } else if (slurp) {
         // Slurp mode: combine all inputs into single array
         // Use JSON stream parser to handle concatenated JSON (not just NDJSON)
@@ -457,6 +478,7 @@ import type { CommandFuzzInfo } from "../fuzz-flags-types.js";
 export const flagsForFuzzing: CommandFuzzInfo = {
   name: "jq",
   flags: [
+    { flag: "-R", type: "boolean" },
     { flag: "-r", type: "boolean" },
     { flag: "-c", type: "boolean" },
     { flag: "-e", type: "boolean" },

--- a/packages/just-bash/src/comparison-tests/fixtures/jq.raw-input.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/jq.raw-input.comparison.fixtures.json
@@ -1,0 +1,69 @@
+{
+  "03c428e42ab1f036": {
+    "command": "printf 'console.log(1)\\n' | jq -Rs '{action:\"load-code\", code: .}'",
+    "files": {},
+    "stdout": "{\n  \"action\": \"load-code\",\n  \"code\": \"console.log(1)\\n\"\n}\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2774b60ac30dbf90": {
+    "command": "jq -R '.' a.txt b.txt",
+    "files": {
+      "a.txt": "first",
+      "b.txt": "second\n"
+    },
+    "stdout": "\"firstsecond\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "352162774da404df": {
+    "command": "printf 'a\\n\\nb' | jq -R '.'",
+    "files": {},
+    "stdout": "\"a\"\n\"\"\n\"b\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3eccd43ed92a3c69": {
+    "command": "jq -Rs '.' a.txt b.txt",
+    "files": {
+      "a.txt": "first\n",
+      "b.txt": "second"
+    },
+    "stdout": "\"first\\nsecond\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4527747d8e92f72c": {
+    "command": "printf 'stdin\\n' | jq -R '.' - file.txt",
+    "files": {
+      "file.txt": "file\n"
+    },
+    "stdout": "\"stdin\"\n\"file\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4ef4020b99945f34": {
+    "command": "printf 'a\\nb\\n' | jq -Rs '.'",
+    "files": {},
+    "stdout": "\"a\\nb\\n\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ed6d0745a5d92cef": {
+    "command": "printf 'a\\nb\\n' | jq -R '.'",
+    "files": {},
+    "stdout": "\"a\"\n\"b\"\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ff334c372880449c": {
+    "command": "jq -R '.' a.txt b.txt",
+    "files": {
+      "a.txt": "first\n",
+      "b.txt": "second"
+    },
+    "stdout": "\"first\"\n\"second\"\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/jq.raw-input.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/jq.raw-input.comparison.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+describe("jq raw input - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  describe("stdin", () => {
+    it("should read stdin lines as strings with -R", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\nb\\n' | jq -R '.'");
+    });
+
+    it("should preserve blank lines with -R", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\n\\nb' | jq -R '.'");
+    });
+
+    it("should slurp raw stdin with -Rs", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(env, testDir, "printf 'a\\nb\\n' | jq -Rs '.'");
+    });
+
+    it("should build an object from raw slurped stdin", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'console.log(1)\\n' | jq -Rs '{action:\"load-code\", code: .}'",
+      );
+    });
+  });
+
+  describe("files", () => {
+    it("should read files line by line with -R", async () => {
+      const env = await setupFiles(testDir, {
+        "a.txt": "first\n",
+        "b.txt": "second",
+      });
+      await compareOutputs(env, testDir, "jq -R '.' a.txt b.txt");
+    });
+
+    it("should join a line across a file boundary without trailing newline", async () => {
+      const env = await setupFiles(testDir, {
+        "a.txt": "first",
+        "b.txt": "second\n",
+      });
+      await compareOutputs(env, testDir, "jq -R '.' a.txt b.txt");
+    });
+
+    it("should slurp files without separators with -Rs", async () => {
+      const env = await setupFiles(testDir, {
+        "a.txt": "first\n",
+        "b.txt": "second",
+      });
+      await compareOutputs(env, testDir, "jq -Rs '.' a.txt b.txt");
+    });
+
+    it("should support stdin marker with files in raw mode", async () => {
+      const env = await setupFiles(testDir, {
+        "file.txt": "file\n",
+      });
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'stdin\\n' | jq -R '.' - file.txt",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `-R` / `--raw-input` support to `jq` (including the common `-Rs` combination), so input can be read as raw strings instead of JSON.

This **builds on #189** by @nicoster, which has gone stale and is now `CONFLICTING`. The reasons #189 can't merge as-is:

1. **Monorepo refactor (#198)** moved everything from `src/...` to `packages/just-bash/src/...`, so #189 edits paths that no longer exist on `main`.
2. **UTF-8 input refactor (#233)** reworked the stdin/file read path (`decodeBytesToUtf8`), changing the insertion context #189 relied on.
3. **A correctness bug:** #189 processed each input file independently. Real jq concatenates all inputs into a single stream and splits lines across file boundaries.

## What changed vs #189

- Rebased onto the current `packages/just-bash` layout.
- **Fixed the file-boundary bug:** inputs are concatenated *before* line splitting. With `a.txt`=`first` (no trailing newline) and `b.txt`=`second\n`, real jq emits `"firstsecond"` (one line spanning the boundary), now matched exactly.
- `-Rs` slurps the entire concatenated input into a single JSON string.
- Trailing newline does not yield a final empty string; interior blank lines are preserved; `\r` is kept (jq splits only on `\n`).

## Testing

- `pnpm typecheck`, `pnpm lint:fix`, `pnpm lint:banned`, `pnpm knip` — all clean
- `pnpm test:run src/commands/jq/jq.raw-input.test.ts src/commands/jq/jq.test.ts` — 47 passing
- `pnpm test:comparison src/comparison-tests/jq.raw-input.comparison.test.ts` — 8 passing, fixtures recorded against `jq-1.7.1`

New coverage: stdin line-by-line, blank lines, `-Rs` slurp, multi-file reads, the cross-file-boundary case, the `-` stdin marker mixed with files, CRLF preservation, empty input, and `-Rr`.

Closes the gap that made e.g. `jq -Rs '{action:"load-code", code: .}' < file.js` fail with `jq: invalid option -- 'R'`.

Credit to @nicoster for the original implementation and tests (#189).
