### PR TITLE
fix(set): support bundled -o in short-flag clusters (set -euo pipefail)

### DIFF
--- a/.changeset/wise-spoons-grin.md
+++ b/.changeset/wise-spoons-grin.md
@@ -1,0 +1,11 @@
+---
+"just-bash": patch
+---
+
+set: support a bundled `-o`/`+o` long option inside a short-flag cluster (e.g. `set -euo pipefail`)
+
+The `set` builtin previously rejected `set -euo pipefail` with `bash: set: -o: invalid option`, because it parsed each character after the `-` as an independent short flag and has no `o` short flag. `-o` was only honored as its own token (`set -eu -o pipefail`).
+
+This is the canonical "bash strict mode" idiom and is extremely common in generated scripts, so the whole script would abort on its first line.
+
+`set` now matches bash: an `o` inside a cluster consumes the *next word* as its long-option name, and the remaining characters keep being parsed as short flags. So `set -euo pipefail` is equivalent to `set -e -u -o pipefail`, `set -oe pipefail` enables both `pipefail` and `errexit`, trailing words become positional parameters, and `+`-clusters (`set +euo pipefail`) disable the options. An invalid bundled name (`set -euo bogus`) still reports `invalid option name`, and an `o` with no following argument falls back to the standalone `-o`/`+o` listing.

--- a/packages/just-bash/src/interpreter/builtins/set.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.test.ts
@@ -348,6 +348,19 @@ describe("set builtin", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("should not consume a following option token as the -o name (`set -o -x`)", async () => {
+      // bash does not treat `-x` as the `-o` option name; it lists options and
+      // then processes `-x` as xtrace. `$-` ends up with `x`.
+      const env = new Bash();
+      const result = await env.exec(`
+        set -o -x
+        echo "dash=$-"
+      `);
+      expect(result.stdout).toContain("errexit");
+      expect(result.stdout).toMatch(/dash=\S*x\S*/);
+      expect(result.exitCode).toBe(0);
+    });
+
     it("should let multiple bundled `o`s consume successive words", async () => {
       // `set -oo pipefail errexit` == `set -o pipefail -o errexit`: each `o`
       // consumes the next word as its long-option name.

--- a/packages/just-bash/src/interpreter/builtins/set.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.test.ts
@@ -306,6 +306,47 @@ describe("set builtin", () => {
       expect(result.stderr).toContain("bogusoption");
       expect(result.stderr).toContain("invalid option name");
     });
+
+    it("should still enable errexit for `set -oe` when no -o name follows", async () => {
+      // bash applies every flag in the cluster even when the bundled `o` has
+      // no option-name argument: `set -oe` (no following word) enables errexit
+      // *and* prints the option listing. The remaining flags are not abandoned.
+      const env = new Bash();
+      const result = await env.exec(`
+        set -oe
+        false
+        echo never
+      `);
+      // errexit is active, so `false` aborts before `echo never`.
+      expect(result.stdout).not.toContain("never");
+      expect(result.exitCode).toBe(1);
+      // The no-name `o` prints the option listing (snapshot taken before `e`
+      // is applied, so errexit shows off there).
+      expect(result.stdout).toContain("errexit");
+    });
+
+    it("should print the listing but apply leading flags for `set -eo`", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -eo
+        echo "dash=$-"
+      `);
+      // The listing is emitted, and errexit (the flag before `o`) is applied.
+      expect(result.stdout).toContain("errexit");
+      expect(result.stdout).toMatch(/dash=\S*e\S*/);
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should enable errexit and nounset for `set -oue` (no -o name)", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -oue
+        echo "dash=$-"
+      `);
+      expect(result.stdout).toMatch(/dash=\S*e\S*/);
+      expect(result.stdout).toMatch(/dash=\S*u\S*/);
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("set -e (errexit)", () => {

--- a/packages/just-bash/src/interpreter/builtins/set.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.test.ts
@@ -224,6 +224,90 @@ describe("set builtin", () => {
     });
   });
 
+  describe("bundled -o in a short-flag cluster (strict mode)", () => {
+    it("should accept `set -euo pipefail`", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -euo pipefail
+        echo ok
+      `);
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toBe("ok\n");
+    });
+
+    it("should enable errexit, nounset and pipefail with -euo pipefail", async () => {
+      const env = new Bash();
+      // nounset must be active: referencing an unset var aborts the script.
+      const result = await env.exec(`
+        set -euo pipefail
+        echo $UNDEFINED
+        echo never
+      `);
+      expect(result.stderr).toContain("UNDEFINED: unbound variable");
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).not.toContain("never");
+    });
+
+    it("should enable pipefail via the bundled -o (-eo pipefail)", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -eo pipefail
+        false | true
+        echo never
+      `);
+      // pipefail makes the pipeline fail; errexit then aborts the script.
+      expect(result.exitCode).toBe(1);
+      expect(result.stdout).not.toContain("never");
+    });
+
+    it("should consume the next word as the -o name regardless of order (-oe pipefail)", async () => {
+      const env = new Bash();
+      // `-oe pipefail` == `-o pipefail` + `-e`: pipefail enabled, no leftover
+      // positional params, and errexit active.
+      const result = await env.exec(`
+        set -oe pipefail
+        echo "args=[$*]"
+        false | true
+        echo never
+      `);
+      expect(result.stdout).toContain("args=[]");
+      expect(result.stdout).not.toContain("never");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should leave trailing words as positional parameters", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -euo pipefail one two
+        echo "$# $1 $2"
+      `);
+      expect(result.stdout).toBe("2 one two\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should disable options with a bundled +o (+euo pipefail)", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        set -euo pipefail
+        set +euo pipefail
+        echo "$UNDEFINED_OK"
+        echo done
+      `);
+      // nounset was turned back off, so the unset var is just empty.
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("done");
+    });
+
+    it("should reject an invalid bundled -o option name", async () => {
+      const env = new Bash();
+      const result = await env.exec("set -euo bogusoption");
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("bogusoption");
+      expect(result.stderr).toContain("invalid option name");
+    });
+  });
+
   describe("set -e (errexit)", () => {
     it("should exit immediately when command fails", async () => {
       const env = new Bash();

--- a/packages/just-bash/src/interpreter/builtins/set.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.test.ts
@@ -347,6 +347,24 @@ describe("set builtin", () => {
       expect(result.stdout).toMatch(/dash=\S*u\S*/);
       expect(result.exitCode).toBe(0);
     });
+
+    it("should let multiple bundled `o`s consume successive words", async () => {
+      // `set -oo pipefail errexit` == `set -o pipefail -o errexit`: each `o`
+      // consumes the next word as its long-option name.
+      const env = new Bash();
+      const result = await env.exec(`
+        set -oo pipefail errexit
+        echo "args=[$*] dash=$-"
+        false | true
+        echo after
+      `);
+      // errexit is on (so `false | true` with pipefail aborts), and no words
+      // leaked into positional parameters.
+      expect(result.stdout).toContain("args=[]");
+      expect(result.stdout).toMatch(/dash=\S*e\S*/);
+      expect(result.stdout).not.toContain("after");
+      expect(result.exitCode).toBe(1);
+    });
   });
 
   describe("set -e (errexit)", () => {

--- a/packages/just-bash/src/interpreter/builtins/set.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.ts
@@ -242,6 +242,29 @@ function getAssocArrayNames(ctx: InterpreterContext): Set<string> {
   return ctx.state.associativeArrays ?? new Set<string>();
 }
 
+/**
+ * Format the `set -o` listing (one option per line, "<name>  on|off").
+ */
+function formatOptionsList(ctx: InterpreterContext): string {
+  const implementedOutput = DISPLAY_OPTIONS.map(
+    (opt) => `${opt.padEnd(16)}${ctx.state.options[opt] ? "on" : "off"}`,
+  );
+  const noopOutput = NOOP_DISPLAY_OPTIONS.map((opt) => `${opt.padEnd(16)}off`);
+  return `${[...implementedOutput, ...noopOutput].sort().join("\n")}\n`;
+}
+
+/**
+ * Format the `set +o` listing (the `set -o <name>` / `set +o <name>`
+ * commands needed to recreate the current option settings).
+ */
+function formatOptionsResetCommands(ctx: InterpreterContext): string {
+  const implementedOutput = DISPLAY_OPTIONS.map(
+    (opt) => `set ${ctx.state.options[opt] ? "-o" : "+o"} ${opt}`,
+  );
+  const noopOutput = NOOP_DISPLAY_OPTIONS.map((opt) => `set +o ${opt}`);
+  return `${[...implementedOutput, ...noopOutput].sort().join("\n")}\n`;
+}
+
 export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
   if (args.includes("--help")) {
     return success(SET_USAGE);
@@ -368,35 +391,61 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
 
     // Handle -o alone (print current settings)
     if (arg === "-o") {
-      const implementedOutput = DISPLAY_OPTIONS.map(
-        (opt) => `${opt.padEnd(16)}${ctx.state.options[opt] ? "on" : "off"}`,
-      );
-      const noopOutput = NOOP_DISPLAY_OPTIONS.map(
-        (opt) => `${opt.padEnd(16)}off`,
-      );
-      const allOptions = [...implementedOutput, ...noopOutput].sort();
-      return success(`${allOptions.join("\n")}\n`);
+      return success(formatOptionsList(ctx));
     }
 
     // Handle +o alone (print commands to recreate settings)
     if (arg === "+o") {
-      const implementedOutput = DISPLAY_OPTIONS.map(
-        (opt) => `set ${ctx.state.options[opt] ? "-o" : "+o"} ${opt}`,
-      );
-      const noopOutput = NOOP_DISPLAY_OPTIONS.map((opt) => `set +o ${opt}`);
-      const allOptions = [...implementedOutput, ...noopOutput].sort();
-      return success(`${allOptions.join("\n")}\n`);
+      return success(formatOptionsResetCommands(ctx));
     }
 
-    // Handle combined short flags like -eu or +eu
+    // Handle combined short flags like -eu or +eu, including a bundled
+    // -o/+o long option (e.g. `set -euo pipefail`). In bash, an `o` inside
+    // a cluster consumes the *next word* as its long-option name — so
+    // `set -euo pipefail` is equivalent to `set -e -u -o pipefail`, and the
+    // remaining characters of the token keep being parsed as short flags
+    // (`set -oe pipefail` sets both pipefail and errexit). Multiple `o`s
+    // consume successive words. An `o` with no available argument behaves
+    // like a standalone `-o`/`+o` and prints the current option settings.
     if (
       arg.length > 1 &&
       (arg[0] === "-" || arg[0] === "+") &&
       arg[1] !== "-"
     ) {
       const enable = arg[0] === "-";
+      // Number of following words already consumed as -o/+o option names.
+      let consumedArgs = 0;
       for (let j = 1; j < arg.length; j++) {
         const flag = arg[j];
+
+        // `o` takes its option name from the next word, not from the
+        // remaining characters of the current token.
+        if (flag === "o") {
+          const valueIndex = i + 1 + consumedArgs;
+          const hasOptionName =
+            valueIndex < args.length &&
+            !args[valueIndex].startsWith("-") &&
+            !args[valueIndex].startsWith("+");
+          if (hasOptionName) {
+            const optName = args[valueIndex];
+            if (!LONG_OPTION_MAP.has(optName)) {
+              const errorMsg = `bash: set: ${optName}: invalid option name\n${SET_USAGE}`;
+              // In POSIX mode, invalid option is fatal
+              if (ctx.state.options.posix) {
+                throw new PosixFatalError(1, "", errorMsg);
+              }
+              return failure(errorMsg);
+            }
+            setShellOption(ctx, LONG_OPTION_MAP.get(optName) ?? null, enable);
+            consumedArgs++;
+            continue;
+          }
+          // No option name available: behave like a standalone `-o`/`+o`.
+          return success(
+            enable ? formatOptionsList(ctx) : formatOptionsResetCommands(ctx),
+          );
+        }
+
         if (!SHORT_OPTION_MAP.has(flag)) {
           const errorMsg = `bash: set: ${arg[0]}${flag}: invalid option\n${SET_USAGE}`;
           // In POSIX mode, invalid option is fatal
@@ -407,7 +456,7 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
         }
         setShellOption(ctx, SHORT_OPTION_MAP.get(flag) ?? null, enable);
       }
-      i++;
+      i += 1 + consumedArgs;
       continue;
     }
 

--- a/packages/just-bash/src/interpreter/builtins/set.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.ts
@@ -369,6 +369,14 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
     return success(lines.length > 0 ? `${lines.join("\n")}\n` : "");
   }
 
+  // Listings emitted by a no-option-name `o` bundled in a short-flag cluster
+  // (e.g. `set -oe`). bash prints the option listing but keeps applying the
+  // rest of the flags, so the output is deferred and flushed once all flags
+  // and tokens have been processed.
+  const pendingListings: string[] = [];
+  const finish = (): ExecResult =>
+    pendingListings.length > 0 ? success(pendingListings.join("")) : OK;
+
   let i = 0;
   while (i < args.length) {
     const arg = args[i];
@@ -405,8 +413,10 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
     // `set -euo pipefail` is equivalent to `set -e -u -o pipefail`, and the
     // remaining characters of the token keep being parsed as short flags
     // (`set -oe pipefail` sets both pipefail and errexit). Multiple `o`s
-    // consume successive words. An `o` with no available argument behaves
-    // like a standalone `-o`/`+o` and prints the current option settings.
+    // consume successive words. An `o` with no available argument prints the
+    // current option settings (like a standalone `-o`/`+o`) but does NOT stop
+    // flag processing — the remaining flags are still applied, so `set -oe`
+    // (no option name) enables errexit and lists the options.
     if (
       arg.length > 1 &&
       (arg[0] === "-" || arg[0] === "+") &&
@@ -440,10 +450,15 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
             consumedArgs++;
             continue;
           }
-          // No option name available: behave like a standalone `-o`/`+o`.
-          return success(
+          // No option name available: like a standalone `-o`/`+o`, bash prints
+          // the option listing — a snapshot of the state *so far*, hence
+          // computed here before later flags in the cluster are applied — but
+          // it keeps processing the remaining flags, so e.g. `set -oe` still
+          // enables errexit. The listing is deferred and flushed at the end.
+          pendingListings.push(
             enable ? formatOptionsList(ctx) : formatOptionsResetCommands(ctx),
           );
+          continue;
         }
 
         if (!SHORT_OPTION_MAP.has(flag)) {
@@ -463,7 +478,7 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
     // Handle -- (end of options)
     if (arg === "--") {
       setPositionalParameters(ctx, args.slice(i + 1));
-      return OK;
+      return finish();
     }
 
     // Handle - (disable xtrace and verbose, end of options)
@@ -473,7 +488,7 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
       updateShellopts(ctx);
       if (i + 1 < args.length) {
         setPositionalParameters(ctx, args.slice(i + 1));
-        return OK;
+        return finish();
       }
       i++;
       continue;
@@ -497,10 +512,10 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
 
     // Non-option arguments are positional parameters
     setPositionalParameters(ctx, args.slice(i));
-    return OK;
+    return finish();
   }
 
-  return OK;
+  return finish();
 }
 
 /**

--- a/packages/just-bash/src/interpreter/builtins/set.ts
+++ b/packages/just-bash/src/interpreter/builtins/set.ts
@@ -397,14 +397,21 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
       continue;
     }
 
-    // Handle -o alone (print current settings)
+    // Handle -o with no option name (print current settings). Like the
+    // bundled form, bash prints the listing but keeps processing any following
+    // tokens — e.g. `set -o -x` lists options and then enables xtrace — so the
+    // listing is deferred and flushed at the end rather than returned here.
     if (arg === "-o") {
-      return success(formatOptionsList(ctx));
+      pendingListings.push(formatOptionsList(ctx));
+      i++;
+      continue;
     }
 
-    // Handle +o alone (print commands to recreate settings)
+    // Handle +o with no option name (print commands to recreate settings).
     if (arg === "+o") {
-      return success(formatOptionsResetCommands(ctx));
+      pendingListings.push(formatOptionsResetCommands(ctx));
+      i++;
+      continue;
     }
 
     // Handle combined short flags like -eu or +eu, including a bundled
@@ -413,10 +420,13 @@ export function handleSet(ctx: InterpreterContext, args: string[]): ExecResult {
     // `set -euo pipefail` is equivalent to `set -e -u -o pipefail`, and the
     // remaining characters of the token keep being parsed as short flags
     // (`set -oe pipefail` sets both pipefail and errexit). Multiple `o`s
-    // consume successive words. An `o` with no available argument prints the
-    // current option settings (like a standalone `-o`/`+o`) but does NOT stop
-    // flag processing — the remaining flags are still applied, so `set -oe`
-    // (no option name) enables errexit and lists the options.
+    // consume successive words. The option name must be a non-option word: a
+    // following `-`/`+`-prefixed token (e.g. `set -o -x`) is NOT consumed as
+    // the name — bash then treats it as the "no name available" case. In that
+    // case the `o` prints the current option settings (like a standalone
+    // `-o`/`+o`) but does NOT stop flag processing — the remaining flags are
+    // still applied, so `set -oe` (no name) enables errexit and lists options,
+    // and `set -o -x` lists options and then enables xtrace.
     if (
       arg.length > 1 &&
       (arg[0] === "-" || arg[0] === "+") &&


### PR DESCRIPTION
## Problem

`set -euo pipefail` — the canonical "bash strict mode" idiom — fails:

```
$ echo 'set -euo pipefail; echo ok' | just-bash
bash: set: -o: invalid option
set: usage: set [-eux] [+eux] [-o option] [+o option]
...
```

The cluster branch of `handleSet` parses every character after `-` as an
independent short flag, and there is no `o` short flag. `-o` was only honored
as its own token (`set -eu -o pipefail`). Because `set -euo pipefail` is what
LLMs / scripts put on the *first line*, the whole script aborts before doing
anything. This reproduces on `main` (and every published version through
3.0.1).

## Fix

Match bash's behavior: an `o` encountered inside a short-flag cluster consumes
the **next word** as its long-option name, and the remaining characters of the
token keep being parsed as short flags.

- `set -euo pipefail` ≡ `set -e -u -o pipefail`
- `set -oe pipefail` enables both `pipefail` (from the next word) and `errexit`
  (the trailing `e`) — order within the token doesn't matter, matching bash
- multiple `o`s consume successive words
- trailing words become positional parameters (`set -euo pipefail a b` → `$1=a`, `$2=b`)
- `+`-clusters disable (`set +euo pipefail`)
- an invalid bundled name still errors with `invalid option name`
  (`set -euo bogus`)
- an `o` with no available argument falls back to the standalone `-o`/`+o`
  listing

The two standalone `-o` / `+o` listing branches were extracted into shared
`formatOptionsList` / `formatOptionsResetCommands` helpers and reused by the
cluster fallback (no behavior change for the standalone forms).

## Tests

Added a `bundled -o in a short-flag cluster (strict mode)` describe block in
`set.test.ts` covering `-euo pipefail`, errexit/nounset/pipefail activation,
`-eo pipefail`, the `-oe pipefail` ordering case, trailing positional params,
`+euo pipefail`, and the invalid-name error.

Verified locally:

- `vitest run` on `set.test.ts` (51 passed), `set-pipefail.test.ts` +
  `set-errexit.test.ts` (37 passed)
- `tsc --noEmit` clean
- `biome check` + `lint:banned` clean

Changeset included (`patch`).