### PR TITLE
fix(tar): support GNU old-style bundled option letters (tar czf, tar xf)

### DIFF
--- a/packages/just-bash/src/commands/tar/tar-options.ts
+++ b/packages/just-bash/src/commands/tar/tar-options.ts
@@ -32,10 +32,21 @@ export interface TarOptions {
 }
 
 export function parseOptions(
-  args: string[],
+  rawArgs: string[],
 ):
   | { ok: true; options: TarOptions; files: string[] }
   | { ok: false; error: ExecResult } {
+  // GNU old-style: bare first arg is a flag bundle. Value-taking letters
+  // (f, C, T, X) must be terminal or they swallow the rest as their value;
+  // move them to the end.
+  const valueTaking = /[fCTX]/g;
+  const args =
+    rawArgs.length > 0 && rawArgs[0] !== "" && !rawArgs[0].startsWith("-")
+      ? [
+          `-${rawArgs[0].replace(valueTaking, "") + (rawArgs[0].match(valueTaking) ?? []).join("")}`,
+          ...rawArgs.slice(1),
+        ]
+      : rawArgs;
   const options: TarOptions = {
     create: false,
     append: false,

--- a/packages/just-bash/src/commands/tar/tar.test.ts
+++ b/packages/just-bash/src/commands/tar/tar.test.ts
@@ -44,6 +44,98 @@ describe("tar", () => {
     });
   });
 
+  describe("old-style options (no leading dash)", () => {
+    it("should create and extract with `tar czf` / `tar xzf`", async () => {
+      const env = new Bash({
+        files: {
+          "/test.txt": "Old-style gzip round trip",
+        },
+      });
+      const create = await env.exec("tar czf /archive.tar.gz /test.txt");
+      expect(create.exitCode).toBe(0);
+
+      await env.exec("rm /test.txt");
+      const extract = await env.exec("tar xzf /archive.tar.gz");
+      expect(extract.exitCode).toBe(0);
+
+      const cat = await env.exec("cat /test.txt");
+      expect(cat.stdout).toBe("Old-style gzip round trip");
+    });
+
+    it("should create and extract with `tar cf` / `tar xf`", async () => {
+      const env = new Bash({
+        files: {
+          "/test.txt": "Old-style plain round trip",
+        },
+      });
+      const create = await env.exec("tar cf /archive.tar /test.txt");
+      expect(create.exitCode).toBe(0);
+
+      await env.exec("rm /test.txt");
+      const extract = await env.exec("tar xf /archive.tar");
+      expect(extract.exitCode).toBe(0);
+
+      const cat = await env.exec("cat /test.txt");
+      expect(cat.stdout).toBe("Old-style plain round trip");
+    });
+
+    it("should list with `tar tf` and `tar tvf`", async () => {
+      const env = new Bash({
+        files: {
+          "/test.txt": "Old-style list",
+        },
+      });
+      await env.exec("tar cf /archive.tar /test.txt");
+
+      const list = await env.exec("tar tf /archive.tar");
+      expect(list.exitCode).toBe(0);
+      expect(list.stdout).toContain("test.txt");
+
+      const verbose = await env.exec("tar tvf /archive.tar");
+      expect(verbose.exitCode).toBe(0);
+      expect(verbose.stdout).toContain("test.txt");
+    });
+
+    it("should support a single bare mode letter", async () => {
+      const env = new Bash({
+        files: {
+          "/test.txt": "Bare mode letter",
+        },
+      });
+      const result = await env.exec("tar c -f /archive.tar /test.txt");
+      expect(result.exitCode).toBe(0);
+
+      const list = await env.exec("tar -tf /archive.tar");
+      expect(list.stdout).toContain("test.txt");
+    });
+
+    it("should create gzip archive with non-terminal f (tar cfz)", async () => {
+      // Regression: `tar cfz archive.tar.gz dir` with f before z misparsed
+      // "z" as the filename instead of setting gzip compression.
+      const env = new Bash({
+        files: {
+          "/note.txt": "cfz regression",
+        },
+      });
+      const create = await env.exec("tar cfz /archive.tar.gz /note.txt");
+      expect(create.exitCode).toBe(0);
+
+      await env.exec("rm /note.txt");
+      const extract = await env.exec("tar xzf /archive.tar.gz");
+      expect(extract.exitCode).toBe(0);
+
+      const cat = await env.exec("cat /note.txt");
+      expect(cat.stdout).toBe("cfz regression");
+    });
+
+    it("should error on unknown old-style option letter", async () => {
+      const env = new Bash();
+      const result = await env.exec("tar qf /archive.tar");
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("invalid option -- 'q'");
+    });
+  });
+
   describe("create (-c)", () => {
     it("should create archive from single file", async () => {
       const env = new Bash({


### PR DESCRIPTION
I wrote this:

I noticed that my agent was constantly producing invalid tar commands because of the old syntax that's still valid. So this adds support for that old syntax. Used Fable 5 for this (for tracking down the bug, implementing fix, testing it, and pring it (not $25 for 80 lines of code hehe).

<img width="336" height="145" alt="SCR-20260609-oibg" src="https://github.com/user-attachments/assets/68c27fd8-64f5-4c16-8220-361d74727435" />

---

Agent wrote this:

**Root cause:** `parseOptions` only recognizes `-`-prefixed args as flags, so the GNU/bsdtar old-style first argument fell through to the `files` list and no operation mode was set.

**Change:** a first argument without a leading dash is rewritten to `-<arg>` before parsing, matching GNU semantics. The existing bundled-flag parser handles the rest, including `f`/`C`/`T`/`X` value consumption and `invalid option` errors for unknown letters. Tests cover `tar czf`/`xzf`, `cf`/`xf`, `tf`/`tvf`, a single bare mode letter, and an unknown-letter error.