### PR TITLE
fix(interpreter): decode each statement's stdout before concatenating to fix UTF-8 mojibake

### DIFF
--- a/.changeset/fix-statement-utf8-interleave.md
+++ b/.changeset/fix-statement-utf8-interleave.md
@@ -1,0 +1,13 @@
+---
+"just-bash": patch
+---
+
+interpreter: fix mojibake when a script interleaves text-output and byte-output statements
+
+When a single `exec()` call ran multiple statements that produced different output "shapes" — e.g. `sed` (text-shaped: `ö` as U+00F6) followed by `grep | head` (byte-shaped: `ö` as bytes 0xC3 0xB6) — the non-ASCII text in the byte-shaped portion came out as mojibake (`KÃ¶penicker` instead of `Köpenicker`).
+
+The root cause: `executeScript` concatenated each statement's raw stdout string before the single UTF-8 decode at the `exec()` output boundary. The text-shaped half contributed a bare `0xF6` byte (not valid UTF-8 on its own), making the combined byte stream invalid, so the boundary decoder fell back to returning the raw string. The byte-shaped half then never got decoded.
+
+The fix decodes each statement's stdout to UTF-8 text in isolation, before concatenating. The decoder is a no-op on already-decoded text (chars > 0xFF short-circuit it), so the existing boundary decode in `Bash.ts` stays idempotent and nothing else changes.
+
+The same `executeScript` path is called for command substitution bodies (`$(cat /file)`), so this also fixes the analogous case where a byte producer inside `$(...)` produced mojibake when its output was spliced into an outer string (e.g. `echo "你好: $(cat /file)"`).

--- a/packages/just-bash/src/encoding-pipeline.test.ts
+++ b/packages/just-bash/src/encoding-pipeline.test.ts
@@ -206,6 +206,68 @@ echo 한 | f`,
     });
   });
 
+  describe("interleaved text + byte statements in one exec() call", () => {
+    // sed is text-shaped (ö as U+00F6); grep|head is byte-shaped (ö as 0xC3 0xB6).
+    // When concatenated raw, the lone 0xF6 makes the combined stream invalid UTF-8
+    // and the boundary decoder in Bash.ts bails, leaving the byte half as mojibake.
+    it("newline-separated text + byte statements round-trip non-ASCII", async () => {
+      const env = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+      const r = await env.exec("sed -n 1p /doc.txt\ngrep Köpenicker /doc.txt | head -1");
+      expect(r.stdout).toBe("Köpenicker\nKöpenicker\n");
+    });
+
+    it("semicolon-separated text + byte statements round-trip non-ASCII", async () => {
+      const env = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+      const r = await env.exec("sed -n 1p /doc.txt; grep Köpenicker /doc.txt | head -1");
+      expect(r.stdout).toBe("Köpenicker\nKöpenicker\n");
+    });
+
+    it("standalone byte producer still works (regression guard)", async () => {
+      const env = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+      const r = await env.exec("grep Köpenicker /doc.txt | head -1");
+      expect(r.stdout).toBe("Köpenicker\n");
+    });
+
+    it("standalone text producer still works (regression guard)", async () => {
+      const env = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+      const r = await env.exec("sed -n 1p /doc.txt");
+      expect(r.stdout).toBe("Köpenicker\n");
+    });
+
+    it("CJK (3-byte codepoints) round-trip across interleave", async () => {
+      const env = new Bash({ files: { "/doc.txt": "日本語\n" } });
+      const r = await env.exec("sed -n 1p /doc.txt\ngrep 日本語 /doc.txt | head -1");
+      expect(r.stdout).toBe("日本語\n日本語\n");
+    });
+
+    it("emoji (4-byte codepoints) round-trip across interleave", async () => {
+      const env = new Bash({ files: { "/doc.txt": "🌍\n" } });
+      const r = await env.exec("sed -n 1p /doc.txt\ngrep 🌍 /doc.txt | head -1");
+      expect(r.stdout).toBe("🌍\n🌍\n");
+    });
+
+    it("command substitution with a byte producer decodes before splicing", async () => {
+      const env = new Bash({ files: { "/world.txt": "世界\n" } });
+      const r = await env.exec('echo "你好: $(cat /world.txt)"');
+      expect(r.stdout).toBe("你好: 世界\n");
+    });
+
+    it("command substitution with grep output decodes before splicing", async () => {
+      const env = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+      const r = await env.exec('echo "Company: $(grep Köpenicker /doc.txt)"');
+      expect(r.stdout).toBe("Company: Köpenicker\n");
+    });
+
+    it("binary file round-trips through cat unaffected by the fix", async () => {
+      const env = new Bash({
+        files: { "/b.bin": new Uint8Array([0x80, 0xff, 0x00, 0x90]) },
+      });
+      await env.exec("cat /b.bin | cat > /out.bin");
+      const out = await env.fs.readFileBuffer("/out.bin");
+      expect(Array.from(out)).toEqual([0x80, 0xff, 0x00, 0x90]);
+    });
+  });
+
   describe("public encoding exports", () => {
     // The byte/text helpers are part of the package's public API.
     // Custom-command authors and downstream tools import them by name;

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -24,9 +24,11 @@ import type {
   WordNode,
 } from "../ast/types.js";
 import {
+  decodeBytesToUtf8,
   encodeUtf8ToBytes,
   latin1FromBytes,
   readBytesFrom,
+  unsafeBytesFromLatin1,
 } from "../encoding.js";
 import type { IFileSystem } from "../fs/interface.js";
 import { mapToRecord } from "../helpers/env.js";
@@ -249,7 +251,17 @@ export class Interpreter {
     for (const statement of node.statements) {
       try {
         const result = await this.executeStatement(statement);
-        appendOutput(result.stdout, result.stderr);
+        // Decode each statement's stdout independently before concatenating.
+        // A script can mix text-shaped statements (sed, awk — ö as U+00F6) with
+        // byte-shaped ones (grep | head — ö as bytes 0xC3 0xB6). Concatenated
+        // raw, the lone 0xF6 makes the combined stream invalid UTF-8, so the
+        // boundary decoder in Bash.ts bails and leaves the byte half as mojibake.
+        // Decoding per statement isolates each shape; the decoder is a no-op on
+        // already-decoded text, so the boundary pass stays idempotent.
+        appendOutput(
+          decodeBytesToUtf8(unsafeBytesFromLatin1(result.stdout)),
+          result.stderr,
+        );
         exitCode = result.exitCode;
         this.ctx.state.lastExitCode = exitCode;
         this.ctx.state.env.set("?", String(exitCode));


### PR DESCRIPTION
## Problem

When a single `exec()` call runs multiple statements that produce different output shapes, non-ASCII text in the byte-shaped output comes out as mojibake.

Two shapes exist internally:

- **Text-shaped** (sed, awk, echo): a decoded JS-Unicode string where `ö` is one char `U+00F6`
- **Byte-shaped** (grep | head, cat, tee): a latin1 byte-view string where `ö` is two chars `0xC3 0xB6`

`executeScript` concatenated each statement's `stdout` raw. The single UTF-8 decode at the `exec()` output boundary then ran over the combined string. Because the text-shaped half contributed a bare `0xF6` byte (not valid UTF-8 on its own), `TextDecoder` with `{ fatal: true }` threw, and the decoder fell back to the raw string. The byte-shaped half never got decoded.

### Reproduction

```ts
const b = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
const r = await b.exec('sed -n 1p /doc.txt\ngrep Köpenicker /doc.txt | head -1');

// actual:   "Köpenicker\nKÃ¶penicker\n"
// expected: "Köpenicker\nKöpenicker\n"
```

Same failure with `;` or `&&` as the separator.

## Fix

Decode each statement's `stdout` to UTF-8 text in isolation before concatenating. `decodeBytesToUtf8` short-circuits on already-decoded text (any char > `0xFF` means it's already Unicode), so the existing boundary decode in `Bash.ts` stays idempotent.

The same `executeScript` path is used for command substitution bodies (`$(cat file)`), so this also fixes non-ASCII mojibake in command substitutions like `echo "你好: $(cat /world.txt)"`. Closes #247.

**Why not use `stdoutAsBytes` / `stdoutKind` metadata here:** byte-passthrough commands (`head`, `tail`, `cat`, `tee`) don't set `stdoutKind` on their result — it defaults to `"text"`. A metadata-based normalization approach double-encodes their already-byte output (verified: it regresses `grep | head`).

## Tests

9 new cases in `encoding-pipeline.test.ts`:

- Primary bug: newline- and semicolon-separated `sed` + `grep|head` (the exact repro above)
- Regression guards for standalone text and byte producers
- CJK (3-byte) and emoji (4-byte) codepoints across the interleave
- Command substitution with `cat` and with `grep`
- Binary file round-trip to confirm non-UTF-8 bytes are unaffected

Relates to #110 (established the `exec()` boundary as the correct decode point — this PR handles a case that single-boundary decoding can't cover).