### PR TITLE
fix(head/tail): read file arguments byte-clean, not UTF-8

### DIFF
--- a/packages/just-bash/src/commands/head/head-tail-shared.ts
+++ b/packages/just-bash/src/commands/head/head-tail-shared.ts
@@ -2,7 +2,11 @@
  * Shared utilities for head and tail commands.
  */
 
-import { latin1FromBytes, readBytesFrom } from "../../encoding.js";
+import {
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  readBytesFrom,
+} from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { unknownOption } from "../help.js";
 
@@ -148,10 +152,16 @@ export async function processHeadTailFiles(
       // Matches the stdin path above and `cat`'s byte-clean behaviour.
       const content = latin1FromBytes(await readBytesFrom(ctx.fs, filePath));
 
-      // Show header if needed - only after we know the file exists
+      // Show header if needed - only after we know the file exists.
+      // The whole result is marked binary, so the redirect/pipe glue writes
+      // each char of `stdout` as one latin1 byte. The header text (which
+      // includes the filename) is JS Unicode, so UTF-8 encode it to its
+      // byte-shaped form first; otherwise a non-ASCII filename like
+      // `café.txt` would be written as latin1 (`é` -> 0xE9) instead of
+      // UTF-8 (`é` -> 0xC3 0xA9), corrupting the header on redirect.
       if (showHeaders) {
         if (filesProcessed > 0) stdout += "\n";
-        stdout += `==> ${file} <==\n`;
+        stdout += latin1FromBytes(encodeUtf8ToBytes(`==> ${file} <==\n`));
       }
       stdout += contentProcessor(content);
       filesProcessed++;

--- a/packages/just-bash/src/commands/head/head-tail-shared.ts
+++ b/packages/just-bash/src/commands/head/head-tail-shared.ts
@@ -2,7 +2,7 @@
  * Shared utilities for head and tail commands.
  */
 
-import { latin1FromBytes } from "../../encoding.js";
+import { latin1FromBytes, readBytesFrom } from "../../encoding.js";
 import type { CommandContext, ExecResult } from "../../types.js";
 import { unknownOption } from "../help.js";
 
@@ -117,13 +117,15 @@ export async function processHeadTailFiles(
 ): Promise<ExecResult> {
   const { quiet, verbose, files } = options;
 
-  // If no files, read from stdin. head/tail are line-oriented and byte-clean
-  // — \n splits are byte-safe regardless of UTF-8 multibyte content.
+  // If no files, read from stdin. head/tail are byte-clean: `\n` splits and
+  // `-c` byte slices are byte-safe over the latin1 view, and the output is
+  // marked binary so the pipeline glue / redirects don't UTF-8 re-encode it.
   if (files.length === 0) {
     return {
       stdout: contentProcessor(latin1FromBytes(ctx.stdin)),
       stderr: "",
       exitCode: 0,
+      stdoutEncoding: "binary",
     };
   }
 
@@ -141,7 +143,10 @@ export async function processHeadTailFiles(
 
     try {
       const filePath = ctx.fs.resolvePath(ctx.cwd, file);
-      const content = await ctx.fs.readFile(filePath);
+      // Read the raw bytes (latin1 view) rather than `fs.readFile`'s UTF-8
+      // decode: `-c` byte counts and binary content must round-trip exactly.
+      // Matches the stdin path above and `cat`'s byte-clean behaviour.
+      const content = latin1FromBytes(await readBytesFrom(ctx.fs, filePath));
 
       // Show header if needed - only after we know the file exists
       if (showHeaders) {
@@ -156,7 +161,7 @@ export async function processHeadTailFiles(
     }
   }
 
-  return { stdout, stderr, exitCode };
+  return { stdout, stderr, exitCode, stdoutEncoding: "binary" };
 }
 
 /**

--- a/packages/just-bash/src/commands/head/head.binary.test.ts
+++ b/packages/just-bash/src/commands/head/head.binary.test.ts
@@ -56,4 +56,19 @@ describe("head with binary files", () => {
     const out = await env.fs.readFileBuffer("/out.bin");
     expect(Array.from(out)).toEqual([0xff, 0x00, 0x80, 0xfe]);
   });
+
+  it("writes a non-ASCII filename header as UTF-8, not latin1, on redirect", async () => {
+    // The whole stream is marked binary, so the header (which carries the
+    // filename) must be UTF-8 encoded to byte-shaped form before mixing it
+    // with the raw file bytes. Otherwise `é` (U+00E9) is written as the
+    // single latin1 byte 0xE9 instead of UTF-8 0xC3 0xA9.
+    const env = new Bash();
+    await env.exec("printf 'hi\\n' > 'café.txt'");
+
+    await env.exec("head -v 'café.txt' > /out.bin");
+    const out = await env.fs.readFileBuffer("/out.bin");
+
+    const expected = new TextEncoder().encode("==> café.txt <==\nhi\n");
+    expect(Array.from(out)).toEqual(Array.from(expected));
+  });
 });

--- a/packages/just-bash/src/commands/head/head.binary.test.ts
+++ b/packages/just-bash/src/commands/head/head.binary.test.ts
@@ -35,4 +35,25 @@ describe("head with binary files", () => {
     expect(result.stdout).toBe("ABC");
     expect(result.exitCode).toBe(0);
   });
+
+  it("-c counts bytes, not codepoints, for a UTF-8 file argument", async () => {
+    // 中 = E4 B8 AD (3 bytes). `head -c 3` must return exactly those 3 bytes.
+    const env = new Bash();
+    await env.exec('printf "中文" > /utf8.txt');
+
+    const result = await env.exec("head -c 3 /utf8.txt");
+    expect(result.stdout).toBe("中");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves high bytes when reading from a file argument (no UTF-8 mangling)", async () => {
+    // 0xFF is invalid UTF-8. The old fs.readFile path decoded it to U+FFFD
+    // (3 bytes), inflating `head -c 4` output to 12 bytes. It must stay 4.
+    const original = new Uint8Array([0xff, 0x00, 0x80, 0xfe, 0x41, 0x42]);
+    const env = new Bash({ files: { "/raw.bin": original } });
+
+    await env.exec("head -c 4 /raw.bin > /out.bin");
+    const out = await env.fs.readFileBuffer("/out.bin");
+    expect(Array.from(out)).toEqual([0xff, 0x00, 0x80, 0xfe]);
+  });
 });

--- a/packages/just-bash/src/commands/tail/tail.binary.test.ts
+++ b/packages/just-bash/src/commands/tail/tail.binary.test.ts
@@ -35,4 +35,24 @@ describe("tail with binary files", () => {
     expect(result.stdout).toBe("CDE");
     expect(result.exitCode).toBe(0);
   });
+
+  it("-c counts bytes, not codepoints, for a UTF-8 file argument", async () => {
+    // 文 = E6 96 87 (3 bytes). `tail -c 3` must return exactly the last 3 bytes.
+    const env = new Bash();
+    await env.exec('printf "中文" > /utf8.txt');
+
+    const result = await env.exec("tail -c 3 /utf8.txt");
+    expect(result.stdout).toBe("文");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves high bytes when reading from a file argument (no UTF-8 mangling)", async () => {
+    // 0xFF is invalid UTF-8; the old fs.readFile path inflated it to U+FFFD.
+    const original = new Uint8Array([0x41, 0x42, 0xff, 0x00, 0x80, 0xfe]);
+    const env = new Bash({ files: { "/raw.bin": original } });
+
+    await env.exec("tail -c 4 /raw.bin > /out.bin");
+    const out = await env.fs.readFileBuffer("/out.bin");
+    expect(Array.from(out)).toEqual([0xff, 0x00, 0x80, 0xfe]);
+  });
 });

--- a/packages/just-bash/src/commands/tail/tail.binary.test.ts
+++ b/packages/just-bash/src/commands/tail/tail.binary.test.ts
@@ -55,4 +55,19 @@ describe("tail with binary files", () => {
     const out = await env.fs.readFileBuffer("/out.bin");
     expect(Array.from(out)).toEqual([0xff, 0x00, 0x80, 0xfe]);
   });
+
+  it("writes a non-ASCII filename header as UTF-8, not latin1, on redirect", async () => {
+    // The whole stream is marked binary, so the header (which carries the
+    // filename) must be UTF-8 encoded to byte-shaped form before mixing it
+    // with the raw file bytes. Otherwise `é` (U+00E9) is written as the
+    // single latin1 byte 0xE9 instead of UTF-8 0xC3 0xA9.
+    const env = new Bash();
+    await env.exec("printf 'hi\\n' > 'café.txt'");
+
+    await env.exec("tail -v 'café.txt' > /out.bin");
+    const out = await env.fs.readFileBuffer("/out.bin");
+
+    const expected = new TextEncoder().encode("==> café.txt <==\nhi\n");
+    expect(Array.from(out)).toEqual(Array.from(expected));
+  });
 });


### PR DESCRIPTION
## Problem

`head` and `tail` read **file arguments** via `ctx.fs.readFile`, which UTF-8-decodes the content. The 3.0.0 stdin byte/utf8 overhaul fixed the **stdin** path (it uses byte-preserving `latin1FromBytes(ctx.stdin)`), but the **file-argument** path was missed. For binary — or any file with bytes > 0x7F — this corrupts data:

- `-c N` slices by **codepoint** instead of **byte**
- invalid/high bytes are re-encoded (e.g. `0xFF` → U+FFFD = 3 bytes), inflating output

### Before (current `main`)

`head -c 4` over the 4 raw bytes `FF 00 80 FE`:

```
$ printf '\xff\x00\x80\xfe' > raw.bin
$ head -c 4 raw.bin | xxd
00000000: efbf bd00 efbf bdef bfbd                  ...........   # ❌ 10 bytes
```

Each invalid byte became `ef bf bd` (U+FFFD). A real-world example: `head -c 50000` over a 50 KB all-`0xFF` file emitted **150000** bytes; over random binary, **95782** bytes.

### After (this PR)

```
$ head -c 4 raw.bin | xxd
00000000: ff00 80fe                                 ....          # ✅ 4 bytes, exact
```

## Fix

In `commands/head/head-tail-shared.ts`, read file arguments with byte-preserving `readBytesFrom` (the same `ByteString` path stdin already uses) and mark stdout `stdoutEncoding: "binary"` (like `cat`) so redirects/pipes don't double-encode the latin1 bytes.

`-c` byte counts and `-n` line splits stay correct: line splitting is on `0x0A`, which is UTF-8-transparent, so it's byte-safe over the latin1 view. ASCII/UTF-8 text is byte-identical in this representation, so existing text behaviour is unchanged.

Marking the stream binary also means the redirect/pipe glue writes **every char of `stdout` as one latin1 byte** — correct for the raw file bytes, but headers (`-v`, or multiple files) carry the **filename as a JS Unicode string**. So the same change UTF-8-encodes the header text to its byte-shaped form (`latin1FromBytes(encodeUtf8ToBytes(...))`) before mixing it with the file bytes, keeping non-ASCII filenames intact on redirect:

```
$ head -v café.txt
==> caf\xc3\xa9.txt <==   # ✅ UTF-8 0xC3 0xA9, not latin1 0xE9
```

This is a one-spot fix in the shared helper, so it covers both `head` and `tail`.

## Tests

Added regression tests to `head.binary.test.ts` and `tail.binary.test.ts`:
- `-c` counts **bytes, not codepoints** for a UTF-8 file argument (`head -c 3` of `中文` → `中`)
- raw high-byte content (`FF 00 80 FE`) round-trips **exactly** through `head -c`/`tail -c` + redirect
- a non-ASCII filename header (`head -v café.txt`) is written as **UTF-8** (`caf\xc3\xa9.txt`), not latin1, on redirect

`pnpm test:run src/commands/head src/commands/tail` → **42 passed**. `typecheck`, `lint`, and `knip` clean.
