### PR TITLE
feat(sandbox): forward capability options through Sandbox.create

### DIFF
--- a/.changeset/sandbox-forward-capability-options.md
+++ b/.changeset/sandbox-forward-capability-options.md
@@ -1,0 +1,17 @@
+---
+"just-bash": minor
+---
+
+sandbox: forward capability flags from `SandboxOptions` into the underlying `Bash`
+
+`Sandbox.create(opts)` previously constructed its internal `Bash` with only a subset
+of `BashOptions`, silently dropping the optional capability flags (`python`,
+`javascript`, `commands`, `customCommands`, `fetch`). A host that drives just-bash
+through the `Sandbox` API (rather than `new Bash(...)`) therefore could not enable
+python3, js-exec, a restricted command set, custom commands, or a custom fetch — even
+though the runtimes ship in the package.
+
+`SandboxOptions` now exposes those fields and `Sandbox.create` forwards them into the
+`Bash` it builds. Behavior is unchanged when a caller omits them (each falls back to
+its existing `BashOptions` default — Python/js-exec stay off, the full command set
+stays available). Fixes the root cause behind vercel/eve#431.

--- a/packages/just-bash/src/commands/python3/python3.sandbox.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.sandbox.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { Sandbox } from "../../sandbox/Sandbox.js";
+
+// End-to-end proof that the `python` capability flag forwarded through
+// `SandboxOptions` reaches the underlying `Bash` and actually registers the
+// python3 command. Without forwarding, python3 stays unavailable even though
+// the CPython runtime ships in the package (see vercel/eve#431).
+describe("Sandbox.create({ python: true })", () => {
+  it(
+    "registers python3 when the capability is enabled",
+    { timeout: 60000 },
+    async () => {
+      const sandbox = await Sandbox.create({ python: true });
+      const cmd = await sandbox.runCommand("python3 --version");
+      expect(await cmd.stdout()).toContain("Python 3.");
+    },
+  );
+
+  it("leaves python3 unavailable by default", async () => {
+    const sandbox = await Sandbox.create();
+    const cmd = await sandbox.runCommand("python3 --version");
+    // Either "not found" or "not available" depending on the bundle context.
+    expect(await cmd.stderr()).toMatch(/command not (found|available)/);
+  });
+});

--- a/packages/just-bash/src/sandbox/Sandbox.test.ts
+++ b/packages/just-bash/src/sandbox/Sandbox.test.ts
@@ -1,5 +1,6 @@
 import { PassThrough } from "node:stream";
 import { describe, expect, it } from "vitest";
+import { defineCommand } from "../custom-commands.js";
 import { Command, type OutputMessage, Sandbox } from "./Sandbox.js";
 
 describe("Sandbox API", () => {
@@ -31,6 +32,26 @@ describe("Sandbox API", () => {
       const cmd = await sandbox.runCommand("recurse() { recurse; }; recurse");
       const stderr = await cmd.stderr();
       expect(stderr).toContain("maximum recursion depth");
+    });
+
+    it("forwards customCommands through to the underlying Bash", async () => {
+      const greet = defineCommand("greet", async (args) => ({
+        stdout: `hello ${args[0] ?? "world"}\n`,
+        stderr: "",
+        exitCode: 0,
+      }));
+      const sandbox = await Sandbox.create({ customCommands: [greet] });
+      const cmd = await sandbox.runCommand("greet sandbox");
+      expect((await cmd.stdout()).trim()).toBe("hello sandbox");
+    });
+
+    it("forwards a restricted commands allow-list through to the underlying Bash", async () => {
+      const sandbox = await Sandbox.create({ commands: ["echo"] });
+      const allowed = await sandbox.runCommand("echo ok");
+      expect((await allowed.stdout()).trim()).toBe("ok");
+      // A built-in outside the allow-list is not registered.
+      const denied = await sandbox.runCommand("grep foo");
+      expect(await denied.stderr()).toContain("command not found");
     });
   });
 

--- a/packages/just-bash/src/sandbox/Sandbox.ts
+++ b/packages/just-bash/src/sandbox/Sandbox.ts
@@ -1,9 +1,11 @@
 import type { Writable } from "node:stream";
-import { Bash } from "../Bash.js";
+import { Bash, type JavaScriptConfig } from "../Bash.js";
+import type { CommandName } from "../commands/registry.js";
+import type { CustomCommand } from "../custom-commands.js";
 import type { IFileSystem } from "../fs/interface.js";
 import { OverlayFs } from "../fs/overlay-fs/index.js";
 import { shellJoinArgs } from "../helpers/shell-quote.js";
-import type { NetworkConfig } from "../network/index.js";
+import type { NetworkConfig, SecureFetch } from "../network/index.js";
 import type { DefenseInDepthConfig } from "../security/types.js";
 import type { CommandFinished } from "./Command.js";
 import { Command } from "./Command.js";
@@ -37,6 +39,35 @@ export interface SandboxOptions {
    * Monkey-patches dangerous JavaScript globals during bash execution.
    */
   defenseInDepth?: DefenseInDepthConfig | boolean;
+  /**
+   * Enable the python3/python commands. Disabled by default: Python adds
+   * security surface (arbitrary code execution via CPython). Forwarded to
+   * the underlying `Bash`.
+   */
+  python?: boolean;
+  /**
+   * Enable the js-exec command (sandboxed JavaScript via QuickJS). Accepts a
+   * boolean or a {@link JavaScriptConfig} (bootstrap code / `invokeTool`
+   * hook). Disabled by default. Forwarded to the underlying `Bash`.
+   */
+  javascript?: boolean | JavaScriptConfig;
+  /**
+   * Restrict the registered command set. When omitted, all built-in commands
+   * are available; pass a list to allow only those. Forwarded to the
+   * underlying `Bash`.
+   */
+  commands?: CommandName[];
+  /**
+   * Custom commands registered alongside the built-ins (these take precedence
+   * over built-ins with the same name). Forwarded to the underlying `Bash`.
+   */
+  customCommands?: CustomCommand[];
+  /**
+   * Custom secure fetch implementation used instead of one derived from
+   * `network`. Providing either `fetch` or `network` registers the network
+   * commands (curl, wget). Forwarded to the underlying `Bash`.
+   */
+  fetch?: SecureFetch;
 }
 
 export interface RunCommandParams {
@@ -88,6 +119,15 @@ export class Sandbox {
       maxLoopIterations: opts?.maxLoopIterations,
       network: opts?.network,
       defenseInDepth: opts?.defenseInDepth,
+      // Capability flags: forwarded so a sandbox created via Sandbox.create
+      // can opt into the same optional features as `new Bash(...)`. Each is
+      // `undefined` when the caller omits it, falling back to the BashOptions
+      // default, so existing behavior is unchanged.
+      python: opts?.python,
+      javascript: opts?.javascript,
+      commands: opts?.commands,
+      customCommands: opts?.customCommands,
+      fetch: opts?.fetch,
     });
     return new Sandbox(bashEnv, opts?.timeoutMs);
   }


### PR DESCRIPTION
## What

`Sandbox.create(opts: SandboxOptions)` builds its internal `Bash` from only a subset of
`BashOptions`, silently dropping the optional capability flags. This PR adds those flags
to `SandboxOptions` and forwards them into the `new Bash({...})` that `Sandbox.create`
constructs:

- `python?: boolean`
- `javascript?: boolean | JavaScriptConfig`
- `commands?: CommandName[]`
- `customCommands?: CustomCommand[]`
- `fetch?: SecureFetch`

(`env`, `cwd`, `fs`/`overlayRoot`, `maxCallDepth`, `maxCommandCount`, `maxLoopIterations`,
`network`, `defenseInDepth` were already forwarded.)

## Why

A host that drives just-bash through the `Sandbox` API rather than `new Bash(...)` could
not enable python3, js-exec, a restricted command set, custom commands, or a custom
fetch — even though the runtimes ship in the package. The flags exist only on
`BashOptions`, and `Sandbox.create` did not pass them through, so they were unreachable
(and the TypeScript type rejected them as excess properties).

Concretely, vercel/eve's just-bash sandbox backend constructs the interpreter via
`Sandbox.create(...)`, so it cannot offer `python3` to agents at all and users fall back
to Docker/microsandbox to run a stdlib-only Python helper. This is the root cause behind
that downstream report: **vercel/eve#431** (and eve's consumer-side passthrough that
extends to these flags once this lands).

Fixes #283.

## Backward compatibility

Behavior is unchanged when a caller omits the new fields: each is forwarded as
`undefined`, falling back to its existing `BashOptions` default (Python/js-exec stay off,
the full command set stays available, fetch derives from `network` as before). No
existing `SandboxOptions` field changes.

## Tests

- `src/sandbox/Sandbox.test.ts` (default unit suite): two new cases proving forwarding
  without WASM — a `customCommands` command runs through `Sandbox.create`, and a
  restricted `commands: ["echo"]` allow-list registers only the listed command.
- `src/commands/python3/python3.sandbox.test.ts` (WASM suite): `Sandbox.create({ python:
  true })` registers `python3` (and it stays unavailable by default) — the direct
  end-to-end proof.

## Validation

- `pnpm typecheck` — clean
- `pnpm exec vitest run --config vitest.unit.config.ts src/sandbox/Sandbox.test.ts` — pass
- `pnpm exec vitest run --config vitest.wasm.config.ts src/commands/python3/python3.sandbox.test.ts` — pass
- `pnpm lint`, `pnpm knip`, `pnpm build` — clean
- A changeset is included (`minor`).

The main open design question is the exact field set surfaced on `SandboxOptions` — I
forwarded the five `BashOptions`-only capability inputs (`python`, `javascript`,
`commands`, `customCommands`, `fetch`), but I'm happy to narrow or reshape that to match
your preference.
