### PR TITLE
fix(jq): handle nested double-quoted strings in \(...) interpolation

### DIFF
--- a/.changeset/jq-nested-interp.md
+++ b/.changeset/jq-nested-interp.md
@@ -1,0 +1,9 @@
+---
+"just-bash": patch
+---
+
+jq: allow nested double-quoted strings inside `"\(...)"` string interpolation
+
+jq string interpolation of the form `"\(...)"` that contained a nested double-quoted string — for example `"\(sub("T.*";""))"` or `"\(ltrimstr("ab"))"` — previously failed with a parse error. The tokenizer terminated the outer string at the first `"` it saw inside the interpolation expression, so the rest of the expression became orphaned tokens.
+
+The lexer now tracks `\(...)` depth while consuming a string literal and treats nested `"..."` pairs as opaque content while inside an interpolation, restoring them verbatim into the captured interpolation source. `parseStringInterpolation` similarly skips over nested strings when balancing parentheses, so the interpolation expression is captured as a whole and handed to the expression parser intact.

--- a/packages/just-bash/src/commands/jq/jq.string-interp-nested-quotes.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.string-interp-nested-quotes.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+// Real jq's string interpolation `"\(...)"` correctly handles nested
+// double-quoted strings inside the interpolation (e.g. sub("T.*"; ""),
+// ltrimstr("ab")). Our tokenizer currently terminates the outer string at
+// the first inner `"`, producing parse errors. These tests pin the
+// real-jq behavior so the fix can be validated.
+describe("jq string interpolation with nested double-quoted strings", () => {
+  it("evaluates sub() with two string literals inside interpolation", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"m":"2026-06-05T10:00:00Z"}\n' },
+    });
+
+    const result = await env.exec(
+      `jq -r '"\\(.m | sub("T.*"; ""))"' /payload.json`,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("2026-06-05\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("evaluates string concatenation with nested string literal", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"m":"hi"}\n' },
+    });
+
+    const result = await env.exec(`jq -r '"\\(.m + "!")"' /payload.json`);
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("hi!\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("evaluates ltrimstr() with a nested string literal", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"m":"abcd"}\n' },
+    });
+
+    const result = await env.exec(
+      `jq -r '"\\(.m | ltrimstr("ab"))"' /payload.json`,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("cd\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("evaluates the full transcript filter over an array", async () => {
+    const env = new Bash({
+      files: {
+        "/payload.json":
+          '[{"m":"2026-06-05T10:00:00Z","n":1,"u":"alice","t":"hello"},' +
+          '{"m":"2026-06-06T11:00:00Z","n":2,"u":"bob","t":"world"}]\n',
+      },
+    });
+
+    const result = await env.exec(
+      `jq -r '.[] | "\\(.m | sub("T.*"; "")) #\\(.n) @\\(.u): \\(.t)"' /payload.json`,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe(
+      "2026-06-05 #1 @alice: hello\n2026-06-06 #2 @bob: world\n",
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("balances parens correctly when nested string contains a paren", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"m":"(hello)"}\n' },
+    });
+
+    const result = await env.exec(
+      `jq -r '"\\(.m | sub("[(]"; "X"))"' /payload.json`,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Xhello)\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  // Control cases: these already pass and should continue to pass after the
+  // fix. They document the boundary of the bug (no nested string literal
+  // inside the interpolation parens).
+  it("control: arithmetic inside interpolation (no nested strings)", async () => {
+    const env = new Bash({
+      files: { "/payload.json": '{"n":5}\n' },
+    });
+
+    const result = await env.exec(`jq -r '"\\(.n + 1)"' /payload.json`);
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("6\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("control: @tsv format string works on array rows", async () => {
+    const env = new Bash({
+      files: {
+        "/payload.json": '[{"a":1,"b":2},{"a":3,"b":4}]\n',
+      },
+    });
+
+    const result = await env.exec(
+      `jq -r '.[] | [.a, .b] | @tsv' /payload.json`,
+    );
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("1\t2\n3\t4\n");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/query-engine/parser.ts
+++ b/packages/just-bash/src/commands/query-engine/parser.ts
@@ -283,8 +283,13 @@ function tokenize(input: string): Token[] {
     // Strings
     if (c === '"') {
       let str = "";
-      while (!isEof() && peek() !== '"') {
-        if (peek() === "\\") {
+      // Track \( ... ) interpolation depth so an inner `"` (nested string
+      // literal) inside the interpolation doesn't terminate the outer string.
+      let interpDepth = 0;
+      while (!isEof()) {
+        const ch = peek();
+        if (interpDepth === 0 && ch === '"') break;
+        if (interpDepth === 0 && ch === "\\") {
           advance();
           if (isEof()) break;
           const escaped = advance();
@@ -306,13 +311,37 @@ function tokenize(input: string): Token[] {
               break;
             case "(":
               str += "\\(";
+              interpDepth = 1;
               break; // Keep for string interpolation
             default:
               str += escaped;
           }
-        } else {
-          str += advance();
+          continue;
         }
+        if (interpDepth > 0) {
+          // Inside \( ... ): preserve raw characters so the interpolation
+          // parser can re-tokenize them. Skip over nested string literals
+          // verbatim and track paren depth.
+          if (ch === '"') {
+            str += advance(); // opening quote
+            while (!isEof()) {
+              const nc = peek();
+              if (nc === "\\") {
+                str += advance(); // backslash
+                if (!isEof()) str += advance(); // escaped char
+                continue;
+              }
+              str += advance();
+              if (nc === '"') break;
+            }
+            continue;
+          }
+          if (ch === "(") interpDepth++;
+          else if (ch === ")") interpDepth--;
+          str += advance();
+          continue;
+        }
+        str += advance();
       }
       if (!isEof()) advance(); // closing quote
       tokens.push({ type: "STRING", value: str, pos: start });
@@ -1091,13 +1120,35 @@ class Parser {
           current = "";
         }
         i += 2;
-        // Find matching paren
+        // Find matching paren, skipping over nested string literals so
+        // parens inside them don't affect depth counting.
         let depth = 1;
         let exprStr = "";
         while (i < str.length && depth > 0) {
-          if (str[i] === "(") depth++;
-          else if (str[i] === ")") depth--;
-          if (depth > 0) exprStr += str[i];
+          const ch = str[i];
+          if (ch === '"') {
+            exprStr += ch;
+            i++;
+            while (i < str.length) {
+              const nc = str[i];
+              if (nc === "\\") {
+                exprStr += nc;
+                i++;
+                if (i < str.length) {
+                  exprStr += str[i];
+                  i++;
+                }
+                continue;
+              }
+              exprStr += nc;
+              i++;
+              if (nc === '"') break;
+            }
+            continue;
+          }
+          if (ch === "(") depth++;
+          else if (ch === ")") depth--;
+          if (depth > 0) exprStr += ch;
           i++;
         }
         const tokens = tokenize(exprStr);

--- a/packages/just-bash/src/spec-tests/jq/skips.ts
+++ b/packages/just-bash/src/spec-tests/jq/skips.ts
@@ -153,10 +153,6 @@ const SKIP_TESTS: Map<string, string> = new Map<string, string>([
   // ============================================================
   // String interpolation edge cases
   // ============================================================
-  [
-    'jq.test:"inter\\("pol" + "ation")"',
-    "String interpolation with complex expression",
-  ],
   ['jq.test:@html "<b>\\(.)</b>"', "String interpolation in @html"],
   ['jq.test:{"a",b,"a$\\(1+1)"}', "String interpolation in object key"],
 
@@ -474,7 +470,6 @@ const SKIP_PATTERNS: Array<{ pattern: RegExp; reason: string }> = [
   { pattern: /contains\("b\\u0000/, reason: "contains with NUL char" },
 
   // String interpolation edge cases
-  { pattern: /inter\\\(/, reason: "String interpolation with backslash" },
   {
     pattern: /\{"[^"]*",\w+,"[^"]*\$\\/,
     reason: "Object shorthand with interpolation",


### PR DESCRIPTION
`<human-comment>`
I ran into this issue with Opus 4.7 driving `gh` and `jq`, and stumbling over the string interpolation. I can see that there were test skips for this scenario, so this PR addresses my failure, and the existing skipped test. Paid extra attention to make sure every commit is verified, this time.
`</human-comment>`

`<bot-comment>`

> ## Summary

> Fixes a `jq` parse error when a string interpolation `"\(...)"` contains a **nested double-quoted string** — e.g. `"\(.m | sub("T.*"; ""))"` or `"\(.m | ltrimstr("ab"))"`. These previously failed with `jq: parse error: Unexpected token EOF` (or `Unexpected character ...`).

> Discovered while running an agent workflow that summarized merged PRs with:

```
jq -r '.[] | "\(.m | sub("T.*"; "")) #\(.n) @\(.u): \(.t)"'
```

> ## Root cause

> The jq tokenizer in `packages/just-bash/src/commands/query-engine/parser.ts` scanned a `"..."` string literal up to the next `"` **without tracking `\(...)` interpolation depth**. The `"` belonging to a nested string inside the interpolation (the quotes in `sub("T.*";"")`) was mistaken for the end of the outer string, so the interpolation was truncated and the remaining characters became orphaned tokens. A secondary issue: `parseStringInterpolation` balanced parens by counting `(`/`)` without skipping nested string literals, so a paren inside a nested string would also miscount.

> The pipe `|`, the `.n` field, and `@tsv` were **not** the cause — those all work fine; only nested quotes inside `\(...)` were affected.

> ## What changed

> Two surgical edits in `query-engine/parser.ts`:

> 1. The tokenizer's string branch now tracks `\(...)` interpolation depth and consumes nested `"..."` literals verbatim (with `\X` escape handling) instead of terminating the outer string early.
> 2. `parseStringInterpolation` skips over nested string literals when balancing parentheses, so the full interpolation source is captured and handed to the expression parser intact.

> ## Testing

> - New collocated test `packages/just-bash/src/commands/jq/jq.string-interp-nested-quotes.test.ts` (7 cases): `sub`, `+ "!"`, `ltrimstr`, the full transcript filter, a paren-in-nested-string regression guard, plus control cases (`"\(.n + 1)"`, `@tsv`). All expectations validated against system `jq 1.7.1`.
> - `pnpm test:run src/commands/jq/ src/commands/query-engine/` — 341 passing, no regressions.
> - `pnpm typecheck`, `pnpm lint:fix`, `pnpm knip` — clean.
> - Spot-checked 16 cases against real jq (escaped quotes inside nested strings, multiple/adjacent/recursive interpolations) — all match exactly.

> The original transcript command now produces byte-identical output to real jq.

> A `patch` changeset is included.

`</bot-comment>`