### PR TITLE
ci(lint): fail when PR commits are not signed/verified

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -16,11 +20,11 @@ jobs:
       - name: Verify commits are signed
         if: github.event_name == 'pull_request'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           unsigned=$(gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
-            --jq '.[] | select(.commit.verification.verified == false) | "\(.sha[0:9])  \(.commit.message | split("\n")[0])"')
+            --jq '.[] | select(.commit.verification.verified != true) | "\(.sha[0:9])  \(.commit.message | split("\n")[0])"')
           if [ -n "$unsigned" ]; then
             echo "::error::The following commits are not signed/verified. Sign every commit and force-push (e.g. git rebase --exec 'git commit --amend --no-edit -S' <base>):"
             echo "$unsigned"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Verify commits are signed
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          unsigned=$(gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+            --jq '.[] | select(.commit.verification.verified == false) | "\(.sha[0:9])  \(.commit.message | split("\n")[0])"')
+          if [ -n "$unsigned" ]; then
+            echo "::error::The following commits are not signed/verified. Sign every commit and force-push (e.g. git rebase --exec 'git commit --amend --no-edit -S' <base>):"
+            echo "$unsigned"
+            exit 1
+          fi
+          echo "All commits are signed and verified."
+
       - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4


### PR DESCRIPTION
## What

Adds a step to the **Lint** workflow that fails the check when any commit in a pull request is not GPG/SSH signed and verified by GitHub.

## Why

Following #251, signing came up as a manual back-and-forth ("that commit isn't signed, please repush"). This automates that feedback loop so future contributors find out from CI immediately, and the maintainer doesn't have to eyeball signature status per commit.

## How

On `pull_request` events the step queries the GitHub API for the PR's commits and fails if any has `verification.verified == false`:

```yaml
- name: Verify commits are signed
  if: github.event_name == 'pull_request'
  env:
    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
  run: |
    unsigned=$(gh api --paginate \
      "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
      --jq '.[] | select(.commit.verification.verified == false) | "\(.sha[0:9])  \(.commit.message | split("\n")[0])"')
    if [ -n "$unsigned" ]; then
      echo "::error::..."
      echo "$unsigned"
      exit 1
    fi
```

Notes:
- Uses GitHub's own verification status (same as the "Verified" badge), since CI runners don't have contributors' public keys for local `git --show-signature`.
- Enforced on `pull_request` only, to avoid breaking squash/merge commits on pushes to `main`.
- Uses the built-in `GITHUB_TOKEN` (read-only); no extra secrets.

Co-authored-by: factory-droid[bot] <138933559+factory-droid[bot]@users.noreply.github.com>