### PR TITLE
Use supported re2js and update proxy methods

### DIFF
--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -114,7 +114,7 @@
     "modern-tar": "^0.7.3",
     "papaparse": "^5.5.3",
     "quickjs-emscripten": "^0.32.0",
-    "re2js": "^1.2.1",
+    "re2js": "^2.8.4",
     "smol-toml": "^1.6.0",
     "sprintf-js": "^1.1.3",
     "sql.js": "^1.13.0",

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -114,7 +114,7 @@
     "modern-tar": "^0.7.3",
     "papaparse": "^5.5.3",
     "quickjs-emscripten": "^0.32.0",
-    "re2js": "^2.8.4",
+    "re2js": "^2.8.5",
     "smol-toml": "^1.6.0",
     "sprintf-js": "^1.1.3",
     "sql.js": "^1.13.0",

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -148,6 +148,8 @@ export class UserRegex implements RegexLike {
    */
   test(input: string): boolean {
     if (this._global) {
+      // Reset lastIndex for global regexes to ensure consistent behavior
+      this._lastIndex = 0;
       // global .test() must advance lastIndex exactly like .exec()
       return this.exec(input) !== null;
     }
@@ -163,35 +165,43 @@ export class UserRegex implements RegexLike {
   exec(input: string): RegExpExecArray | null {
     const matcher = this.acquireMatcher(input);
 
+    // For global regex, start from lastIndex
     const startPos = this._global ? this._lastIndex : 0;
-
-    if (startPos > input.length || !matcher.find(startPos)) {
-      if (this._global) this._lastIndex = 0;
+    if (!matcher.find(startPos)) {
+      if (this._global) {
+        this._lastIndex = 0;
+      }
       return null;
     }
 
+    // Build result array
     const groupCount = this._re2.groupCount();
     const result: string[] = [];
 
-    // Group 0 is the full match, followed by captures
-    for (let i = 0; i <= groupCount; i++) {
-      result.push((matcher.group(i) as string | null) ?? "");
+    // Group 0 is the full match
+    result.push(matcher.group(0) ?? "");
+
+    // Add capture groups
+    for (let i = 1; i <= groupCount; i++) {
+      const group = matcher.group(i);
+      result.push(group as string);
     }
 
+    // Add RegExpExecArray properties
     const execResult = result as unknown as RegExpExecArray;
     execResult.index = matcher.start(0);
     execResult.input = input;
 
+    // Add named groups if any
     const namedGroups = this._re2.namedGroups();
     if (namedGroups && Object.keys(namedGroups).length > 0) {
-      // re2js natively returns a dict of strings/nulls
       execResult.groups = matcher.getNamedGroups() as { [key: string]: string };
     }
 
+    // Update lastIndex for global regex
     if (this._global) {
       this._lastIndex = matcher.end(0);
-
-      // Advance lastIndex to prevent infinite loops on zero-width matches
+      // Handle zero-length matches
       if (matcher.start(0) === matcher.end(0)) {
         this._lastIndex++;
       }

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -211,7 +211,7 @@ export class UserRegex implements RegexLike {
     if (this._global) {
       this._lastIndex = 0;
 
-      const matches = Array.from(this._re2.matchAll(input), m => m[0]);
+      const matches = Array.from(this._re2.matchAll(input), (m) => m[0]);
       return matches.length > 0 ? (matches as RegExpMatchArray) : null;
     }
 
@@ -229,9 +229,10 @@ export class UserRegex implements RegexLike {
       this._lastIndex = 0;
     }
 
-    const matcher = typeof replacement === "function"
-      ? this._re2.matcher(input)
-      : this.acquireMatcher(input);
+    const matcher =
+      typeof replacement === "function"
+        ? this._re2.matcher(input)
+        : this.acquireMatcher(input);
 
     if (this._global) {
       return matcher.replaceAll(replacement);

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -81,9 +81,6 @@ export class UserRegex implements RegexLike {
   // Cache native RegExp for compatibility - created lazily
   private _nativeRegex: RegExp | null = null;
   // Reusable RE2 Matcher to avoid per-call allocation in tight grep loops.
-  // Matcher allocation dominates regex.test/exec cost when called once per line
-  // across thousands of lines. We mutate charSequence in-place (not resetMatcherInput,
-  // which is broken in re2js 1.2.1 — see acquireMatcher).
   private _matcher: ReturnType<RE2JS["matcher"]> | null = null;
   private _matcherInput: string | null = null;
 
@@ -93,20 +90,15 @@ export class UserRegex implements RegexLike {
       this._matcherInput = input;
       return this._matcher;
     }
+
     if (this._matcherInput !== input) {
-      // Swap the cached Utf16MatcherInput's charSequence in-place to avoid
-      // allocating a new Matcher per call. RE2JS's resetMatcherInput is not
-      // safe with raw strings (the constructor wraps strings via
-      // MatcherInput.utf16, but resetMatcherInput assigns its argument
-      // directly and then calls .length() as a method, which throws on a
-      // raw string). MatcherInput is not exported, so we mutate the existing
-      // wrapper's charSequence field — Matcher.reset() reads matcherInput.length()
-      // afterwards, so the new length is picked up correctly.
-      // biome-ignore lint/suspicious/noExplicitAny: reaching into re2js internals
-      (this._matcher as any).matcherInput.charSequence = input;
+      // @ts-expect-error: re2js underlying JS supports strings, but types are outdated
+      this._matcher.resetMatcherInput(input);
       this._matcherInput = input;
+    } else {
+      this._matcher.reset();
     }
-    this._matcher.reset();
+
     return this._matcher;
   }
 
@@ -138,7 +130,7 @@ export class UserRegex implements RegexLike {
           pattern.includes("(?<!")
         ) {
           explanation =
-            " Lookahead (?=, ?!) and lookbehind (?<=, ?<!) assertions are not supported in this environment because the regex engine uses RE2 for ReDoS protection. RE2 guarantees linear-time matching but cannot support these features.";
+            " Lookahead (?=, ?!) and lookbehind (?<=, ?<!) assertions are not supported in this environment because the regex engine uses RE2 for ReDoS protection. RE2 guarantees linear-time matching but cannot support these features."; // in reallity it can, it just have performance penalties - https://github.com/le0pard/re2js#lookbehinds-linear-time-execution
         } else if (msg.includes("backreference") || /\\[1-9]/.test(pattern)) {
           explanation =
             " Backreferences (\\1, \\2, etc.) are not supported in this environment because the regex engine uses RE2 for ReDoS protection. RE2 guarantees linear-time matching but cannot support backreferences.";
@@ -160,8 +152,7 @@ export class UserRegex implements RegexLike {
     if (this._global) {
       this._lastIndex = 0;
     }
-    const matcher = this.acquireMatcher(input);
-    return matcher.find();
+    return this._re2.test(input);
   }
 
   /**
@@ -171,51 +162,35 @@ export class UserRegex implements RegexLike {
   exec(input: string): RegExpExecArray | null {
     const matcher = this.acquireMatcher(input);
 
-    // For global regex, start from lastIndex
     const startPos = this._global ? this._lastIndex : 0;
+
     if (!matcher.find(startPos)) {
-      if (this._global) {
-        this._lastIndex = 0;
-      }
+      if (this._global) this._lastIndex = 0;
       return null;
     }
 
-    // Build result array
     const groupCount = this._re2.groupCount();
     const result: string[] = [];
 
-    // Group 0 is the full match
-    result.push(matcher.group(0) ?? "");
-
-    // Add capture groups
-    for (let i = 1; i <= groupCount; i++) {
-      const group = matcher.group(i);
-      result.push(group as string);
+    // Group 0 is the full match, followed by captures
+    for (let i = 0; i <= groupCount; i++) {
+      result.push((matcher.group(i) as string | null) ?? "");
     }
 
-    // Add RegExpExecArray properties
     const execResult = result as unknown as RegExpExecArray;
     execResult.index = matcher.start(0);
     execResult.input = input;
 
-    // Add named groups if any
     const namedGroups = this._re2.namedGroups();
     if (namedGroups && Object.keys(namedGroups).length > 0) {
-      // Use Object.create(null) to prevent prototype pollution from names like __proto__
-      const groups: { [key: string]: string } = Object.create(null);
-      for (const [name, index] of Object.entries(namedGroups)) {
-        const value = matcher.group(index as number);
-        if (value !== null) {
-          groups[name] = value;
-        }
-      }
-      execResult.groups = groups;
+      // re2js natively returns a dict of strings/nulls
+      execResult.groups = matcher.getNamedGroups() as { [key: string]: string };
     }
 
-    // Update lastIndex for global regex
     if (this._global) {
       this._lastIndex = matcher.end(0);
-      // Handle zero-length matches
+
+      // Advance lastIndex to prevent infinite loops on zero-width matches
       if (matcher.start(0) === matcher.end(0)) {
         this._lastIndex++;
       }
@@ -229,33 +204,14 @@ export class UserRegex implements RegexLike {
    * With global flag, returns all matches. Without, returns first match with groups.
    */
   match(input: string): RegExpMatchArray | null {
-    // Reset lastIndex for consistent behavior
     if (this._global) {
       this._lastIndex = 0;
+
+      const matches = Array.from(this._re2.matchAll(input), m => m[0]);
+      return matches.length > 0 ? (matches as RegExpMatchArray) : null;
     }
 
-    if (!this._global) {
-      // Non-global: return first match with groups (same as exec)
-      return this.exec(input);
-    }
-
-    // Global: return all matches without groups
-    const matches: string[] = [];
-    const matcher = this.acquireMatcher(input);
-    let pos = 0;
-
-    while (matcher.find(pos)) {
-      const matchStr = matcher.group(0) ?? "";
-      matches.push(matchStr);
-      pos = matcher.end(0);
-      // Handle zero-length matches
-      if (matcher.start(0) === matcher.end(0)) {
-        pos++;
-      }
-      if (pos > input.length) break;
-    }
-
-    return matches.length > 0 ? (matches as RegExpMatchArray) : null;
+    return this.exec(input);
   }
 
   /**
@@ -269,78 +225,14 @@ export class UserRegex implements RegexLike {
       this._lastIndex = 0;
     }
 
-    if (typeof replacement === "string") {
-      const matcher = this.acquireMatcher(input);
-      if (this._global) {
-        return matcher.replaceAll(replacement, true);
-      }
-      return matcher.replaceFirst(replacement, true);
+    const matcher = typeof replacement === "function"
+      ? this._re2.matcher(input)
+      : this.acquireMatcher(input);
+
+    if (this._global) {
+      return matcher.replaceAll(replacement);
     }
-
-    // Callback replacement - we need to do this manually.
-    // Use a fresh Matcher rather than the shared cached one: the user-provided
-    // callback may re-enter this same UserRegex instance (e.g. call test/exec/
-    // replace), which would route through acquireMatcher and repoint the shared
-    // matcher's charSequence to a different input. The next matcher.find(pos)
-    // would then advance through the wrong string. A fresh matcher keeps the
-    // iteration state private to this replace() call.
-    const result: string[] = [];
-    const matcher = this._re2.matcher(input);
-    let lastEnd = 0;
-    let pos = 0;
-    const groupCount = this._re2.groupCount();
-    const namedGroups = this._re2.namedGroups();
-
-    while (matcher.find(pos)) {
-      // Add text before match
-      result.push(input.slice(lastEnd, matcher.start(0)));
-
-      // Build callback arguments
-      const args: (string | number | Record<string, string>)[] = [];
-      const fullMatch = matcher.group(0) ?? "";
-
-      // Add capture groups
-      for (let i = 1; i <= groupCount; i++) {
-        args.push(matcher.group(i) as string);
-      }
-
-      // Add index and input
-      args.push(matcher.start(0));
-      args.push(input);
-
-      // Add named groups if present
-      if (namedGroups && Object.keys(namedGroups).length > 0) {
-        // Use Object.create(null) to prevent prototype pollution from names like __proto__
-        const groups: Record<string, string> = Object.create(null);
-        for (const [name, index] of Object.entries(namedGroups)) {
-          groups[name] = matcher.group(index as number) ?? "";
-        }
-        args.push(groups);
-      }
-
-      // Capture positions before invoking callback. The matcher is private to
-      // this call, but capturing now avoids relying on matcher state being
-      // unchanged across the callback boundary.
-      const matchStart = matcher.start(0);
-      const matchEnd = matcher.end(0);
-
-      result.push(replacement(fullMatch, ...args));
-
-      lastEnd = matchEnd;
-      pos = lastEnd;
-      // Handle zero-length matches
-      if (matchStart === matchEnd) {
-        pos++;
-      }
-
-      if (!this._global) break;
-      if (pos > input.length) break;
-    }
-
-    // Add remaining text
-    result.push(input.slice(lastEnd));
-
-    return result.join("");
+    return matcher.replaceFirst(replacement);
   }
 
   /**
@@ -381,50 +273,8 @@ export class UserRegex implements RegexLike {
     }
 
     this._lastIndex = 0;
-    // matchAll is a generator that suspends at `yield`. The shared `_matcher`
-    // would be corrupted if a caller interleaves any other method on the same
-    // UserRegex instance between two `next()` calls (acquireMatcher would
-    // reset/repoint it). Use a fresh Matcher to keep iterator state private.
-    const matcher = this._re2.matcher(input);
-    const groupCount = this._re2.groupCount();
-    const namedGroups = this._re2.namedGroups();
-    let pos = 0;
 
-    while (matcher.find(pos)) {
-      // Build result array
-      const result: string[] = [];
-      result.push(matcher.group(0) ?? "");
-
-      for (let i = 1; i <= groupCount; i++) {
-        result.push(matcher.group(i) as string);
-      }
-
-      const execResult = result as unknown as RegExpMatchArray;
-      execResult.index = matcher.start(0);
-      execResult.input = input;
-
-      // Add named groups if any
-      if (namedGroups && Object.keys(namedGroups).length > 0) {
-        // Use Object.create(null) to prevent prototype pollution from names like __proto__
-        const groups: { [key: string]: string } = Object.create(null);
-        for (const [name, index] of Object.entries(namedGroups)) {
-          const value = matcher.group(index as number);
-          if (value !== null) {
-            groups[name] = value;
-          }
-        }
-        execResult.groups = groups;
-      }
-
-      yield execResult;
-
-      pos = matcher.end(0);
-      // Prevent infinite loop on zero-length matches
-      if (matcher.start(0) === matcher.end(0)) {
-        pos++;
-      }
-      if (pos > input.length) break;
-    }
+    yield* this._re2.matchAll(input) as IterableIterator<RegExpMatchArray>;
   }
 
   /**

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -148,11 +148,13 @@ export class UserRegex implements RegexLike {
    * Test if the pattern matches the input string.
    */
   test(input: string): boolean {
-    // Reset lastIndex for global regexes to ensure consistent behavior
-    if (this._global) {
-      this._lastIndex = 0;
+    if (!this._global) {
+      // The DFA engine is blisteringly fast for simple existence checks
+      return this._re2.test(input);
     }
-    return this._re2.test(input);
+
+    // global .test() must advance lastIndex exactly like .exec()
+    return this.exec(input) !== null;
   }
 
   /**

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -148,8 +148,6 @@ export class UserRegex implements RegexLike {
    */
   test(input: string): boolean {
     if (this._global) {
-      // Reset lastIndex for global regexes to ensure consistent behavior
-      this._lastIndex = 0;
       // global .test() must advance lastIndex exactly like .exec()
       return this.exec(input) !== null;
     }

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -92,7 +92,6 @@ export class UserRegex implements RegexLike {
     }
 
     if (this._matcherInput !== input) {
-      // @ts-expect-error: re2js underlying JS supports strings, but types are outdated
       this._matcher.resetMatcherInput(input);
       this._matcherInput = input;
     } else {
@@ -260,7 +259,7 @@ export class UserRegex implements RegexLike {
    */
   search(input: string): number {
     const matcher = this.acquireMatcher(input);
-    if (matcher.find()) {
+    if (matcher.find(0)) {
       return matcher.start(0);
     }
     return -1;
@@ -377,9 +376,6 @@ export class ConstantRegex implements RegexLike {
   }
 
   test(input: string): boolean {
-    if (this._regex.global) {
-      this._regex.lastIndex = 0;
-    }
     return this._regex.test(input);
   }
 

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -148,6 +148,7 @@ export class UserRegex implements RegexLike {
    */
   test(input: string): boolean {
     if (this._global) {
+      // Reset lastIndex for global regexes to ensure consistent behavior
       this._lastIndex = 0;
       // global .test() must advance lastIndex exactly like .exec()
       return this.exec(input) !== null;
@@ -206,6 +207,7 @@ export class UserRegex implements RegexLike {
    * With global flag, returns all matches. Without, returns first match with groups.
    */
   match(input: string): RegExpMatchArray | null {
+    // Reset lastIndex for consistent behavior
     if (this._global) {
       this._lastIndex = 0;
 
@@ -260,7 +262,7 @@ export class UserRegex implements RegexLike {
    */
   search(input: string): number {
     const matcher = this.acquireMatcher(input);
-    if (matcher.find(0)) {
+    if (matcher.find()) {
       return matcher.start(0);
     }
     return -1;

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -147,13 +147,14 @@ export class UserRegex implements RegexLike {
    * Test if the pattern matches the input string.
    */
   test(input: string): boolean {
-    if (!this._global) {
-      // The DFA engine is blisteringly fast for simple existence checks
-      return this._re2.test(input);
+    if (this._global) {
+      this._lastIndex = 0;
+      // global .test() must advance lastIndex exactly like .exec()
+      return this.exec(input) !== null;
     }
 
-    // global .test() must advance lastIndex exactly like .exec()
-    return this.exec(input) !== null;
+    // The DFA engine is blisteringly fast for simple existence checks
+    return this._re2.test(input);
   }
 
   /**
@@ -165,7 +166,7 @@ export class UserRegex implements RegexLike {
 
     const startPos = this._global ? this._lastIndex : 0;
 
-    if (!matcher.find(startPos)) {
+    if (startPos > input.length || !matcher.find(startPos)) {
       if (this._global) this._lastIndex = 0;
       return null;
     }
@@ -376,6 +377,10 @@ export class ConstantRegex implements RegexLike {
   }
 
   test(input: string): boolean {
+    if (this._regex.global) {
+      this._regex.lastIndex = 0;
+    }
+
     return this._regex.test(input);
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: ^0.32.0
         version: 0.32.0
       re2js:
-        specifier: ^2.8.4
-        version: 2.8.4
+        specifier: ^2.8.5
+        version: 2.8.5
       seek-bzip:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3680,8 +3680,8 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  re2js@2.8.4:
-    resolution: {integrity: sha512-YT5Vvcm8rKzzF3xSnaPr856xnEoRXfivdXwsnRgSOEtejU2jpBNTYOsGSNbbsrZfgkGE+qdDSXv2lz9r30WDyg==}
+  re2js@2.8.5:
+    resolution: {integrity: sha512-L13fl3sRU6GgC/3fGrZ3DBZt2knDy/MVTw90oVBKhdlLr9uKwrxlxJUD+zkEMm8X/nq1XMi5GS4jq8O4FjmHoA==}
     engines: {node: '>=18.0.0'}
 
   react-dom@19.2.3:
@@ -7930,7 +7930,7 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  re2js@2.8.4: {}
+  re2js@2.8.5: {}
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: ^0.32.0
         version: 0.32.0
       re2js:
-        specifier: ^1.2.1
-        version: 1.4.0
+        specifier: ^2.8.4
+        version: 2.8.4
       seek-bzip:
         specifier: ^2.0.0
         version: 2.0.0
@@ -3680,9 +3680,9 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  re2js@1.4.0:
-    resolution: {integrity: sha512-KTOIcZTSOpOxbu3i0+T6mFQ6tkxXKlTxfcMFs1trQbsMnG84qNq+DjXr8Afu+FEFjvF1NNlldpC7roPyazFI8g==}
-    deprecated: Accidental publish of breaking changes. Please downgrade to 1.3.3 or upgrade to the latest version.
+  re2js@2.8.4:
+    resolution: {integrity: sha512-YT5Vvcm8rKzzF3xSnaPr856xnEoRXfivdXwsnRgSOEtejU2jpBNTYOsGSNbbsrZfgkGE+qdDSXv2lz9r30WDyg==}
+    engines: {node: '>=18.0.0'}
 
   react-dom@19.2.3:
     resolution: {integrity: sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==}
@@ -7930,7 +7930,7 @@ snapshots:
       strip-json-comments: 2.0.1
     optional: true
 
-  re2js@1.4.0: {}
+  re2js@2.8.4: {}
 
   react-dom@19.2.3(react@19.2.3):
     dependencies:


### PR DESCRIPTION
Reason for changes:
 - Use currently supported re2js version - https://github.com/le0pard/re2js/blob/main/SECURITY.md
 - Use highly optimized boolean testing methods (use fast DFA engines instead of NFA) - https://github.com/le0pard/re2js/tree/main#high-performance-boolean-testing
 - Use helper methods, which not need reimplement for proxy logic, like `matchAll` or `getNamedGroups`
 - I published in `2.8.5` re2js version with fix for `resetMatcherInput` polymorphic inputs and fix typing for it, but you can wait several days/weeks, so this fresh release will not be susspicion as some kind of "supply chain attack"