### PR TITLE
fix(rg): search piped stdin when no paths are given

### DIFF
--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -116,9 +116,6 @@ export async function executeSearch(
     };
   }
 
-  // Default to current directory
-  const paths = inputPaths.length === 0 ? ["."] : inputPaths;
-
   // Determine case sensitivity
   const effectiveIgnoreCase = determineIgnoreCase(options, patterns);
 
@@ -140,6 +137,70 @@ export async function executeSearch(
       exitCode: 2,
     };
   }
+
+  // If no paths given and stdin has content, search stdin (like real rg).
+  // In a pipeline, the previous command's stdout becomes this command's
+  // stdin — search that text instead of defaulting to the current directory.
+  // Skip when `-f -` already consumed stdin for patterns to avoid
+  // double-consuming it as both pattern source and search input.
+  const stdinConsumedByPatternFile = options.patternFiles.includes("-");
+  const stdinText = decodeBytesToUtf8(ctx.stdin);
+  if (
+    inputPaths.length === 0 &&
+    stdinText.length > 0 &&
+    !stdinConsumedByPatternFile
+  ) {
+    const content = stdinText;
+    const result = searchContent(content, regex, {
+      invertMatch: options.invertMatch,
+      showLineNumbers: options.lineNumber,
+      countOnly: options.count,
+      countMatches: options.countMatches,
+      filename: "",
+      onlyMatching: options.onlyMatching,
+      beforeContext: options.beforeContext,
+      afterContext: options.afterContext,
+      maxCount: options.maxCount,
+      contextSeparator: options.contextSeparator,
+      showColumn: options.column,
+      vimgrep: options.vimgrep,
+      showByteOffset: options.byteOffset,
+      replace:
+        options.replace !== null ? convertReplacement(options.replace) : null,
+      passthru: options.passthru,
+      multiline: options.multiline,
+      kResetGroup,
+    });
+
+    if (options.quiet) {
+      return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };
+    }
+
+    if (options.filesWithMatches) {
+      return {
+        stdout: result.matched ? "(standard input)\n" : "",
+        stderr: "",
+        exitCode: result.matched ? 0 : 1,
+      };
+    }
+
+    if (options.filesWithoutMatch) {
+      return {
+        stdout: result.matched ? "" : "(standard input)\n",
+        stderr: "",
+        exitCode: result.matched ? 1 : 0,
+      };
+    }
+
+    return {
+      stdout: result.output,
+      stderr: "",
+      exitCode: result.matched ? 0 : 1,
+    };
+  }
+
+  // Default to current directory
+  const paths = inputPaths.length === 0 ? ["."] : inputPaths;
 
   // Load gitignore files
   let gitignore: GitignoreManager | null = null;

--- a/packages/just-bash/src/commands/rg/rg.stdin.test.ts
+++ b/packages/just-bash/src/commands/rg/rg.stdin.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("rg searches stdin when no paths are given", () => {
+  it("searches piped stdin instead of cwd", async () => {
+    const env = new Bash({
+      files: {
+        // File exists but should NOT be searched — only stdin should be
+        "/decoy.txt": "decoy line\n",
+      },
+    });
+    const result = await env.exec(
+      'printf "hello world\\ngoodbye\\n" | rg "hello"',
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello world");
+    expect(result.stdout).not.toContain("decoy");
+  });
+
+  it("returns exit code 1 when stdin has no match", async () => {
+    const env = new Bash({ files: {} });
+    const result = await env.exec('echo "hello" | rg "xyz"');
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe("");
+  });
+
+  it("supports case-insensitive search on stdin", async () => {
+    const env = new Bash({ files: {} });
+    const result = await env.exec('printf "Hello World\\n" | rg -i "hello"');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("Hello World");
+  });
+
+  it("supports inverted match on stdin", async () => {
+    const env = new Bash({ files: {} });
+    const result = await env.exec('printf "aaa\\nbbb\\nccc\\n" | rg -v "bbb"');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("aaa");
+    expect(result.stdout).toContain("ccc");
+    expect(result.stdout).not.toContain("bbb");
+  });
+
+  it("supports count mode on stdin", async () => {
+    const env = new Bash({ files: {} });
+    const result = await env.exec('printf "foo\\nbar\\nfoo\\n" | rg -c "foo"');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.trim()).toBe("2");
+  });
+
+  it("searches files when explicit path is given (not stdin)", async () => {
+    const env = new Bash({
+      files: { "/data.txt": "target line\n" },
+    });
+    const result = await env.exec(
+      'echo "stdin content" | rg "target" /data.txt',
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("target line");
+  });
+
+  it("does not double-consume stdin when -f - is used", async () => {
+    const env = new Bash({
+      files: { "/data.txt": "hello world\ngoodbye\n" },
+    });
+    // -f - reads patterns from stdin; rg should then search the explicit
+    // path, not try to also search stdin as content
+    const result = await env.exec('echo "hello" | rg -f - /data.txt');
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("hello world");
+  });
+
+  it("supports multibyte UTF-8 patterns from piped stdin", async () => {
+    const env = new Bash({ files: {} });
+    const result = await env.exec("printf '한글 found\\nmiss\\n' | rg '한글'");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("한글 found");
+    expect(result.stdout).not.toContain("miss");
+  });
+});

--- a/packages/just-bash/src/commands/rg/rg.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/rg/rg.utf8-stdin.test.ts
@@ -8,9 +8,6 @@ describe("rg reads UTF-8 from stdin", () => {
     });
     const result = await env.exec("cat /in.txt | rg '한글'");
     expect(result.exitCode).toBe(0);
-    // rg prefixes matches from stdin with a `<filename>:<line>:` source
-    // identifier; the bytes after the last `:` are the matched line.
-    const matched = result.stdout.split(":").slice(2).join(":");
-    expect(matched.trim()).toBe("한글 found");
+    expect(result.stdout).toContain("한글 found");
   });
 });


### PR DESCRIPTION
## Summary

When `rg` receives piped stdin with no explicit path arguments, it ignores stdin and defaults to recursively searching the current working directory (`.`). This is inconsistent with real ripgrep and with how `grep` already handles stdin in just-bash.

## Reproduction

```bash
# rg ignores stdin, searches cwd instead
echo "hello world" | rg "hello"
# Expected: hello world
# Actual: recursively searches . and returns all file matches containing "hello"

# grep handles stdin correctly
echo "hello world" | grep "hello"
# Output: hello world ✅
```

## Fix

After building the regex, check for non-empty stdin before defaulting to `.`. When stdin has content and no paths are given, `searchContent` is called directly on the stdin text with all applicable options (invert, count, context, quiet, `-l`, etc.).

Also fixes `rg.utf8-stdin.test.ts` which was previously passing by accident — it tested `cat /in.txt | rg '한글'` but rg was actually finding the match by searching the filesystem (it found `in.txt`), not by reading stdin.

## Tests

- 7 new stdin-specific tests covering: basic piped search, no-match exit code, case-insensitive, inverted match, count mode, explicit-path-overrides-stdin, and multibyte UTF-8
- All 515 existing rg tests pass (82 skipped)
- All 205 existing grep tests pass (8 skipped)

Fixes #280
