### PR TITLE
chore(deps): bump node-liblzma optional dep ^2.0.3 → ^5.0.0

### DIFF
--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -123,6 +123,6 @@
   },
   "optionalDependencies": {
     "@mongodb-js/zstd": "^7.0.0",
-    "node-liblzma": "^5.0.0"
+    "node-liblzma": "^5.1.1"
   }
 }

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -123,6 +123,6 @@
   },
   "optionalDependencies": {
     "@mongodb-js/zstd": "^7.0.0",
-    "node-liblzma": "^2.0.3"
+    "node-liblzma": "^5.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       node-liblzma:
-        specifier: ^2.0.3
-        version: 2.2.0
+        specifier: ^5.0.0
+        version: 5.0.3
 
   packages/just-bash-executor:
     dependencies:
@@ -3427,10 +3427,9 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-liblzma@2.2.0:
-    resolution: {integrity: sha512-s0KzNOWwOJJgPG6wxg6cKohnAl9Wk/oW1KrQaVzJBjQwVcUGPQCzpR46Ximygjqj/3KhOrtJXnYMp/xYAXp75g==}
-    engines: {node: '>=16.0.0'}
-    hasBin: true
+  node-liblzma@5.0.3:
+    resolution: {integrity: sha512-5LN4sLdqDfk1dtaKmjqqiRHYzTxoQZvUAJKWbk9WblWnHKPl4H/7UZ6MmVBTHOOmic0OpPUhqkYOpt0fneL+hQ==}
+    engines: {node: '>=22.0.0'}
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -7645,7 +7644,7 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-liblzma@2.2.0:
+  node-liblzma@5.0.3:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -246,8 +246,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       node-liblzma:
-        specifier: ^5.0.0
-        version: 5.0.3
+        specifier: ^5.1.1
+        version: 5.1.1
 
   packages/just-bash-executor:
     dependencies:
@@ -1194,6 +1194,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/env@16.2.0-canary.26':
     resolution: {integrity: sha512-Y34nRhuzbm6lfwbr+5sUN0f322vDc1Q9zBSx7+rtFN0RJP6degxPnDk4/hjPrG4XhUPnByl4t/Jr96+FR4PWoQ==}
 
@@ -1601,6 +1607,9 @@ packages:
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -3362,6 +3371,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -3427,8 +3441,8 @@ packages:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
 
-  node-liblzma@5.0.3:
-    resolution: {integrity: sha512-5LN4sLdqDfk1dtaKmjqqiRHYzTxoQZvUAJKWbk9WblWnHKPl4H/7UZ6MmVBTHOOmic0OpPUhqkYOpt0fneL+hQ==}
+  node-liblzma@5.1.1:
+    resolution: {integrity: sha512-PRMAjS9mMbIxvYO/YlahriN5gAuCrcP2Cm2sFZKdNynO7af7vmGhWVT7os6CplNdmz9KdnHLNsgve4kpajK5rw==}
     engines: {node: '>=22.0.0'}
 
   node-releases@2.0.38:
@@ -3613,6 +3627,10 @@ packages:
 
   postcss@8.5.12:
     resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prebuild-install@7.1.3:
@@ -4011,6 +4029,10 @@ packages:
 
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.1.0:
@@ -5318,6 +5340,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
   '@next/env@16.2.0-canary.26': {}
 
   '@next/eslint-plugin-next@16.1.6':
@@ -5475,7 +5504,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
@@ -5587,6 +5616,11 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -7583,6 +7617,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.15: {}
+
   napi-build-utils@2.0.0:
     optional: true
 
@@ -7644,7 +7680,7 @@ snapshots:
   node-gyp-build@4.8.4:
     optional: true
 
-  node-liblzma@5.0.3:
+  node-liblzma@5.1.1:
     dependencies:
       node-addon-api: 8.7.0
       node-gyp-build: 4.8.4
@@ -7846,6 +7882,12 @@ snapshots:
   postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -8365,6 +8407,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tinyrainbow@3.1.0: {}
 
   tldts-core@7.0.28: {}
@@ -8552,9 +8599,9 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.12
+      postcss: 8.5.16
       rolldown: 1.0.0-rc.17
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.6.0
       esbuild: 0.27.7


### PR DESCRIPTION
Bumps the optional `node-liblzma` dependency from `^2.0.3` (which resolves to the 4-major-old 2.2.0) to `^5.0.0`.

## Why

- 5.x ships prebuilt binaries for Linux/macOS/Windows and fixed native builds on Windows + Visual Studio 2026 and pnpm/mise-managed runtimes — so this optional dep (which `tar` lazy-loads, and whose comment notes "may fail on some systems") is far less likely to fail to load.
- It also fixes a WASM stream-decode crash on Node 26 / Deno.

## Compatibility

- The API `just-bash` uses (`xzSync` / `unxzSync`) is unchanged in 5.x.
- **Verified:** the full `src/commands/tar` suite — **170 tests**, including the xz source and bundled-binary paths — passes with `node-liblzma@5.0.3`.

## One trade-off

5.x raises the engine floor from Node ≥16 to **Node ≥22**. As an optional dependency with the existing lazy-load fallback, Node <22 users degrade gracefully (xz unavailable, with the current error) rather than break.

Closes #274. Happy to adjust the range (e.g. accept both 2.x and 5.x) if you'd prefer to keep Node <22 xz support.
