### PR TITLE
fix(interpreter): decode each statement's stdout via stdoutKind to fix UTF-8 mojibake

### DIFF
--- a/.changeset/byte-text-output-shape.md
+++ b/.changeset/byte-text-output-shape.md
@@ -1,0 +1,20 @@
+---
+"just-bash": patch
+---
+
+interpreter: fix UTF-8 mojibake when a script interleaves text-output and byte-output statements
+
+A single `exec()` can interleave text-shaped statements (sed, awk, echo — `ö`
+as `U+00F6`) with byte-shaped ones (grep | head, cat — `ö` as bytes
+`0xC3 0xB6`). `executeScript` / `executeStatement` concatenated each result's
+raw stdout, so the lone high byte from the text half made the combined stream
+invalid UTF-8, the output-boundary decoder bailed, and the byte half came back
+as Latin-1 mojibake (`KÃ¶penicker` for `Köpenicker`). The same path backs
+command substitution, so `echo "你好: $(cat /file)"` was affected too.
+
+The fix decodes each statement/pipeline result to text via its explicit
+`stdoutKind` (`decodedTextFromResult`) before concatenating — no guessing from
+string contents, so text whose code units merely look like UTF-8 (`Ã¶`) is
+preserved. `tac` (stdin path) and `curl` (response body) now declare
+`stdoutKind: "bytes"` on the results that forward raw bytes, so the decode is
+driven per output rather than by inspecting characters.

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -322,7 +322,10 @@ export const curlCommand: Command = {
         }
       }
 
-      return { stdout: output, stderr: "", exitCode: 0 };
+      // The response body is a latin1-shaped byte buffer (see
+      // `fetchBodyToStdoutString`); any prepended headers / verbose markers are
+      // ASCII, so the whole stream is byte-shaped and must be marked "bytes".
+      return { stdout: output, stderr: "", exitCode: 0, stdoutKind: "bytes" };
     } catch (error) {
       const message = getErrorMessage(error);
 

--- a/packages/just-bash/src/commands/tac/tac.ts
+++ b/packages/just-bash/src/commands/tac/tac.ts
@@ -37,7 +37,9 @@ async function tacExecute(
     }
   }
 
-  // Read from stdin. tac is byte-clean — splits on \n then reverses.
+  // Read from stdin. tac is byte-clean — splits on \n then reverses, so the
+  // stdin path forwards the original latin1 bytes and must be marked "bytes"
+  // (the file path above reads decoded text and stays text-shaped).
   const lines = latin1FromBytes(ctx.stdin).split("\n");
   if (lines[lines.length - 1] === "") {
     lines.pop();
@@ -47,6 +49,7 @@ async function tacExecute(
     stdout: reversed.length > 0 ? `${reversed.join("\n")}\n` : "",
     stderr: "",
     exitCode: 0,
+    stdoutKind: "bytes",
   };
 }
 

--- a/packages/just-bash/src/encoding-issue-957.test.ts
+++ b/packages/just-bash/src/encoding-issue-957.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "./Bash.js";
+
+/**
+ * Reproducers from ai-ecoverse/slicc#957: "Bash command substitution `$(...)`
+ * double-encodes UTF-8 bytes".
+ *
+ * The downstream report saw UTF-8 captured via `$(...)` / `head -c` / `tail -c`
+ * / `cat | …` come back Latin-1 double-encoded (em-dash `e2 80 94` → `c3 a2 c2
+ * 80 c2 94`), with each extra capture layer adding another encode pass. The
+ * issue also lists operations that were NOT broken (heredoc literals, plain
+ * `printf`/`echo`, on-disk bytes), which we pin as non-regression guards.
+ *
+ * Bytes are asserted directly here rather than via `python3`/`node` (as the
+ * issue did) so the checks don't depend on the optional worker runtimes.
+ */
+
+function utf8Hex(s: string): string {
+  return [...new TextEncoder().encode(s)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(" ");
+}
+
+describe("issue #957 — $(...) / byte-window UTF-8 round-trips", () => {
+  it("captures `$(cat file)` without Latin-1 double-encoding (the original report)", async () => {
+    const b = new Bash({ files: { "/utf8.txt": "—\n" } });
+    const r = await b.exec('VAR=$(cat /utf8.txt); printf %s "$VAR"');
+    expect(r.exitCode).toBe(0);
+    // em-dash U+2014 = e2 80 94, NOT the reported c3 a2 c2 80 c2 94.
+    expect(utf8Hex(r.stdout)).toBe("e2 80 94");
+    expect(r.stdout).toBe("—");
+  });
+
+  it("does not triple-encode when the capture is wrapped again", async () => {
+    const b = new Bash({ files: { "/utf8.txt": "—\n" } });
+    const r = await b.exec(
+      'VAR=$(cat /utf8.txt); VAR2=$(echo "$VAR"); printf %s "$VAR2"',
+    );
+    expect(r.exitCode).toBe(0);
+    expect(utf8Hex(r.stdout)).toBe("e2 80 94");
+  });
+
+  it("keeps `head -c` / `tail -c` byte windows aligned to the source bytes", async () => {
+    // "ABC—DEF\n" = 41 42 43 | e2 80 94 | 44 45 46 0a. The first 6 bytes are
+    // "ABC" + the em-dash; the last 3 of those are exactly the em-dash.
+    const b = new Bash({ files: { "/f.txt": "ABC—DEF\n" } });
+    const r = await b.exec('X=$(head -c 6 /f.txt | tail -c 3); printf %s "$X"');
+    expect(r.exitCode).toBe(0);
+    expect(utf8Hex(r.stdout)).toBe("e2 80 94");
+  });
+
+  it("counts `head -c` byte windows exactly even when they split a codepoint", async () => {
+    // head -c 4 cuts mid-em-dash (41 42 43 e2); the pipe must forward 4 raw
+    // bytes, not a re-encoded expansion.
+    const b = new Bash({ files: { "/f.txt": "ABC—DEF\n" } });
+    const r = await b.exec("head -c 4 /f.txt | wc -c");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("4");
+  });
+
+  it("preserves UTF-8 through `cat | sed` (listed as NOT broken)", async () => {
+    const b = new Bash({ files: { "/utf8.txt": "—\n" } });
+    const r = await b.exec("cat /utf8.txt | sed 's/^/PFX: /'");
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("PFX: —\n");
+    expect(utf8Hex(r.stdout)).toBe("50 46 58 3a 20 e2 80 94 0a");
+  });
+
+  it("round-trips a real-world multi-codepoint payload via `$(cat)` to disk and stdout", async () => {
+    // The Slack chat.postMessage case: ESCAPED=$(cat file) re-emitted later.
+    const b = new Bash({ files: { "/reply.txt": "price: 5 × 3 — done 🌍" } });
+    const r = await b.exec(
+      'ESCAPED=$(cat /reply.txt); printf %s "$ESCAPED" > /out.txt; printf %s "$ESCAPED"',
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout).toBe("price: 5 × 3 — done 🌍");
+    // × = c3 97, — = e2 80 94, 🌍 = f0 9f 8c 8d — single-encoded on disk.
+    const onDisk = await b.fs.readFileBuffer("/out.txt");
+    expect(Array.from(onDisk)).toEqual([
+      0x70, 0x72, 0x69, 0x63, 0x65, 0x3a, 0x20, 0x35, 0x20, 0xc3, 0x97, 0x20,
+      0x33, 0x20, 0xe2, 0x80, 0x94, 0x20, 0x64, 0x6f, 0x6e, 0x65, 0x20, 0xf0,
+      0x9f, 0x8c, 0x8d,
+    ]);
+  });
+
+  it("writes correct on-disk bytes from a quoted heredoc literal (NOT broken)", async () => {
+    const b = new Bash({});
+    await b.exec("cat > /x <<'JS'\nsome — text\nJS");
+    const onDisk = await b.fs.readFileBuffer("/x");
+    expect(Array.from(onDisk)).toEqual([
+      0x73, 0x6f, 0x6d, 0x65, 0x20, 0xe2, 0x80, 0x94, 0x20, 0x74, 0x65, 0x78,
+      0x74, 0x0a,
+    ]);
+  });
+
+  it("emits literal UTF-8 from printf / echo unchanged (NOT broken)", async () => {
+    const b = new Bash({});
+    expect(utf8Hex((await b.exec("printf '%s' '—'")).stdout)).toBe("e2 80 94");
+    expect(utf8Hex((await b.exec("echo -n '—'")).stdout)).toBe("e2 80 94");
+  });
+});

--- a/packages/just-bash/src/encoding-statement-interleave.test.ts
+++ b/packages/just-bash/src/encoding-statement-interleave.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "./Bash.js";
+
+/**
+ * UTF-8 across statement / command-substitution boundaries (issue #957).
+ *
+ * A single `exec()` can interleave text-shaped statements (sed, awk, echo — ö
+ * as U+00F6) with byte-shaped ones (grep | head, cat — ö as bytes 0xC3 0xB6).
+ * Concatenated raw, the lone high byte from the text half makes the combined
+ * stream invalid UTF-8, so the output-boundary decoder bails and leaves the
+ * byte half as Latin-1 mojibake. The fix decodes each statement/pipeline result
+ * to text via its explicit `stdoutKind` before concatenating.
+ */
+
+function utf8Hex(s: string): string {
+  return [...new TextEncoder().encode(s)]
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join(" ");
+}
+
+describe("statement-interleave UTF-8 (issue #957)", () => {
+  it("round-trips when text (sed) and byte (grep|head) statements interleave", async () => {
+    const b = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
+    expect(
+      (await b.exec("sed -n 1p /doc.txt\ngrep Köpenicker /doc.txt | head -1"))
+        .stdout,
+    ).toBe("Köpenicker\nKöpenicker\n");
+    expect(
+      (await b.exec("sed -n 1p /doc.txt; grep Köpenicker /doc.txt | head -1"))
+        .stdout,
+    ).toBe("Köpenicker\nKöpenicker\n");
+  });
+
+  it("handles 3-byte (CJK) and 4-byte (emoji) codepoints across the interleave", async () => {
+    const cjk = new Bash({ files: { "/d.txt": "日本語\n" } });
+    expect(
+      (await cjk.exec("sed -n 1p /d.txt\ngrep 日本語 /d.txt | head -1")).stdout,
+    ).toBe("日本語\n日本語\n");
+    const emoji = new Bash({ files: { "/e.txt": "🌍\n" } });
+    expect(
+      (await emoji.exec("sed -n 1p /e.txt\ngrep 🌍 /e.txt | head -1")).stdout,
+    ).toBe("🌍\n🌍\n");
+  });
+
+  it("decodes a byte producer inside command substitution before splicing", async () => {
+    const b = new Bash({ files: { "/world.txt": "世界\n" } });
+    expect((await b.exec('echo "你好: $(cat /world.txt)"')).stdout).toBe(
+      "你好: 世界\n",
+    );
+    expect(
+      (await b.exec('echo "Company: $(grep 世界 /world.txt)"')).stdout,
+    ).toBe("Company: 世界\n");
+  });
+
+  it("preserves UTF-8 through $(...) captured into a var and re-emitted (the #957 report)", async () => {
+    const b = new Bash({ files: { "/utf8.txt": "—\n" } });
+    const r = await b.exec('VAR=$(cat /utf8.txt); printf %s "$VAR"');
+    expect(r.exitCode).toBe(0);
+    expect(utf8Hex(r.stdout)).toBe("e2 80 94");
+    expect(r.stdout).toBe("—");
+  });
+
+  it("builds a UTF-8 payload from a file via $(...) without mojibake", async () => {
+    const b = new Bash({ files: { "/msg.txt": "price: 5 × 3 — done 🌍" } });
+    const r = await b.exec('TEXT=$(cat /msg.txt); printf %s "$TEXT"');
+    expect(r.stdout).toBe("price: 5 × 3 — done 🌍");
+  });
+
+  it("decodes byte output inside a for-loop body (Jueast case)", async () => {
+    const b = new Bash({ files: { "/世界.txt": "Hello 世界\n" } });
+    const r = await b.exec(
+      'for f in /世界.txt; do echo "--- $(basename "$f")"; grep Hello "$f" | head -n 1; done',
+    );
+    expect(r.stdout).toBe("--- 世界.txt\nHello 世界\n");
+  });
+
+  it("does NOT decode text-shaped output whose chars look like mojibake (no regression)", async () => {
+    // `KÃ¶penicker` from `echo` is text (U+00C3 U+00B6), not bytes. It must not
+    // be reinterpreted as UTF-8 — the heuristic that guesses from code units
+    // would wrongly fold `Ã¶` into `ö` and change shell control flow.
+    const b = new Bash({});
+    expect(
+      (
+        await b.exec(
+          '[ "$(echo KÃ¶penicker)" = KÃ¶penicker ] && echo SAME || echo DIFF',
+        )
+      ).stdout,
+    ).toBe("SAME\n");
+  });
+
+  it("preserves a legitimate single Latin-1 char that is invalid standalone UTF-8", async () => {
+    const b = new Bash({});
+    expect(
+      (
+        await b.exec(
+          '[ "$(echo Köpenicker)" = Köpenicker ] && echo SAME || echo DIFF',
+        )
+      ).stdout,
+    ).toBe("SAME\n");
+  });
+
+  it("passes raw binary through cat redirection untouched by the decode", async () => {
+    const b = new Bash({
+      files: { "/b.bin": new Uint8Array([0x80, 0xff, 0x00, 0x90]) },
+    });
+    await b.exec("cat /b.bin | cat > /out.bin");
+    const out = await b.fs.readFileBuffer("/out.bin");
+    expect(Array.from(out)).toEqual([0x80, 0xff, 0x00, 0x90]);
+  });
+});

--- a/packages/just-bash/src/encoding.ts
+++ b/packages/just-bash/src/encoding.ts
@@ -168,6 +168,25 @@ export function stdoutAsBytes(result: {
 }
 
 /**
+ * Normalize a command's stdout to decoded UTF-8 text, consulting its explicit
+ * `stdoutKind` (or legacy `stdoutEncoding`) rather than guessing from string
+ * contents. Byte-shaped output is UTF-8 decoded once (falling back to the raw
+ * latin1 view for non-UTF-8 bytes); text-shaped output is returned unchanged so
+ * it is never re-decoded. Used at the statement/script concatenation and
+ * command-substitution boundaries so interleaved text and byte producers
+ * combine into a single, consistently-decoded string.
+ */
+export function decodedTextFromResult(result: {
+  stdout: string;
+  stdoutKind?: OutputKind;
+  stdoutEncoding?: "binary";
+}): string {
+  return stdoutKind(result) === "bytes"
+    ? decodeBytesToUtf8(unsafeBytesFromLatin1(result.stdout))
+    : result.stdout;
+}
+
+/**
  * Build an `ExecResult`-shaped object whose stdout is decoded text. Sets
  * `stdoutKind: "text"` so the pipe knows to UTF-8 encode it on handoff
  * and redirects know to write it as UTF-8. Use for command authors that

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -24,6 +24,7 @@ import type {
   WordNode,
 } from "../ast/types.js";
 import {
+  decodedTextFromResult,
   encodeUtf8ToBytes,
   latin1FromBytes,
   readBytesFrom,
@@ -249,7 +250,13 @@ export class Interpreter {
     for (const statement of node.statements) {
       try {
         const result = await this.executeStatement(statement);
-        appendOutput(result.stdout, result.stderr);
+        // Decode each statement's stdout to text via its explicit `stdoutKind`
+        // before concatenating. A script can interleave text-shaped statements
+        // (sed, awk — ö as U+00F6) with byte-shaped ones (grep | head — ö as
+        // bytes 0xC3 0xB6); concatenated raw, the lone high byte makes the
+        // combined stream invalid UTF-8 and the boundary decoder bails, leaving
+        // the byte half as mojibake. Decoding per statement isolates each shape.
+        appendOutput(decodedTextFromResult(result), result.stderr);
         exitCode = result.exitCode;
         this.ctx.state.lastExitCode = exitCode;
         this.ctx.state.env.set("?", String(exitCode));
@@ -432,7 +439,11 @@ export class Interpreter {
       if (operator === "||" && exitCode === 0) continue;
 
       const result = await this.executePipeline(pipeline);
-      stdout += result.stdout;
+      // Decode each pipeline's stdout to text via its explicit `stdoutKind`
+      // before concatenating, so a statement that joins text-shaped and
+      // byte-shaped pipelines with && / || does not interleave raw byte and
+      // Unicode chunks (which would defeat the output-boundary UTF-8 decode).
+      stdout += decodedTextFromResult(result);
       stderr += result.stderr;
       exitCode = result.exitCode;
       lastExecutedIndex = i;


### PR DESCRIPTION
## Problem

A single `exec()` can interleave **text-shaped** statements (`sed`, `awk`, `echo` — `ö` as `U+00F6`) with **byte-shaped** ones (`grep | head`, `cat` — `ö` as bytes `0xC3 0xB6`). `Interpreter.executeScript` / `executeStatement` concatenated each statement's raw `stdout`, so the lone high byte from the text half made the combined stream invalid UTF-8. The single decode at the `exec()` output boundary (`Bash.ts`) then bailed (`{ fatal: true }` throws → returns raw), leaving the byte half as Latin-1 mojibake.

```ts
const b = new Bash({ files: { "/doc.txt": "Köpenicker\n" } });
await b.exec("sed -n 1p /doc.txt\ngrep Köpenicker /doc.txt | head -1");
// actual:   "Köpenicker\nKÃ¶penicker\n"
// expected: "Köpenicker\nKöpenicker\n"
```

The same `executeScript` path backs command substitution, so `echo "你好: $(cat /file)"` and `VAR=$(cat utf8); printf %s "$VAR"` were affected too.

## Fix

The library already ships the right signal — `stdoutKind` / `stdoutAsBytes` (introduced in #233) — and the pipe glue (`pipeline-execution.ts`) already uses it. The gap was only that the **statement/script/command-substitution concat sites ignored it**.

1. **`decodedTextFromResult(result)`** (`encoding.ts`): normalize a result to text using its explicit `stdoutKind` (byte-shaped → UTF-8 decode once, falling back to raw latin1 for non-UTF-8; text-shaped → unchanged, never re-decoded). It consults the metadata, never the characters, so text whose latin1 code units merely *look* like UTF-8 (`Ã¶`) is preserved and shell control flow doesn't change.
2. **`executeScript` + `executeStatement`** decode each statement/pipeline result with that helper before concatenating. (2 lines.)

## Per-output shape, not per-command

The shape is a property of each **output**, not of the command, so it's declared at the point of production:

- The byte-passthrough producers already self-mark (`cat`/`head`/`tail`/`tee`/`gzip` via the legacy `stdoutEncoding` alias; `cut`/`base64`/`tar`/`uniq`/`join` via `stdoutKind`).
- This PR adds the two that were missing it: **`tac`** (only the stdin path forwards raw bytes — the file path reads decoded text and stays text) and **`curl`** (the response body). This per-output precision is exactly what a per-command label can't express: `tac`'s file path is text while its stdin path is bytes.

I verified completeness by temporarily making `ExecResult.stdoutKind` *required* and letting `tsc` enumerate every return site (your "make the issue visible in the type system" approach from #233), confirming `tac` + `curl` were the only byte-passthrough outputs not already self-marking, then relaxing the field back to optional so nothing breaks for external command authors.

## Tests

`encoding-statement-interleave.test.ts`: interleave (newline / `;`), 3-byte CJK + 4-byte emoji, `$(...)` byte producers, the `VAR=$(cat); printf` report, the for-loop body case, the `echo KÃ¶penicker` SAME non-regression guard, the lone-Latin-1 `Köpenicker` guard, and a raw-binary passthrough guard.

`encoding-issue-957.test.ts`: the downstream reproducers from ai-ecoverse/slicc#957 — `$(cat file)` em-dash capture (asserting `e2 80 94`, not the reported `c3 a2 c2 80 c2 94`), no triple-encode when the capture is re-wrapped, `head -c`/`tail -c` byte-window alignment, a real-world multi-codepoint payload round-tripped to disk, plus the issue's "NOT broken" guards (heredoc literal, `cat | sed`, `printf`/`echo`).

## Relation to #265

#265 found this same bug first and correctly identified `executeScript` as a decode point. This PR differs in two ways that matter:

- **Metadata instead of char-sniffing.** #265 decodes every statement with `decodeBytesToUtf8(unsafeBytesFromLatin1(stdout))`, inferring the shape from the code units. That misfires on text whose Latin-1 code units happen to form valid UTF-8: `$(echo KÃ¶penicker)` gets folded to `Köpenicker`, flipping `[ "$(echo KÃ¶penicker)" = KÃ¶penicker ]` from `SAME` to `DIFF` — a real control-flow change. Keying on the explicit `stdoutKind` leaves text untouched and only decodes outputs that declare themselves byte-shaped.
- **Both concat sites.** #265 patches `executeScript` only; the review comment on #265 (thanks @Jueast) shows a compound-statement case — `grep | head` inside a `for` body — that still mojibakes because it flows through the `executeStatement` `&&`/`||` loop. This PR fixes both sites and includes that exact `for`-loop repro as a regression test.

#265's note that the metadata path "double-encodes byte output" was accurate when written, but #233/#264 since made the byte-passthrough commands (`cat`/`head`/`tail`/`tee`) self-declare their shape via the legacy `stdoutEncoding` alias; this PR fills the last two gaps (`tac` stdin, `curl` body) so the metadata is now complete. Closes #247 (as #265 also does); intended to supersede #265.

Two cases in `encoding-statement-interleave.test.ts` are concrete #265 differentiators — they pass here and fail under #265's char-sniffing approach (verified by reconstructing it locally): **`does NOT decode text-shaped output whose chars look like mojibake`** (#265 folds `$(echo KÃ¶penicker)` to `Köpenicker`, flipping the `[ … = KÃ¶penicker ]` test to `DIFF`) and **`decodes byte output inside a for-loop body (Jueast case)`** (#265 patches `executeScript` only, so the `for`-body `grep | head` still mojibakes through `executeStatement`).

> Opened as draft for your review of the `decodedTextFromResult` boundary and the `tac`/`curl` per-output markers.



