### PR TITLE
fix(interpreter): avoid lazy import in assignment path that trips defense-in-depth (#273)

### DIFF
--- a/.changeset/assignment-lazy-import.md
+++ b/.changeset/assignment-lazy-import.md
@@ -1,0 +1,19 @@
+---
+"just-bash": patch
+---
+
+interpreter: avoid lazy import in variable assignment path that trips defense-in-depth (fixes #273)
+
+Any non-`export` variable assignment (bare `SECRET=s`, prefixed `SECRET=s cmd`,
+or before a custom command) failed with a defense-in-depth security violation
+(`dynamic import of Node.js builtin 'node:module' is blocked during script
+execution`), while plain commands and `export`-ed assignments passed.
+
+`processScalarAssignment()` resolved `isArray` via `await import("./expansion.js")`
+in two spots. In the bundled `dist`, that dynamic `import()` marks `expansion.js`
+as a lazily-linked chunk whose `createRequire` banner imports `node:module`; the
+defense layer's ESM `resolve` hook blocks that builtin import when the sandbox is
+active and untrusted, so it blocked just-bash's own chunk load. The file already
+statically imports from `./expansion.js`, so `isArray` is now pulled from that
+static import and the two lazy imports are removed — no lazy `node:module`-bearing
+chunk is linked at runtime. No public API change.

--- a/packages/just-bash/src/interpreter/simple-command-assignments.ts
+++ b/packages/just-bash/src/interpreter/simple-command-assignments.ts
@@ -22,6 +22,7 @@ import {
   expandWord,
   expandWordWithGlob,
   getArrayElements,
+  isArray,
 } from "./expansion.js";
 import {
   parseKeyedElementFromWord,
@@ -785,7 +786,6 @@ async function processScalarAssignment(
       finalValue = "0";
     }
   } else {
-    const { isArray } = await import("./expansion.js");
     const appendKey = isArray(ctx, targetName) ? `${targetName}_0` : targetName;
     finalValue = append ? (ctx.state.env.get(appendKey) || "") + value : value;
   }
@@ -799,7 +799,6 @@ async function processScalarAssignment(
   if (namerefArrayRef) {
     actualEnvKey = await computeNamerefArrayEnvKey(ctx, namerefArrayRef);
   } else {
-    const { isArray } = await import("./expansion.js");
     if (isArray(ctx, targetName)) {
       actualEnvKey = `${targetName}_0`;
     }

--- a/packages/just-bash/src/interpreter/temp-env-prefix-defense.test.ts
+++ b/packages/just-bash/src/interpreter/temp-env-prefix-defense.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { DefenseInDepthBox } from "../security/defense-in-depth-box.js";
+
+describe("temp env prefix under defense-in-depth", () => {
+  afterEach(() => {
+    DefenseInDepthBox.resetInstance();
+  });
+
+  it("runs a command with a leading env assignment", async () => {
+    const bash = new Bash({ defenseInDepth: true });
+    const result = await bash.exec("FOO=bar true");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("passes the temp binding through to the command", async () => {
+    const bash = new Bash({ defenseInDepth: true });
+    const result = await bash.exec("FOO=bar echo hi");
+
+    expect(result.stdout).toBe("hi\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  // Regression guard for the bundled-dist failure where a leading env
+  // assignment (`FOO=bar cmd`) threw "security violation: dynamic import of
+  // Node.js builtin 'node:module' is blocked during script execution". The
+  // assignment path used `await import("./expansion.js")`, which in the dist
+  // bundle links a lazy chunk whose static graph pulls in `node:module`; the
+  // defense-in-depth ESM resolve hook then blocked it. expansion.js is already
+  // statically imported here, so the lazy import must not be reintroduced.
+  it("does not lazily import sibling interpreter modules", () => {
+    const source = readFileSync(
+      fileURLToPath(
+        new URL("./simple-command-assignments.ts", import.meta.url),
+      ),
+      "utf8",
+    );
+    expect(source).not.toMatch(/await\s+import\(/);
+  });
+});


### PR DESCRIPTION
Fixes #273.

I authored this with Opus 4.8 and validated that the fix works (commands with a leading env assignment — `FOO=bar cmd` — now run under the sandbox instead of throwing a security violation). It's verifiable straight from the CLI: `node ./dist/cli/just-bash.js -c 'SECRET=s echo hi; SECRET=s true; echo "exit=$?"'` prints `hi` / `exit=0` after the fix.

*The root cause, fix, and test notes below were written by the agent based on its investigation.*

### Root cause

Any non-`export` variable assignment — bare (`SECRET=s`), prefixed (`SECRET=s echo hi`), or before a custom command — fails under defense-in-depth with:

```
bash: security violation: dynamic import of Node.js builtin 'node:module' is blocked during script execution
```

Plain commands and `export`-ed assignments pass.

`processScalarAssignment` in `simple-command-assignments.ts` resolved `isArray` via `const { isArray } = await import("./expansion.js")` in two spots. In the bundled `dist`, that dynamic `import()` marks `expansion.js` as a lazily-linked chunk whose `createRequire` banner (added in 3.0.1, #238) imports `node:module`. On first link during sandboxed execution, the defense-in-depth ESM `resolve` hook sees the `node:module` builtin specifier and blocks it — a fail-closed false positive on benign input, not a sandbox escape.

The dynamic imports were never necessary: the file already statically imports from `./expansion.js` (which re-exports `isArray`), and there's no circular-dependency reason for the lazy form.

### Fix

Add `isArray` to the existing static `import { … } from "./expansion.js"` and delete both `await import("./expansion.js")` calls, using `isArray` directly. The static import dedupes the chunk, so no lazy `node:module`-bearing chunk is ever linked at runtime. No public API change.

### Tests

- New `temp-env-prefix-defense.test.ts`: `FOO=bar true` and `FOO=bar echo hi` succeed under `new Bash({ defenseInDepth: true })`, plus a source guard asserting the file contains no `await import(`. The in-process suite can't reproduce the bundler-only failure (the relative specifier isn't itself blocked; only the lazily-linked `node:module` was), so the source guard is the real reintroduction guard.
- Full interpreter + security suites green; also validated end-to-end against the built `dist` CLI, which runs with `defenseInDepth` on by default.
