### PR TITLE
refactor(interpreter): model stdin as a single shared StdinStream

### DIFF
--- a/.changeset/stdin-stream.md
+++ b/.changeset/stdin-stream.md
@@ -1,0 +1,39 @@
+---
+"just-bash": minor
+---
+
+interpreter: model stdin as a single shared stream (`StdinStream`), fixing loops and compound commands losing stdin position
+
+Stdin is now represented exactly one way everywhere: a `StdinStream` object
+that behaves like a bash file descriptor — it holds the content bytes and a
+read offset, and is shared by reference. Reading is consuming: a command
+that drains stdin (`cat`, `grep`, `sed`, ...) advances the offset for every
+other holder of the stream, including across subshell and pipeline-stage
+boundaries. This replaces the old `groupStdin?: string` snapshot plus
+per-call-site fallback rules, which made it easy for a command to read the
+loop's stdin without advancing it.
+
+Fixes, all verified against real bash via recorded comparison fixtures:
+
+- Commands inside `while read` loop bodies (pipelines, `cat`, `grep`, `tr`,
+  and ~30 other stdin consumers) now advance the loop's stdin instead of
+  re-reading the same input each iteration.
+- Stdin redirections (`<`, `<<`, `<<-`, `<<<`, `<&`) now work uniformly on
+  all compound commands (`if`, `for`, `while`, `until`, `case`, subshells,
+  groups) through one shared resolution path.
+- Subshells share the stdin offset with their parent (matching bash fd
+  semantics): `{ (read x); read y; } < f` gives `y` the second line.
+- A pipeline stage that produces empty output no longer lets the next
+  command fall back to the enclosing scope's stdin.
+- Heredoc/here-string content on compound commands and functions is now
+  UTF-8 encoded into the byte pipeline consistently (previously only simple
+  commands did this).
+- Function definition redirects (`f() { ...; } < file`) now apply on every
+  call and win over piped stdin; a missing redirect file is an error and
+  the body does not run (both match bash).
+
+BREAKING (TypeScript API): `CommandContext.stdin` is now a `StdinStream`
+instead of a `ByteString`. Custom commands call `ctx.stdin.readAll()` to
+consume input (or `ctx.stdin.peek()` to inspect without consuming) and
+convert with `latin1FromBytes` / `decodeBytesToUtf8` as before. The
+`StdinStream` class is exported from the package root.

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -37,9 +37,10 @@ const hello = defineCommand("hello", async (args, ctx) => {
 });
 
 const upper = defineCommand("upper", async (args, ctx) => {
-  // ctx.stdin is a ByteString — decode to text before string ops.
+  // ctx.stdin is a stream: readAll() consumes it and returns a ByteString —
+  // decode to text before string ops.
   return {
-    stdout: decodeBytesToUtf8(ctx.stdin).toUpperCase(),
+    stdout: decodeBytesToUtf8(ctx.stdin.readAll()).toUpperCase(),
     stderr: "",
     exitCode: 0,
   };
@@ -51,7 +52,7 @@ await bash.exec("hello Alice"); // "Hello, Alice!\n"
 await bash.exec("echo 'test' | upper"); // "TEST\n"
 ```
 
-Custom commands receive a `CommandContext` with `fs`, `cwd`, `env`, `stdin`, and `exec` (for subcommands), and work with pipes, redirections, and all shell features.
+Custom commands receive a `CommandContext` with `fs`, `cwd`, `env`, `stdin` (a consumable stream: `readAll()` to drain it, `peek()` to inspect without consuming), and `exec` (for subcommands), and work with pipes, redirections, and all shell features.
 
 <details>
 <summary><h2>Supported Commands</h2></summary>

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -62,6 +62,7 @@ import {
   SecurityViolationError,
 } from "./security/defense-in-depth-box.js";
 import type { DefenseInDepthConfig } from "./security/types.js";
+import { StdinStream } from "./stdin-stream.js";
 import { serialize } from "./transform/serialize.js";
 import type {
   BashTransformResult,
@@ -374,6 +375,7 @@ export class Bash {
     this.state = {
       env,
       cwd,
+      stdin: new StdinStream(),
       previousDir: "/home/user",
       functions: new Map<string, FunctionDefNode>(),
       localScopes: [],
@@ -648,7 +650,9 @@ export class Bash {
       // UTF-8 bytes. Callers that already prepared a byte buffer (e.g.
       // `Buffer.from(buf).toString("latin1")`) opt into raw passthrough
       // via `stdinKind: "bytes"`.
-      groupStdin: encodeStdinForPipeline(options?.stdin, options?.stdinKind),
+      stdin: new StdinStream(
+        encodeStdinForPipeline(options?.stdin, options?.stdinKind) ?? "",
+      ),
       // Cooperative cancellation signal (used by timeout command)
       signal: options?.signal,
       // Extra arguments injected directly into first command's arg list

--- a/packages/just-bash/src/commands/awk/awk2.ts
+++ b/packages/just-bash/src/commands/awk/awk2.ts
@@ -239,7 +239,7 @@ export const awkCommand2: Command = {
       } else {
         // awk parses fields with regex / FS — decode bytes to UTF-8 so
         // non-ASCII data isn't split mid-codepoint.
-        const lines = decodeBytesToUtf8(ctx.stdin).split("\n");
+        const lines = decodeBytesToUtf8(ctx.stdin.readAll()).split("\n");
         if (lines.length > 0 && lines[lines.length - 1] === "") {
           lines.pop();
         }

--- a/packages/just-bash/src/commands/base64/base64.ts
+++ b/packages/just-bash/src/commands/base64/base64.ts
@@ -34,7 +34,9 @@ async function readBinary(
     // Convert binary string directly to bytes without UTF-8 re-encoding
     return {
       ok: true,
-      data: Uint8Array.from(latin1FromBytes(ctx.stdin), (c) => c.charCodeAt(0)),
+      data: Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
+        c.charCodeAt(0),
+      ),
     };
   }
 
@@ -44,7 +46,9 @@ async function readBinary(
     if (file === "-") {
       // Convert binary string directly to bytes without UTF-8 re-encoding
       chunks.push(
-        Uint8Array.from(latin1FromBytes(ctx.stdin), (c) => c.charCodeAt(0)),
+        Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
+          c.charCodeAt(0),
+        ),
       );
       continue;
     }

--- a/packages/just-bash/src/commands/bash/bash.ts
+++ b/packages/just-bash/src/commands/bash/bash.ts
@@ -39,7 +39,7 @@ export const bashCommand: Command = {
     // No arguments - read script from stdin if available. Decode bytes — a
     // bash script's UTF-8 string literals must reach the parser as text.
     if (args.length === 0) {
-      const stdinText = decodeBytesToUtf8(ctx.stdin);
+      const stdinText = decodeBytesToUtf8(ctx.stdin.readAll());
       if (stdinText.trim()) {
         return executeScript(stdinText, "bash", [], ctx);
       }
@@ -91,7 +91,7 @@ export const shCommand: Command = {
     // No arguments - read script from stdin if available. Decode bytes — a
     // shell script's UTF-8 string literals must reach the parser as text.
     if (args.length === 0) {
-      const stdinText = decodeBytesToUtf8(ctx.stdin);
+      const stdinText = decodeBytesToUtf8(ctx.stdin.readAll());
       if (stdinText.trim()) {
         return executeScript(stdinText, "sh", [], ctx);
       }
@@ -162,7 +162,9 @@ async function executeScript(
   const result = await ctx.exec(scriptToRun, {
     env: positionalEnv,
     cwd: ctx.cwd,
-    stdin: latin1FromBytes(ctx.stdin),
+    // Forward stdin without consuming the outer stream — the nested
+    // exec seeds its own stream from this copy.
+    stdin: latin1FromBytes(ctx.stdin.peek()),
     stdinKind: "bytes",
     signal: ctx.signal,
   });

--- a/packages/just-bash/src/commands/column/column.ts
+++ b/packages/just-bash/src/commands/column/column.ts
@@ -172,12 +172,12 @@ export const column: Command = {
     // see follow-up.)
     let content: string;
     if (files.length === 0) {
-      content = decodeBytesToUtf8(ctx.stdin) ?? "";
+      content = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
     } else {
       const parts: string[] = [];
       for (const file of files) {
         if (file === "-") {
-          parts.push(decodeBytesToUtf8(ctx.stdin) ?? "");
+          parts.push(decodeBytesToUtf8(ctx.stdin.readAll()) ?? "");
         } else {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);
           const fileContent = await ctx.fs.readFile(filePath);

--- a/packages/just-bash/src/commands/comm/comm.ts
+++ b/packages/just-bash/src/commands/comm/comm.ts
@@ -80,7 +80,7 @@ export const commCommand: Command = {
     // compares equal regardless of which leg it came from.
     const readFile = async (file: string): Promise<string | null> => {
       if (file === "-") {
-        return decodeBytesToUtf8(ctx.stdin);
+        return decodeBytesToUtf8(ctx.stdin.readAll());
       }
       try {
         const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/diff/diff.ts
+++ b/packages/just-bash/src/commands/diff/diff.ts
@@ -58,10 +58,14 @@ export const diffCommand: Command = {
 
     // diff compares lines as strings. Normalize stdin (byte buffer) to
     // UTF-8 so it compares correctly against file content (utf8 by default).
+    // Read stdin once so `diff - -` compares stdin against itself (GNU
+    // behavior) instead of draining it on the first operand.
+    const stdinContent =
+      f1 === "-" || f2 === "-" ? decodeBytesToUtf8(ctx.stdin.readAll()) : "";
     try {
       c1 =
         f1 === "-"
-          ? decodeBytesToUtf8(ctx.stdin)
+          ? stdinContent
           : await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, f1));
     } catch {
       return {
@@ -74,7 +78,7 @@ export const diffCommand: Command = {
     try {
       c2 =
         f2 === "-"
-          ? decodeBytesToUtf8(ctx.stdin)
+          ? stdinContent
           : await ctx.fs.readFile(ctx.fs.resolvePath(ctx.cwd, f2));
     } catch {
       return {

--- a/packages/just-bash/src/commands/env/env.ts
+++ b/packages/just-bash/src/commands/env/env.ts
@@ -111,8 +111,10 @@ export const envCommand: Command = {
       cwd: ctx.cwd,
       env: mapToRecord(newEnv),
       replaceEnv: true,
-      stdin: latin1FromBytes(ctx.stdin),
-      // ctx.stdin is already byte-shaped — forward verbatim.
+      // Forward stdin to the subcommand without consuming the outer
+      // stream — the subcommand's exec gets its own copy. Bytes are
+      // already latin1-shaped; pass verbatim.
+      stdin: latin1FromBytes(ctx.stdin.peek()),
       stdinKind: "bytes",
       signal: ctx.signal,
       args: cmdArgs,

--- a/packages/just-bash/src/commands/expand/expand.ts
+++ b/packages/just-bash/src/commands/expand/expand.ts
@@ -218,7 +218,7 @@ export const expand: Command = {
     if (files.length === 0) {
       // expand counts column positions for tab-stop math; decode bytes so a
       // multibyte char counts as one column rather than 2–4.
-      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+      const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
       output = processContent(input, options);
     } else {
       for (const file of files) {

--- a/packages/just-bash/src/commands/expand/unexpand.ts
+++ b/packages/just-bash/src/commands/expand/unexpand.ts
@@ -260,7 +260,7 @@ export const unexpand: Command = {
     if (files.length === 0) {
       // unexpand counts column positions for tab-stop math; decode bytes so
       // a multibyte char doesn't pretend to be several columns wide.
-      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+      const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
       output = processContent(input, options);
     } else {
       for (const file of files) {

--- a/packages/just-bash/src/commands/fold/fold.ts
+++ b/packages/just-bash/src/commands/fold/fold.ts
@@ -244,7 +244,7 @@ export const fold: Command = {
     if (files.length === 0) {
       // Read from stdin. fold counts width in codepoints (and tab-stops),
       // so decode bytes — wrapping mid-multibyte would corrupt the data.
-      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+      const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
       output = processContent(input, options);
     } else {
       // Process each file

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -226,22 +226,26 @@ export const grepCommand: Command = {
       };
     }
 
-    // If no files and stdin is provided (including empty string), read from
-    // stdin. grep runs regex over text — decode bytes to UTF-8 so multibyte
-    // codepoints match `.` / character classes correctly.
-    if (files.length === 0 && ctx.stdin !== undefined) {
-      const result = searchContent(decodeBytesToUtf8(ctx.stdin), regex, {
-        invertMatch,
-        showLineNumbers,
-        countOnly,
-        filename: "",
-        onlyMatching,
-        beforeContext,
-        afterContext,
-        maxCount,
-        kResetGroup,
-        preFilter,
-      });
+    // If no files, read from stdin (even when empty). grep runs regex over
+    // text — decode bytes to UTF-8 so multibyte codepoints match `.` /
+    // character classes correctly.
+    if (files.length === 0) {
+      const result = searchContent(
+        decodeBytesToUtf8(ctx.stdin.readAll()),
+        regex,
+        {
+          invertMatch,
+          showLineNumbers,
+          countOnly,
+          filename: "",
+          onlyMatching,
+          beforeContext,
+          afterContext,
+          maxCount,
+          kResetGroup,
+          preFilter,
+        },
+      );
       if (quietMode) {
         return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };
       }

--- a/packages/just-bash/src/commands/gzip/gzip.ts
+++ b/packages/just-bash/src/commands/gzip/gzip.ts
@@ -288,7 +288,7 @@ async function processFile(
 
   // Handle stdin
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
       c.charCodeAt(0),
     );
     if (decompress) {
@@ -611,7 +611,7 @@ async function listFile(
   let inputData: Uint8Array;
 
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
       c.charCodeAt(0),
     );
   } else {
@@ -664,7 +664,7 @@ async function testFile(
   let inputData: Uint8Array;
 
   if (file === "-" || file === "") {
-    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+    inputData = Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
       c.charCodeAt(0),
     );
   } else {

--- a/packages/just-bash/src/commands/head/head-tail-shared.ts
+++ b/packages/just-bash/src/commands/head/head-tail-shared.ts
@@ -126,7 +126,7 @@ export async function processHeadTailFiles(
   // marked binary so the pipeline glue / redirects don't UTF-8 re-encode it.
   if (files.length === 0) {
     return {
-      stdout: contentProcessor(latin1FromBytes(ctx.stdin)),
+      stdout: contentProcessor(latin1FromBytes(ctx.stdin.readAll())),
       stderr: "",
       exitCode: 0,
       stdoutEncoding: "binary",

--- a/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
+++ b/packages/just-bash/src/commands/html-to-markdown/html-to-markdown.ts
@@ -98,7 +98,7 @@ export const htmlToMarkdownCommand: Command = {
     // default already.
     let input: string;
     if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = decodeBytesToUtf8(ctx.stdin);
+      input = decodeBytesToUtf8(ctx.stdin.readAll());
     } else {
       try {
         const filePath = ctx.fs.resolvePath(ctx.cwd, files[0]);

--- a/packages/just-bash/src/commands/join/join.ts
+++ b/packages/just-bash/src/commands/join/join.ts
@@ -294,7 +294,7 @@ export const join: Command = {
     const contents: string[] = [];
     for (const file of files) {
       if (file === "-") {
-        contents.push(decodeBytesToUtf8(ctx.stdin) ?? "");
+        contents.push(decodeBytesToUtf8(ctx.stdin.readAll()) ?? "");
       } else {
         const filePath = ctx.fs.resolvePath(ctx.cwd, file);
         const content = await ctx.fs.readFile(filePath);

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -332,7 +332,10 @@ export const jqCommand: Command = {
     if (nullInput) {
       // No input
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      inputs.push({ source: "stdin", content: decodeBytesToUtf8(ctx.stdin) });
+      inputs.push({
+        source: "stdin",
+        content: decodeBytesToUtf8(ctx.stdin.readAll()),
+      });
     } else {
       // Read all files in parallel using shared utility
       const result = await withDefenseContext("file read", () =>

--- a/packages/just-bash/src/commands/js-exec/js-exec.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.ts
@@ -598,18 +598,21 @@ export const jsExecCommand: Command = {
           exitCode: 2,
         };
       }
-    } else if (decodeBytesToUtf8(ctx.stdin).trim()) {
+    } else {
+      // readAll() consumes stdin, so read once and branch on the result.
       // Decode bytes — JS source can contain unicode identifiers and string
       // literals; running latin1 bytes as code corrupts them.
-      jsCode = decodeBytesToUtf8(ctx.stdin);
+      const stdinCode = decodeBytesToUtf8(ctx.stdin.readAll());
+      if (!stdinCode.trim()) {
+        return {
+          stdout: "",
+          stderr:
+            "js-exec: no input provided (use -c CODE or provide a script file)\n",
+          exitCode: 2,
+        };
+      }
+      jsCode = stdinCode;
       scriptPath = "<stdin>";
-    } else {
-      return {
-        stdout: "",
-        stderr:
-          "js-exec: no input provided (use -c CODE or provide a script file)\n",
-        exitCode: 2,
-      };
     }
 
     // Auto-detect module mode and type stripping from file extension

--- a/packages/just-bash/src/commands/md5sum/checksum.ts
+++ b/packages/just-bash/src/commands/md5sum/checksum.ts
@@ -170,7 +170,7 @@ export function createChecksumCommand(
       // through without decoding.
       const readBinary = async (file: string): Promise<Uint8Array | null> => {
         if (file === "-") {
-          return Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+          return Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
             c.charCodeAt(0),
           );
         }
@@ -190,7 +190,7 @@ export function createChecksumCommand(
           // Decode UTF-8 so non-ASCII filenames in the list survive.
           const content =
             file === "-"
-              ? decodeBytesToUtf8(ctx.stdin)
+              ? decodeBytesToUtf8(ctx.stdin.readAll())
               : await ctx.fs
                   .readFile(ctx.fs.resolvePath(ctx.cwd, file))
                   .catch(() => null);

--- a/packages/just-bash/src/commands/nl/nl.ts
+++ b/packages/just-bash/src/commands/nl/nl.ts
@@ -281,7 +281,7 @@ export const nl: Command = {
     if (files.length === 0) {
       // Read from stdin. nl reads files as utf8 by default; normalize stdin
       // to text so the line-numbered output is consistent with file inputs.
-      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+      const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
       const result = processContent(input, options, lineNumber);
       output = result.output;
     } else {

--- a/packages/just-bash/src/commands/od/od.ts
+++ b/packages/just-bash/src/commands/od/od.ts
@@ -49,7 +49,7 @@ async function odExecute(
 
   // Get input - from file or stdin. od is byte-oriented: dump the raw byte
   // buffer character-by-character, where each char is one byte.
-  let input: string = latin1FromBytes(ctx.stdin);
+  let input: string = latin1FromBytes(ctx.stdin.readAll());
 
   // Check for file argument
   if (fileArgs.length > 0 && fileArgs[0] !== "-") {

--- a/packages/just-bash/src/commands/paste/paste.ts
+++ b/packages/just-bash/src/commands/paste/paste.ts
@@ -63,7 +63,7 @@ export const pasteCommand: Command = {
     // paste reads files as UTF-8 text; normalize stdin to the same shape so
     // the joined output is consistent and the boundary doesn't see a mix of
     // latin1 byte buffer and Unicode codepoints.
-    const stdinText = decodeBytesToUtf8(ctx.stdin);
+    const stdinText = decodeBytesToUtf8(ctx.stdin.readAll());
     const stdinLines = stdinText ? stdinText.split("\n") : [""];
     if (stdinLines.length > 0 && stdinLines[stdinLines.length - 1] === "") {
       stdinLines.pop();

--- a/packages/just-bash/src/commands/python3/python3.queue-timeout-exploit.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.queue-timeout-exploit.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { resolveLimits } from "../../limits.js";
+import { StdinStream } from "../../stdin-stream.js";
 import type { CommandContext } from "../../types.js";
 
 type MockWorkerController = {
@@ -103,7 +103,7 @@ function createContextWithFs(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: EMPTY_BYTES,
+    stdin: new StdinStream(),
     limits: resolveLimits({ maxPythonTimeoutMs: timeoutMs }),
   };
 }

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -554,7 +554,7 @@ export const python3Command: Command = {
       // Empty stdin runs an empty program (exit 0) — matching CPython's
       // behavior in non-interactive contexts where no program is provided.
       // Decode bytes — Python source can hold unicode string literals.
-      pythonCode = decodeBytesToUtf8(ctx.stdin);
+      pythonCode = decodeBytesToUtf8(ctx.stdin.readAll());
       scriptPath = "-";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
@@ -578,16 +578,19 @@ export const python3Command: Command = {
           exitCode: 2,
         };
       }
-    } else if (decodeBytesToUtf8(ctx.stdin).trim()) {
-      pythonCode = decodeBytesToUtf8(ctx.stdin);
-      scriptPath = "<stdin>";
     } else {
-      return {
-        stdout: "",
-        stderr:
-          "python3: no input provided (use -c CODE, -m MODULE, or provide a script file)\n",
-        exitCode: 2,
-      };
+      // readAll() consumes stdin, so read once and branch on the result.
+      const stdinCode = decodeBytesToUtf8(ctx.stdin.readAll());
+      if (!stdinCode.trim()) {
+        return {
+          stdout: "",
+          stderr:
+            "python3: no input provided (use -c CODE, -m MODULE, or provide a script file)\n",
+          exitCode: 2,
+        };
+      }
+      pythonCode = stdinCode;
+      scriptPath = "<stdin>";
     }
 
     return executePython(pythonCode, ctx, scriptPath, parsed.scriptArgs);

--- a/packages/just-bash/src/commands/python3/python3.worker-protocol-abuse.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.worker-protocol-abuse.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
+import { StdinStream } from "../../stdin-stream.js";
 import type { CommandContext } from "../../types.js";
 
 type WorkerScript = (worker: {
@@ -99,7 +99,7 @@ function createContext(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: EMPTY_BYTES,
+    stdin: new StdinStream(),
     ...overrides,
   };
 }

--- a/packages/just-bash/src/commands/rev/rev.ts
+++ b/packages/just-bash/src/commands/rev/rev.ts
@@ -71,14 +71,14 @@ export const rev: Command = {
       // Read from stdin. rev reverses by codepoint, so decode bytes to UTF-8
       // first — reversing the latin1 bytes of a multibyte sequence would
       // shred valid UTF-8 into garbage.
-      const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+      const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
       output = processContent(input);
     } else {
       // Process each file
       for (const file of files) {
         if (file === "-") {
           // Dash means read from stdin
-          const input = decodeBytesToUtf8(ctx.stdin) ?? "";
+          const input = decodeBytesToUtf8(ctx.stdin.readAll()) ?? "";
           output += processContent(input);
         } else {
           const filePath = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -85,7 +85,7 @@ export async function executeSearch(
     try {
       let content: string;
       if (patternFile === "-") {
-        content = decodeBytesToUtf8(ctx.stdin);
+        content = decodeBytesToUtf8(ctx.stdin.readAll());
       } else {
         const filePath = ctx.fs.resolvePath(ctx.cwd, patternFile);
         content = await ctx.fs.readFile(filePath);

--- a/packages/just-bash/src/commands/sed/sed.ts
+++ b/packages/just-bash/src/commands/sed/sed.ts
@@ -543,7 +543,7 @@ export const sedCommand: Command = {
     // UTF-8 so multibyte sequences match as single chars rather than several
     // latin1 bytes.
     if (files.length === 0) {
-      content = decodeBytesToUtf8(ctx.stdin);
+      content = decodeBytesToUtf8(ctx.stdin.readAll());
       try {
         const result = await withDefenseContext("stdin processing", () =>
           processContent(content, commands, effectiveSilent, {
@@ -586,7 +586,7 @@ export const sedCommand: Command = {
         if (stdinConsumed) {
           fileContent = "";
         } else {
-          fileContent = decodeBytesToUtf8(ctx.stdin);
+          fileContent = decodeBytesToUtf8(ctx.stdin.readAll());
           stdinConsumed = true;
         }
       } else {

--- a/packages/just-bash/src/commands/split/split.ts
+++ b/packages/just-bash/src/commands/split/split.ts
@@ -345,7 +345,7 @@ export const split: Command = {
     // non-ASCII files.
     let content: string;
     if (inputFile === "-") {
-      content = latin1FromBytes(ctx.stdin) ?? "";
+      content = latin1FromBytes(ctx.stdin.readAll()) ?? "";
     } else {
       const filePath = ctx.fs.resolvePath(ctx.cwd, inputFile);
       try {

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.ts
@@ -542,7 +542,7 @@ export const sqlite3Command: Command = {
 
     // Get SQL from argument or stdin. SQL is text — decode bytes to UTF-8 so
     // string literals containing multibyte characters survive intact.
-    let sql = sqlArg || decodeBytesToUtf8(ctx.stdin).trim();
+    let sql = sqlArg || decodeBytesToUtf8(ctx.stdin.readAll()).trim();
     if (options.cmd) {
       sql = options.cmd + (sql ? `; ${sql}` : "");
     }

--- a/packages/just-bash/src/commands/sqlite3/sqlite3.worker-protocol-abuse.test.ts
+++ b/packages/just-bash/src/commands/sqlite3/sqlite3.worker-protocol-abuse.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EMPTY_BYTES } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
+import { StdinStream } from "../../stdin-stream.js";
 import type { CommandContext } from "../../types.js";
 import { _internals, sqlite3Command } from "./sqlite3.js";
 
@@ -59,7 +59,7 @@ function createContext(
       ["PATH", "/usr/bin:/bin"],
       ["IFS", " \t\n"],
     ]),
-    stdin: EMPTY_BYTES,
+    stdin: new StdinStream(),
     ...overrides,
   };
 }

--- a/packages/just-bash/src/commands/strings/strings.ts
+++ b/packages/just-bash/src/commands/strings/strings.ts
@@ -229,7 +229,9 @@ export const strings: Command = {
     // Pass latin1-shaped bytes directly so multibyte UTF-8 sequences in the
     // source aren't re-encoded by TextEncoder.
     const stdinBytes = (): Uint8Array =>
-      Uint8Array.from(latin1FromBytes(ctx.stdin) ?? "", (c) => c.charCodeAt(0));
+      Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()) ?? "", (c) =>
+        c.charCodeAt(0),
+      );
 
     if (files.length === 0) {
       // Read from stdin

--- a/packages/just-bash/src/commands/tac/tac.ts
+++ b/packages/just-bash/src/commands/tac/tac.ts
@@ -40,7 +40,7 @@ async function tacExecute(
   // Read from stdin. tac is byte-clean — splits on \n then reverses, so the
   // stdin path forwards the original latin1 bytes and must be marked "bytes"
   // (the file path above reads decoded text and stays text-shaped).
-  const lines = latin1FromBytes(ctx.stdin).split("\n");
+  const lines = latin1FromBytes(ctx.stdin.readAll()).split("\n");
   if (lines[lines.length - 1] === "") {
     lines.pop();
   }

--- a/packages/just-bash/src/commands/tar/tar.ts
+++ b/packages/just-bash/src/commands/tar/tar.ts
@@ -683,7 +683,7 @@ async function extractTarArchive(
     }
   } else {
     // Read from stdin - convert binary string directly to bytes without UTF-8 re-encoding
-    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
       c.charCodeAt(0),
     );
   }
@@ -923,7 +923,7 @@ async function listTarArchive(
     }
   } else {
     // Read from stdin - convert binary string directly to bytes without UTF-8 re-encoding
-    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin), (c) =>
+    archiveData = Uint8Array.from(latin1FromBytes(ctx.stdin.readAll()), (c) =>
       c.charCodeAt(0),
     );
   }

--- a/packages/just-bash/src/commands/tee/tee.ts
+++ b/packages/just-bash/src/commands/tee/tee.ts
@@ -32,7 +32,7 @@ export const teeCommand: Command = {
     const files = parsed.result.positional;
     // tee is byte-clean: stdin bytes are written to each file and the same
     // bytes pass through to stdout.
-    const content = latin1FromBytes(ctx.stdin);
+    const content = latin1FromBytes(ctx.stdin.readAll());
     let stderr = "";
     let exitCode = 0;
 

--- a/packages/just-bash/src/commands/time/time.ts
+++ b/packages/just-bash/src/commands/time/time.ts
@@ -117,8 +117,10 @@ export const timeCommand: Command = {
       result = await ctx.exec(shellJoinArgs([commandArgs[0]]), {
         env: mapToRecord(ctx.env),
         cwd: ctx.cwd,
-        stdin: latin1FromBytes(ctx.stdin),
-        // ctx.stdin is already byte-shaped — forward verbatim.
+        // Forward stdin to the subcommand without consuming the outer
+        // stream — the subcommand's exec gets its own copy. Bytes are
+        // already latin1-shaped; pass verbatim.
+        stdin: latin1FromBytes(ctx.stdin.peek()),
         stdinKind: "bytes",
         signal: ctx.signal,
         args: commandArgs.slice(1),

--- a/packages/just-bash/src/commands/timeout/timeout.ts
+++ b/packages/just-bash/src/commands/timeout/timeout.ts
@@ -134,8 +134,10 @@ export const timeoutCommand: Command = {
         .exec(shellJoinArgs([commandArgs[0]]), {
           cwd: ctx.cwd,
           signal: controller.signal,
-          stdin: latin1FromBytes(ctx.stdin),
-          // ctx.stdin is already byte-shaped — forward verbatim.
+          // Forward stdin to the subcommand without consuming the outer
+          // stream — the subcommand's exec gets its own copy. Bytes are
+          // already latin1-shaped; pass verbatim.
+          stdin: latin1FromBytes(ctx.stdin.peek()),
           stdinKind: "bytes",
           args: commandArgs.slice(1),
         })

--- a/packages/just-bash/src/commands/tr/tr.ts
+++ b/packages/just-bash/src/commands/tr/tr.ts
@@ -176,7 +176,7 @@ export const trCommand: Command = {
     // Translation operates on codepoints — set1 / set2 args are real Unicode
     // strings, so we must decode bytes to UTF-8 first, otherwise multibyte
     // chars don't match the SET they were spelled with.
-    const content = decodeBytesToUtf8(ctx.stdin);
+    const content = decodeBytesToUtf8(ctx.stdin.readAll());
 
     // Helper to check if character is in set1 (considering complement mode)
     const isInSet1 = (char: string): boolean => {

--- a/packages/just-bash/src/commands/xan/csv.ts
+++ b/packages/just-bash/src/commands/xan/csv.ts
@@ -90,7 +90,7 @@ export async function readCsvInput(
 
   // CSV is text; decode bytes so multibyte fields aren't split mid-codepoint.
   if (!file || file === "-") {
-    input = decodeBytesToUtf8(ctx.stdin);
+    input = decodeBytesToUtf8(ctx.stdin.readAll());
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/xan/xan-data.ts
+++ b/packages/just-bash/src/commands/xan/xan-data.ts
@@ -144,7 +144,7 @@ export async function cmdFixlengths(
   let input: string;
 
   if (!file || file === "-") {
-    input = decodeBytesToUtf8(ctx.stdin);
+    input = decodeBytesToUtf8(ctx.stdin.readAll());
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);
@@ -516,7 +516,7 @@ async function cmdFromJson(
   let input: string;
 
   if (!file || file === "-") {
-    input = decodeBytesToUtf8(ctx.stdin);
+    input = decodeBytesToUtf8(ctx.stdin.readAll());
   } else {
     try {
       const path = ctx.fs.resolvePath(ctx.cwd, file);

--- a/packages/just-bash/src/commands/xargs/xargs.ts
+++ b/packages/just-bash/src/commands/xargs/xargs.ts
@@ -97,7 +97,7 @@ export const xargsCommand: Command = {
     // (whitespace). xargs' delimiters (`\0`, ASCII whitespace, user-provided
     // single-byte delim) all live in the ASCII range, but the args produced
     // are passed onward as text — decode so multibyte filenames survive.
-    const stdinText = decodeBytesToUtf8(ctx.stdin);
+    const stdinText = decodeBytesToUtf8(ctx.stdin.readAll());
     let items: string[];
     if (nullSeparator) {
       items = stdinText.split("\0").filter((s) => s.length > 0);

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -290,7 +290,7 @@ export const yqCommand: Command = {
     if (options.nullInput) {
       input = "";
     } else if (files.length === 0 || (files.length === 1 && files[0] === "-")) {
-      input = decodeBytesToUtf8(ctx.stdin);
+      input = decodeBytesToUtf8(ctx.stdin.readAll());
     } else {
       try {
         const resolvedFilePath = ctx.fs.resolvePath(ctx.cwd, files[0]);

--- a/packages/just-bash/src/comparison-tests/fixtures/stdin-consumption.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/stdin-consumption.comparison.fixtures.json
@@ -1,0 +1,128 @@
+{
+  "01756da43756ce76": {
+    "command": "{ (read x; echo \"sub=$x\"); read y; echo \"y=$y\"; } < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "sub=a\ny=b\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1927c7b331c4a1ca": {
+    "command": "while read o; do\n  while read i; do echo \"$o-$i\"; done < inner.txt\ndone < outer.txt",
+    "files": {
+      "outer.txt": "1\n2\n",
+      "inner.txt": "x\ny\n"
+    },
+    "stdout": "1-x\n1-y\n2-x\n2-y\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2ec775de1e1c8550": {
+    "command": "printf 'x\\ny\\n' | cat - -",
+    "files": {},
+    "stdout": "x\ny\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2f33c1ff284be0b7": {
+    "command": "while read l; do echo \"$l\" | tr a-z A-Z; done < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "A\nB\nC\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "35f1a4f42d5d6b09": {
+    "command": "f() { cat; } < f.txt\nprintf 'PIPE\\n' | f",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "a\nb\nc\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "39a865051cd3a2ca": {
+    "command": "f() { echo ran; } < missing.txt\nf\necho \"rc=$?\"",
+    "files": {},
+    "stdout": "rc=1\n",
+    "stderr": "environment: line 1: missing.txt: No such file or directory\n",
+    "exitCode": 0
+  },
+  "4b9c91429aeeb51a": {
+    "command": "printf 'a\\nb\\nc\\n' | { while read l; do echo \"L:$l\"; cat > /dev/null; done; echo done; }",
+    "files": {},
+    "stdout": "L:a\ndone\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "682d7b4917567989": {
+    "command": "{ read x; echo \"x=$x\"; tr a-z A-Z; } < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "x=a\nB\nC\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "6b47fb983d362d03": {
+    "command": "printf 'a\\nb\\nc\\n' | while read l; do echo \"$l\" | cat; done",
+    "files": {},
+    "stdout": "a\nb\nc\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "735f94249ebd302b": {
+    "command": "{ read a; read b; echo \"$b:$a\"; } < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "b:a\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "8160a10d878359cf": {
+    "command": "while read l; do echo \"L:$l\"; cat; done < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "L:a\nb\nc\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "89be2b49146a8c1b": {
+    "command": "while read l; do echo \"L:$l\"; grep b; done < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "L:a\nb\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "92e40cd5403e307a": {
+    "command": "{ eval 'read x'; echo \"x=$x\"; read y; echo \"y=$y\"; } < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "x=a\ny=b\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "c1430ffea3cfc418": {
+    "command": "printf 'x\\ny\\n' | diff - -\necho \"rc=$?\"",
+    "files": {},
+    "stdout": "rc=0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "fcded2f07c04fadb": {
+    "command": "{ printf '' | cat; echo \"after:$(cat)\"; } < f.txt",
+    "files": {
+      "f.txt": "a\nb\nc\n"
+    },
+    "stdout": "after:a\nb\nc\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/stdin-consumption.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/stdin-consumption.comparison.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Stdin consumption semantics - Real Bash Comparison
+ *
+ * Verifies that stdin behaves like a shared file descriptor: reading
+ * consumes it for every holder (loop bodies, subshells, functions),
+ * pipeline stages get their own stdin, and redirects scope correctly.
+ */
+describe("Stdin consumption - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const threeLines = "a\nb\nc\n";
+
+  it("cat in while-read body drains the loop's redirected stdin", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `while read l; do echo "L:$l"; cat; done < f.txt`,
+    );
+  });
+
+  it("grep in while-read body drains the loop's redirected stdin", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `while read l; do echo "L:$l"; grep b; done < f.txt`,
+    );
+  });
+
+  it("tr in group body consumes the rest after read", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `{ read x; echo "x=$x"; tr a-z A-Z; } < f.txt`,
+    );
+  });
+
+  it("subshell read shares the stdin offset with the parent", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `{ (read x; echo "sub=$x"); read y; echo "y=$y"; } < f.txt`,
+    );
+  });
+
+  it("read consumption inside a pipeline stage survives the subshell", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `while read l; do echo "$l" | tr a-z A-Z; done < f.txt`,
+    );
+  });
+
+  it("piped while loop with a command pipeline in the body keeps position", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      `printf 'a\\nb\\nc\\n' | while read l; do echo "$l" | cat; done`,
+    );
+  });
+
+  it("function definition redirect wins over piped stdin", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `f() { cat; } < f.txt
+printf 'PIPE\\n' | f`,
+    );
+  });
+
+  it("function definition redirect with missing file errors without running body", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      `f() { echo ran; } < missing.txt
+f
+echo "rc=$?"`,
+    );
+  });
+
+  it("consecutive reads in a group each take one line", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `{ read a; read b; echo "$b:$a"; } < f.txt`,
+    );
+  });
+
+  it("cat - - reads stdin only once", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, `printf 'x\\ny\\n' | cat - -`);
+  });
+
+  it("diff - - compares stdin against itself", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      `printf 'x\\ny\\n' | diff - -
+echo "rc=$?"`,
+    );
+  });
+
+  it("empty pipeline output does not fall back to outer stdin", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `{ printf '' | cat; echo "after:$(cat)"; } < f.txt`,
+    );
+  });
+
+  it("nested while loops each consume their own redirect", async () => {
+    const env = await setupFiles(testDir, {
+      "outer.txt": "1\n2\n",
+      "inner.txt": "x\ny\n",
+    });
+    await compareOutputs(
+      env,
+      testDir,
+      `while read o; do
+  while read i; do echo "$o-$i"; done < inner.txt
+done < outer.txt`,
+    );
+  });
+
+  it("read after a body cat sees exhausted stdin and ends the loop", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      `printf 'a\\nb\\nc\\n' | { while read l; do echo "L:$l"; cat > /dev/null; done; echo done; }`,
+    );
+  });
+
+  it("eval body consumes the group's redirected stdin", async () => {
+    const env = await setupFiles(testDir, { "f.txt": threeLines });
+    await compareOutputs(
+      env,
+      testDir,
+      `{ eval 'read x'; echo "x=$x"; read y; echo "y=$y"; } < f.txt`,
+    );
+  });
+});

--- a/packages/just-bash/src/custom-commands.test.ts
+++ b/packages/just-bash/src/custom-commands.test.ts
@@ -7,7 +7,8 @@ import {
   isLazyCommand,
   type LazyCommand,
 } from "./custom-commands.js";
-import { decodeBytesToUtf8, EMPTY_BYTES } from "./encoding.js";
+import { decodeBytesToUtf8 } from "./encoding.js";
+import { StdinStream } from "./stdin-stream.js";
 import type { Command } from "./types.js";
 
 describe("custom-commands", () => {
@@ -83,7 +84,7 @@ describe("custom-commands", () => {
         fs: {} as never,
         cwd: "/",
         env: new Map(),
-        stdin: EMPTY_BYTES,
+        stdin: new StdinStream(),
       });
       expect(loadCount).toBe(1);
       expect(result1.stdout).toBe("lazy loaded\n");
@@ -93,7 +94,7 @@ describe("custom-commands", () => {
         fs: {} as never,
         cwd: "/",
         env: new Map(),
-        stdin: EMPTY_BYTES,
+        stdin: new StdinStream(),
       });
       expect(loadCount).toBe(1);
       expect(result2.stdout).toBe("lazy loaded\n");
@@ -117,7 +118,7 @@ describe("custom-commands", () => {
 
     it("custom command receives stdin from pipe", async () => {
       const wordcount = defineCommand("wordcount", async (_args, ctx) => {
-        const text = decodeBytesToUtf8(ctx.stdin);
+        const text = decodeBytesToUtf8(ctx.stdin.readAll());
         const words = text.trim().split(/\s+/).filter(Boolean).length;
         return { stdout: `${words}\n`, stderr: "", exitCode: 0 };
       });
@@ -237,7 +238,7 @@ describe("custom-commands", () => {
 
     it("custom command works in pipeline with built-in commands", async () => {
       const upper = defineCommand("upper", async (_args, ctx) => ({
-        stdout: decodeBytesToUtf8(ctx.stdin).toUpperCase(),
+        stdout: decodeBytesToUtf8(ctx.stdin.readAll()).toUpperCase(),
         stderr: "",
         exitCode: 0,
       }));

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -31,7 +31,7 @@ export {
 export type { CustomCommand, LazyCommand } from "./custom-commands.js";
 export { defineCommand } from "./custom-commands.js";
 // Byte/text boundary helpers — required by custom commands that read
-// `ctx.stdin` (an opaque `ByteString`).
+// `ctx.stdin` (a `StdinStream` whose reads return an opaque `ByteString`).
 export type { ByteString, OutputKind } from "./encoding.js";
 export {
   bytesOutput,
@@ -45,6 +45,9 @@ export {
   unsafeBytesFromLatin1,
 } from "./encoding.js";
 export { InMemoryFs } from "./fs/in-memory-fs/index.js";
+// Stdin stream — needed to construct a CommandContext outside the
+// interpreter (tests, custom harnesses).
+export { StdinStream } from "./stdin-stream.js";
 export type {
   BufferEncoding,
   CpOptions,

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -6,7 +6,6 @@
  */
 
 import { isBrowserExcludedCommand } from "../commands/browser-excluded.js";
-import { unsafeBytesFromLatin1 } from "../encoding.js";
 import { sanitizeErrorMessage } from "../fs/sanitize-error.js";
 import { awaitWithDefenseContext } from "../security/defense-context.js";
 import {
@@ -68,7 +67,6 @@ export type RunCommandFn = (
   commandName: string,
   args: string[],
   quotedArgs: boolean[],
-  stdin: string,
   skipFunctions?: boolean,
   useDefaultPath?: boolean,
   stdinSourceFd?: number,
@@ -85,7 +83,6 @@ export type BuildExportedEnvFn = () => Record<string, string>;
 export type ExecuteUserScriptFn = (
   scriptPath: string,
   args: string[],
-  stdin?: string,
 ) => Promise<ExecResult>;
 
 /**
@@ -107,7 +104,6 @@ export async function dispatchBuiltin(
   commandName: string,
   args: string[],
   _quotedArgs: boolean[],
-  stdin: string,
   skipFunctions: boolean,
   _useDefaultPath: boolean,
   stdinSourceFd: number,
@@ -147,7 +143,7 @@ export async function dispatchBuiltin(
   // In POSIX mode, eval is a special builtin that cannot be overridden by functions
   // In non-POSIX mode (bash default), functions can override eval
   if (commandName === "eval" && ctx.state.options.posix) {
-    return handleEval(ctx, args, stdin);
+    return handleEval(ctx, args);
   }
   if (commandName === "shift") {
     return handleShift(ctx, args);
@@ -177,10 +173,10 @@ export async function dispatchBuiltin(
     return handleSource(ctx, args);
   }
   if (commandName === "read") {
-    return handleRead(ctx, args, stdin, stdinSourceFd);
+    return handleRead(ctx, args, stdinSourceFd);
   }
   if (commandName === "mapfile" || commandName === "readarray") {
-    return handleMapfile(ctx, args, stdin);
+    return handleMapfile(ctx, args);
   }
   if (commandName === "declare" || commandName === "typeset") {
     return handleDeclare(ctx, args);
@@ -193,13 +189,13 @@ export async function dispatchBuiltin(
   if (!skipFunctions) {
     const func = ctx.state.functions.get(commandName);
     if (func) {
-      return callFunction(ctx, func, args, stdin);
+      return callFunction(ctx, func, args);
     }
   }
   // Simple builtins (can be overridden by functions)
   // eval: In non-POSIX mode, functions can override eval (handled above for POSIX mode)
   if (commandName === "eval") {
-    return handleEval(ctx, args, stdin);
+    return handleEval(ctx, args);
   }
   if (commandName === "cd") {
     return await handleCd(ctx, args);
@@ -214,10 +210,10 @@ export async function dispatchBuiltin(
     return handleLet(ctx, args);
   }
   if (commandName === "command") {
-    return handleCommandBuiltin(dispatchCtx, args, stdin);
+    return handleCommandBuiltin(dispatchCtx, args);
   }
   if (commandName === "builtin") {
-    return handleBuiltinBuiltin(dispatchCtx, args, stdin);
+    return handleBuiltinBuiltin(dispatchCtx, args);
   }
   if (commandName === "shopt") {
     return handleShopt(ctx, args);
@@ -228,7 +224,7 @@ export async function dispatchBuiltin(
       return OK;
     }
     const [cmd, ...rest] = args;
-    return runCommand(cmd, rest, [], stdin, false, false, -1);
+    return runCommand(cmd, rest, [], false, false, -1);
   }
   if (commandName === "wait") {
     // wait - wait for background jobs (stub: no-op in this context)
@@ -271,7 +267,6 @@ export async function dispatchBuiltin(
 async function handleCommandBuiltin(
   dispatchCtx: BuiltinDispatchContext,
   args: string[],
-  stdin: string,
 ): Promise<ExecResult> {
   const { ctx, runCommand } = dispatchCtx;
 
@@ -316,7 +311,7 @@ async function handleCommandBuiltin(
   // Run command without checking functions, but builtins are still available
   // Pass useDefaultPath to use /usr/bin:/bin instead of $PATH
   const [cmd, ...rest] = cmdArgs;
-  return runCommand(cmd, rest, [], stdin, true, useDefaultPath, -1);
+  return runCommand(cmd, rest, [], true, useDefaultPath, -1);
 }
 
 /**
@@ -325,7 +320,6 @@ async function handleCommandBuiltin(
 async function handleBuiltinBuiltin(
   dispatchCtx: BuiltinDispatchContext,
   args: string[],
-  stdin: string,
 ): Promise<ExecResult> {
   const { runCommand } = dispatchCtx;
 
@@ -349,7 +343,7 @@ async function handleBuiltinBuiltin(
   }
   const [, ...rest] = cmdArgs;
   // Run as builtin (recursive call, skip function lookup)
-  return runCommand(cmd, rest, [], stdin, true, false, -1);
+  return runCommand(cmd, rest, [], true, false, -1);
 }
 
 /**
@@ -360,7 +354,6 @@ export async function executeExternalCommand(
   dispatchCtx: BuiltinDispatchContext,
   commandName: string,
   args: string[],
-  stdin: string,
   useDefaultPath: boolean,
 ): Promise<ExecResult> {
   const { ctx, buildExportedEnv, executeUserScript } = dispatchCtx;
@@ -401,7 +394,7 @@ export async function executeExternalCommand(
       }
       ctx.state.hashTable.set(commandName, resolved.path);
     }
-    return await executeUserScript(resolved.path, args, stdin);
+    return await executeUserScript(resolved.path, args);
   }
   const { cmd, path: cmdPath } = resolved;
   // Add to hash table for PATH caching (only for non-path commands)
@@ -412,18 +405,6 @@ export async function executeExternalCommand(
     ctx.state.hashTable.set(commandName, cmdPath);
   }
 
-  // Use groupStdin as fallback if no stdin from redirections/pipeline —
-  // needed for commands inside groups/functions that receive stdin via
-  // heredoc. The pipeline glue (pipeline-execution.ts) and the
-  // stdin-source sites (heredoc, here-string, `< file`, options.stdin)
-  // are responsible for handing us a latin1-shaped byte buffer; we just
-  // brand it. Commands that decode their input internally (sed, jq,
-  // ...) return text via `textOutput()`, and the pipe / redirect layer
-  // converts to bytes on their behalf.
-  const effectiveStdin = unsafeBytesFromLatin1(
-    stdin || ctx.state.groupStdin || "",
-  );
-
   // Build exported environment for commands that need it (printenv, env, etc.)
   // Most builtins need access to the full env to modify state
   const exportedEnv = buildExportedEnv();
@@ -433,7 +414,11 @@ export async function executeExternalCommand(
     cwd: ctx.state.cwd,
     env: ctx.state.env,
     exportedEnv,
-    stdin: effectiveStdin,
+    // The scope's shared stdin stream, installed by the pipeline stage or
+    // stdin redirect (if any). Reading from it consumes input for every
+    // other holder of the stream — that's what makes `while read` loops
+    // over redirected stdin work when body commands also read stdin.
+    stdin: ctx.state.stdin,
     limits: ctx.limits,
     exec: ctx.execFn,
     fetch: ctx.fetch,

--- a/packages/just-bash/src/interpreter/builtins/compgen.ts
+++ b/packages/just-bash/src/interpreter/builtins/compgen.ts
@@ -472,7 +472,7 @@ export async function handleCompgen(
 
       try {
         // Call the function - errors during execution return exit code 1
-        const funcResult = await callFunction(ctx, func, funcArgs, "");
+        const funcResult = await callFunction(ctx, func, funcArgs);
 
         // Check if there was an error (e.g., division by zero)
         if (funcResult.exitCode !== 0) {

--- a/packages/just-bash/src/interpreter/builtins/complete.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/complete.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { StdinStream } from "../../stdin-stream.js";
 import type { InterpreterContext, InterpreterState } from "../types.js";
 import { handleComplete } from "./complete.js";
 
@@ -7,6 +8,7 @@ function createMockCtx(): InterpreterContext {
   const state: InterpreterState = {
     env: new Map(),
     cwd: "/",
+    stdin: new StdinStream(),
     previousDir: "/",
     functions: new Map(),
     localScopes: [],

--- a/packages/just-bash/src/interpreter/builtins/compopt.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/compopt.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { StdinStream } from "../../stdin-stream.js";
 import type { InterpreterContext, InterpreterState } from "../types.js";
 import { handleComplete } from "./complete.js";
 import { handleCompopt } from "./compopt.js";
@@ -8,6 +9,7 @@ function createMockCtx(): InterpreterContext {
   const state: InterpreterState = {
     env: new Map(),
     cwd: "/",
+    stdin: new StdinStream(),
     previousDir: "/",
     functions: new Map(),
     localScopes: [],

--- a/packages/just-bash/src/interpreter/builtins/eval.ts
+++ b/packages/just-bash/src/interpreter/builtins/eval.ts
@@ -19,7 +19,6 @@ import type { InterpreterContext } from "../types.js";
 export async function handleEval(
   ctx: InterpreterContext,
   args: string[],
-  stdin?: string,
 ): Promise<ExecResult> {
   // Handle options like bash does:
   // -- ends option processing
@@ -50,13 +49,9 @@ export async function handleEval(
     return OK;
   }
 
-  // Save and set groupStdin for piped eval commands
-  // This allows stdin from the pipeline to flow to commands within eval
-  const savedGroupStdin = ctx.state.groupStdin;
-  const effectiveStdin = stdin ?? ctx.state.groupStdin;
-  if (effectiveStdin !== undefined) {
-    ctx.state.groupStdin = effectiveStdin;
-  }
+  // Stdin (from a pipeline or redirect on the eval command itself) is
+  // already installed as the scope's shared stream, so commands inside
+  // the evaluated script consume it directly.
 
   try {
     // Parse and execute in the current environment
@@ -76,8 +71,5 @@ export async function handleEval(
       return failure(`bash: eval: ${(error as Error).message}\n`);
     }
     throw error;
-  } finally {
-    // Restore groupStdin
-    ctx.state.groupStdin = savedGroupStdin;
   }
 }

--- a/packages/just-bash/src/interpreter/builtins/mapfile.ts
+++ b/packages/just-bash/src/interpreter/builtins/mapfile.ts
@@ -13,6 +13,7 @@
  *   array      Array name (default: MAPFILE)
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { ExecResult } from "../../types.js";
 import { clearArray } from "../helpers/array.js";
 import { result } from "../helpers/result.js";
@@ -21,7 +22,6 @@ import type { InterpreterContext } from "../types.js";
 export function handleMapfile(
   ctx: InterpreterContext,
   args: string[],
-  stdin: string,
 ): ExecResult {
   // Parse options
   let delimiter = "\n";
@@ -62,15 +62,13 @@ export function handleMapfile(
     }
   }
 
-  // Use stdin from parameter, or fall back to groupStdin
-  let effectiveStdin = stdin;
-  if (!effectiveStdin && ctx.state.groupStdin !== undefined) {
-    effectiveStdin = ctx.state.groupStdin;
-  }
+  // mapfile consumes all of stdin, even when -n stops assigning early
+  // (matching the previous behavior of draining the shared input).
+  const effectiveStdin = latin1FromBytes(ctx.state.stdin.readAll());
 
   // Split input by delimiter
   const lines: string[] = [];
-  let remaining = effectiveStdin;
+  let remaining: string = effectiveStdin;
   let lineCount = 0;
   let skipped = 0;
   const maxArrayElements = ctx.limits?.maxArrayElements ?? 100000;
@@ -161,11 +159,6 @@ export function handleMapfile(
     `${arrayName}__length`,
     String(Math.max(existingLength, newEndIndex)),
   );
-
-  // Consume from groupStdin if we used it
-  if (ctx.state.groupStdin !== undefined && !stdin) {
-    ctx.state.groupStdin = "";
-  }
 
   return result("", "", 0);
 }

--- a/packages/just-bash/src/interpreter/builtins/read.ts
+++ b/packages/just-bash/src/interpreter/builtins/read.ts
@@ -2,6 +2,7 @@
  * read - Read a line of input builtin
  */
 
+import { latin1FromBytes } from "../../encoding.js";
 import type { ExecResult } from "../../types.js";
 import { clearArray } from "../helpers/array.js";
 import {
@@ -55,7 +56,6 @@ function encodeRwFdContent(
 export function handleRead(
   ctx: InterpreterContext,
   args: string[],
-  stdin: string,
   stdinSourceFd = -1,
 ): ExecResult {
   // Parse options
@@ -263,9 +263,11 @@ export function handleRead(
     return result("", "", 1);
   }
 
-  // Use stdin from parameter, or fall back to groupStdin (for piped groups/while loops)
-  // If -u is specified, use the file descriptor content instead
-  let effectiveStdin = stdin;
+  // Read from the scope's stdin stream without consuming it yet — read is
+  // a partial consumer: it parses a line, then advances the shared stream
+  // by exactly the bytes it used so the next reader picks up after it.
+  // If -u is specified, use the file descriptor content instead.
+  let effectiveStdin: string;
 
   if (fileDescriptor >= 0) {
     // Read from specified file descriptor
@@ -274,8 +276,10 @@ export function handleRead(
     } else {
       effectiveStdin = "";
     }
-  } else if (!effectiveStdin && ctx.state.groupStdin !== undefined) {
-    effectiveStdin = ctx.state.groupStdin;
+  } else {
+    // read does byte-position math over the buffer, so keep the latin1
+    // byte view rather than decoding to text.
+    effectiveStdin = latin1FromBytes(ctx.state.stdin.peek());
   }
 
   // Handle -d '' (empty delimiter) - reads until NUL byte
@@ -308,8 +312,8 @@ export function handleRead(
           );
         }
       }
-    } else if (ctx.state.groupStdin !== undefined && !stdin) {
-      ctx.state.groupStdin = effectiveStdin.substring(bytesConsumed);
+    } else {
+      ctx.state.stdin.advance(bytesConsumed);
     }
   };
 

--- a/packages/just-bash/src/interpreter/control-flow.ts
+++ b/packages/just-bash/src/interpreter/control-flow.ts
@@ -15,11 +15,9 @@ import type {
   CaseNode,
   CStyleForNode,
   ForNode,
-  HereDocNode,
   IfNode,
   UntilNode,
   WhileNode,
-  WordNode,
 } from "../ast/types.js";
 import type { ExecResult } from "../types.js";
 import { evaluateArithmetic } from "./arithmetic.js";
@@ -258,48 +256,15 @@ export async function executeCStyleFor(
 export async function executeWhile(
   ctx: InterpreterContext,
   node: WhileNode,
-  stdin = "",
 ): Promise<ExecResult> {
   let stdout = "";
   let stderr = "";
   let exitCode = 0;
   let iterations = 0;
 
-  // Process here-doc redirections to get stdin content
-  let effectiveStdin = stdin;
-  for (const redir of node.redirections) {
-    if (
-      (redir.operator === "<<" || redir.operator === "<<-") &&
-      redir.target.type === "HereDoc"
-    ) {
-      const hereDoc = redir.target as HereDocNode;
-      let content = await expandWord(ctx, hereDoc.content);
-      if (hereDoc.stripTabs) {
-        content = content
-          .split("\n")
-          .map((line) => line.replace(/^\t+/, ""))
-          .join("\n");
-      }
-      effectiveStdin = content;
-    } else if (redir.operator === "<<<" && redir.target.type === "Word") {
-      effectiveStdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
-    } else if (redir.operator === "<" && redir.target.type === "Word") {
-      try {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        effectiveStdin = await ctx.fs.readFile(filePath);
-      } catch {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        return failure(`bash: ${target}: No such file or directory\n`);
-      }
-    }
-  }
-
-  // Save and set groupStdin for piped while loops
-  const savedGroupStdin = ctx.state.groupStdin;
-  if (effectiveStdin) {
-    ctx.state.groupStdin = effectiveStdin;
-  }
+  // Stdin redirections (<, <<, <<<) were already resolved and installed
+  // as the scope's stdin stream by the command dispatcher; body commands
+  // (read, cat, ...) consume it from ctx.state.stdin by reference.
 
   ctx.state.loopDepth++;
   try {
@@ -390,7 +355,6 @@ export async function executeWhile(
     }
   } finally {
     ctx.state.loopDepth--;
-    ctx.state.groupStdin = savedGroupStdin;
   }
 
   return result(stdout, stderr, exitCode);

--- a/packages/just-bash/src/interpreter/functions.ts
+++ b/packages/just-bash/src/interpreter/functions.ts
@@ -6,19 +6,15 @@
  * - Function calls (with positional parameters and local scopes)
  */
 
-import type {
-  FunctionDefNode,
-  HereDocNode,
-  RedirectionNode,
-  WordNode,
-} from "../ast/types.js";
+import type { FunctionDefNode } from "../ast/types.js";
+import { StdinStream } from "../stdin-stream.js";
 import type { ExecResult } from "../types.js";
 import { clearLocalVarStackForScope } from "./builtins/variable-assignment.js";
 import { ExitError, ReturnError } from "./errors.js";
-import { expandWord } from "./expansion.js";
 import { OK, result, throwExecutionLimit } from "./helpers/result.js";
 import { POSIX_SPECIAL_BUILTINS } from "./helpers/shell-constants.js";
 import { applyRedirections, preExpandRedirectTargets } from "./redirections.js";
+import { resolveStdinRedirections, withStdin } from "./stdin-redirect.js";
 import type { InterpreterContext } from "./types.js";
 
 export function executeFunctionDef(
@@ -41,56 +37,10 @@ export function executeFunctionDef(
   return OK;
 }
 
-/**
- * Process input redirections to get stdin content for function calls.
- * Handles heredocs (<<, <<-), here-strings (<<<), and file input (<).
- */
-async function processInputRedirections(
-  ctx: InterpreterContext,
-  redirections: RedirectionNode[],
-): Promise<string> {
-  let stdin = "";
-
-  for (const redir of redirections) {
-    if (
-      (redir.operator === "<<" || redir.operator === "<<-") &&
-      redir.target.type === "HereDoc"
-    ) {
-      const hereDoc = redir.target as HereDocNode;
-      let content = await expandWord(ctx, hereDoc.content);
-      // <<- strips leading tabs from each line
-      if (hereDoc.stripTabs) {
-        content = content
-          .split("\n")
-          .map((line) => line.replace(/^\t+/, ""))
-          .join("\n");
-      }
-      // Only handle fd 0 (stdin) for now
-      const fd = redir.fd ?? 0;
-      if (fd === 0) {
-        stdin = content;
-      }
-    } else if (redir.operator === "<<<" && redir.target.type === "Word") {
-      stdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
-    } else if (redir.operator === "<" && redir.target.type === "Word") {
-      const target = await expandWord(ctx, redir.target as WordNode);
-      const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-      try {
-        stdin = await ctx.fs.readFile(filePath);
-      } catch {
-        // File not found - stdin remains unchanged
-      }
-    }
-  }
-
-  return stdin;
-}
-
 export async function callFunction(
   ctx: InterpreterContext,
   func: FunctionDefNode,
   args: string[],
-  stdin = "",
   callLine?: number,
 ): Promise<ExecResult> {
   ctx.state.callDepth++;
@@ -206,14 +156,25 @@ export async function callFunction(
   }
 
   try {
-    // Process redirections on the function definition to get stdin
-    // Only use redirection-based stdin if no pipeline stdin was passed
-    const redirectionStdin = await processInputRedirections(
+    // Stdin redirections on the function definition (`f() { ...; } < file`)
+    // install a fresh stream for the call, overriding any inherited/piped
+    // stdin — matching bash, where the definition's redirect is applied
+    // each time the function runs. Without one, the body inherits the
+    // caller's stream by reference.
+    const resolvedStdin = await resolveStdinRedirections(
       ctx,
       func.redirections,
     );
-    const effectiveStdin = stdin || redirectionStdin;
-    const execResult = await ctx.executeCommand(func.body, effectiveStdin);
+    if ("error" in resolvedStdin) {
+      cleanup();
+      return resolvedStdin.error;
+    }
+    const runBody = (): Promise<ExecResult> =>
+      ctx.executeCommand(func.body, null);
+    const execResult =
+      resolvedStdin.stdin !== null
+        ? await withStdin(ctx, new StdinStream(resolvedStdin.stdin), runBody)
+        : await runBody();
     cleanup();
     // Apply output redirections from the function definition using pre-expanded targets
     // e.g., fun() { echo hi; } 1>&2 should redirect output to stderr when called

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -15,7 +15,6 @@ import type {
   CommandNode,
   ConditionalCommandNode,
   GroupNode,
-  HereDocNode,
   PipelineNode,
   ScriptNode,
   SimpleCommandNode,
@@ -23,12 +22,7 @@ import type {
   SubshellNode,
   WordNode,
 } from "../ast/types.js";
-import {
-  decodedTextFromResult,
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-  readBytesFrom,
-} from "../encoding.js";
+import { decodedTextFromResult } from "../encoding.js";
 import type { IFileSystem } from "../fs/interface.js";
 import { mapToRecord } from "../helpers/env.js";
 import type { ExecutionLimits } from "../limits.js";
@@ -38,6 +32,7 @@ import {
   DefenseInDepthBox,
   SecurityViolationError,
 } from "../security/defense-in-depth-box.js";
+import { StdinStream } from "../stdin-stream.js";
 import type {
   CommandRegistry,
   ExecResult,
@@ -91,10 +86,7 @@ import {
   throwExecutionLimit,
 } from "./helpers/result.js";
 import { isPosixSpecialBuiltin } from "./helpers/shell-constants.js";
-import {
-  isWordLiteralMatch,
-  parseRwFdContent,
-} from "./helpers/word-matching.js";
+import { isWordLiteralMatch } from "./helpers/word-matching.js";
 import { traceSimpleCommand } from "./helpers/xtrace.js";
 import { executePipeline as executePipelineHelper } from "./pipeline-execution.js";
 import {
@@ -103,6 +95,11 @@ import {
   processFdVariableRedirections,
 } from "./redirections.js";
 import { processAssignments } from "./simple-command-assignments.js";
+import {
+  resolveStdinRedirections,
+  withStdin,
+  withStdinRedirects,
+} from "./stdin-redirect.js";
 import {
   executeGroup as executeGroupHelper,
   executeSubshell as executeSubshellHelper,
@@ -375,9 +372,8 @@ export class Interpreter {
   private async executeUserScript(
     scriptPath: string,
     args: string[],
-    stdin = "",
   ): Promise<ExecResult> {
-    return executeUserScriptHelper(this.ctx, scriptPath, args, stdin, (ast) =>
+    return executeUserScriptHelper(this.ctx, scriptPath, args, (ast) =>
       this.executeScript(ast),
     );
   }
@@ -484,37 +480,65 @@ export class Interpreter {
   }
 
   private async executePipeline(node: PipelineNode): Promise<ExecResult> {
-    return executePipelineHelper(this.ctx, node, (cmd, stdin) =>
-      this.executeCommand(cmd, stdin),
+    return executePipelineHelper(this.ctx, node, (cmd, pipeStdin) =>
+      this.executeCommand(cmd, pipeStdin),
     );
   }
 
   private async executeCommand(
     node: CommandNode,
-    stdin: string,
+    pipeStdin: StdinStream | null,
   ): Promise<ExecResult> {
     this.assertDefenseContext("command");
 
     this.ctx.coverage?.hit(`bash:cmd:${node.type}`);
+
+    // A pipeline stage's stdin (the previous stage's stdout) is installed
+    // for the whole node — simple or compound — so everything below reads
+    // the same shared stream. A `null` means "inherit the enclosing stdin"
+    // (first stage / single command).
+    if (pipeStdin) {
+      return withStdin(this.ctx, pipeStdin, () => this.dispatchCommand(node));
+    }
+    return this.dispatchCommand(node);
+  }
+
+  private async dispatchCommand(node: CommandNode): Promise<ExecResult> {
     switch (node.type) {
       case "SimpleCommand":
-        return this.executeSimpleCommand(node, stdin);
+        return this.executeSimpleCommand(node);
       case "If":
-        return executeIf(this.ctx, node);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeIf(this.ctx, node),
+        );
       case "For":
-        return executeFor(this.ctx, node);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeFor(this.ctx, node),
+        );
       case "CStyleFor":
-        return executeCStyleFor(this.ctx, node);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeCStyleFor(this.ctx, node),
+        );
       case "While":
-        return executeWhile(this.ctx, node, stdin);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeWhile(this.ctx, node),
+        );
       case "Until":
-        return executeUntil(this.ctx, node);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeUntil(this.ctx, node),
+        );
       case "Case":
-        return executeCase(this.ctx, node);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          executeCase(this.ctx, node),
+        );
       case "Subshell":
-        return this.executeSubshell(node, stdin);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          this.executeSubshell(node),
+        );
       case "Group":
-        return this.executeGroup(node, stdin);
+        return withStdinRedirects(this.ctx, node.redirections, () =>
+          this.executeGroup(node),
+        );
       case "FunctionDef":
         return executeFunctionDef(this.ctx, node);
       case "ArithmeticCommand":
@@ -528,10 +552,9 @@ export class Interpreter {
 
   private async executeSimpleCommand(
     node: SimpleCommandNode,
-    stdin: string,
   ): Promise<ExecResult> {
     try {
-      return await this.executeSimpleCommandInner(node, stdin);
+      return await this.executeSimpleCommandInner(node);
     } catch (error) {
       if (error instanceof GlobError) {
         // GlobError from failglob should return exit code 1 with error message
@@ -545,7 +568,6 @@ export class Interpreter {
 
   private async executeSimpleCommandInner(
     node: SimpleCommandNode,
-    stdin: string,
   ): Promise<ExecResult> {
     // Update currentLine for $LINENO
     if (node.line !== undefined) {
@@ -656,102 +678,21 @@ export class Interpreter {
       return fdVarError;
     }
 
-    // Track source FD for stdin from read-write file descriptors
-    // This allows the read builtin to update the FD's position after reading
-    let stdinSourceFd = -1;
-
-    for (const redir of node.redirections) {
-      if (
-        (redir.operator === "<<" || redir.operator === "<<-") &&
-        redir.target.type === "HereDoc"
-      ) {
-        const hereDoc = redir.target as HereDocNode;
-        let content = await expandWord(this.ctx, hereDoc.content);
-        // <<- strips leading tabs from each line
-        if (hereDoc.stripTabs) {
-          content = content
-            .split("\n")
-            .map((line) => line.replace(/^\t+/, ""))
-            .join("\n");
-        }
-        // Heredocs land here as JS Unicode text; the pipeline contract
-        // expects stdin to be a latin1 byte buffer. UTF-8 encode the
-        // text once at the source so byte consumers downstream see real
-        // bytes and binary writes don't truncate codepoints to their
-        // low byte.
-        content = latin1FromBytes(encodeUtf8ToBytes(content));
-        // If this is a non-standard fd (not 0), store in fileDescriptors for -u option
-        const fd = redir.fd ?? 0;
-        if (fd !== 0) {
-          if (!this.ctx.state.fileDescriptors) {
-            this.ctx.state.fileDescriptors = new Map();
-          }
-          checkFdLimit(this.ctx);
-          this.ctx.state.fileDescriptors.set(fd, content);
-        } else {
-          stdin = content;
-        }
-        continue;
+    // Resolve stdin redirections (<, <<, <<-, <<<, <&) for this command.
+    // A resolved redirect installs a fresh stream scoped to the command;
+    // otherwise the command inherits the enclosing stdin.
+    const resolvedStdin = await resolveStdinRedirections(
+      this.ctx,
+      node.redirections,
+    );
+    if ("error" in resolvedStdin) {
+      for (const [name, value] of tempAssignments) {
+        if (value === undefined) this.ctx.state.env.delete(name);
+        else this.ctx.state.env.set(name, value);
       }
-
-      if (redir.operator === "<<<" && redir.target.type === "Word") {
-        // Same byte-encoding step as heredoc — here-strings deliver
-        // JS Unicode text and need to land as bytes.
-        stdin = latin1FromBytes(
-          encodeUtf8ToBytes(
-            `${await expandWord(this.ctx, redir.target as WordNode)}\n`,
-          ),
-        );
-        continue;
-      }
-
-      if (redir.operator === "<" && redir.target.type === "Word") {
-        try {
-          const target = await expandWord(this.ctx, redir.target as WordNode);
-          const filePath = this.ctx.fs.resolvePath(this.ctx.state.cwd, target);
-          // Read as raw bytes — `<` is a transparent file-to-stdin
-          // pipe and we don't want the smart-utf8 read path turning
-          // valid bytes into U+FFFD replacement chars.
-          stdin = latin1FromBytes(await readBytesFrom(this.ctx.fs, filePath));
-        } catch {
-          const target = await expandWord(this.ctx, redir.target as WordNode);
-          for (const [name, value] of tempAssignments) {
-            if (value === undefined) this.ctx.state.env.delete(name);
-            else this.ctx.state.env.set(name, value);
-          }
-          return failure(`bash: ${target}: No such file or directory\n`);
-        }
-      }
-
-      // Handle <& input redirection from file descriptor
-      if (redir.operator === "<&" && redir.target.type === "Word") {
-        const target = await expandWord(this.ctx, redir.target as WordNode);
-        const sourceFd = Number.parseInt(target, 10);
-        if (!Number.isNaN(sourceFd) && this.ctx.state.fileDescriptors) {
-          const fdContent = this.ctx.state.fileDescriptors.get(sourceFd);
-          if (fdContent !== undefined) {
-            // Handle different FD content formats
-            if (fdContent.startsWith("__rw__:")) {
-              // Read/write mode: format is __rw__:pathLength:path:position:content
-              const parsed = parseRwFdContent(fdContent);
-              if (parsed) {
-                // Return content starting from current position
-                stdin = parsed.content.slice(parsed.position);
-                stdinSourceFd = sourceFd;
-              }
-            } else if (
-              fdContent.startsWith("__file__:") ||
-              fdContent.startsWith("__file_append__:")
-            ) {
-              // These are output-only, can't read from them
-            } else {
-              // Plain content (from exec N< file or here-docs)
-              stdin = fdContent;
-            }
-          }
-        }
-      }
+      return resolvedStdin.error;
     }
+    const { stdin: redirectStdin, stdinSourceFd } = resolvedStdin;
 
     const commandName = await expandWord(this.ctx, node.name);
 
@@ -844,15 +785,18 @@ export class Interpreter {
         if (args.length > 0) {
           const newCommandName = args.shift() as string;
           quotedArgs.shift();
-          return await this.runCommand(
-            newCommandName,
-            args,
-            quotedArgs,
-            stdin,
-            false,
-            false,
-            stdinSourceFd,
-          );
+          const run = (): Promise<ExecResult> =>
+            this.runCommand(
+              newCommandName,
+              args,
+              quotedArgs,
+              false,
+              false,
+              stdinSourceFd,
+            );
+          return redirectStdin !== null
+            ? await withStdin(this.ctx, new StdinStream(redirectStdin), run)
+            : await run();
         }
         // No args - treat as no-op (status 0)
         // Preserve lastExitCode for command subs like $(exit 42)
@@ -1069,15 +1013,19 @@ export class Interpreter {
     let controlFlowError: BreakError | ContinueError | null = null;
 
     try {
-      cmdResult = await this.runCommand(
-        commandName,
-        args,
-        quotedArgs,
-        stdin,
-        false,
-        false,
-        stdinSourceFd,
-      );
+      const run = (): Promise<ExecResult> =>
+        this.runCommand(
+          commandName,
+          args,
+          quotedArgs,
+          false,
+          false,
+          stdinSourceFd,
+        );
+      cmdResult =
+        redirectStdin !== null
+          ? await withStdin(this.ctx, new StdinStream(redirectStdin), run)
+          : await run();
     } catch (error) {
       // For break/continue, we still need to apply redirections before propagating
       // This handles cases like "break > file" where the file should be created
@@ -1181,17 +1129,16 @@ export class Interpreter {
     commandName: string,
     args: string[],
     quotedArgs: boolean[],
-    stdin: string,
     skipFunctions = false,
     useDefaultPath = false,
     stdinSourceFd = -1,
   ): Promise<ExecResult> {
     const dispatchCtx: BuiltinDispatchContext = {
       ctx: this.ctx,
-      runCommand: (name, a, qa, s, sf, udp, ssf) =>
-        this.runCommand(name, a, qa, s, sf, udp, ssf),
+      runCommand: (name, a, qa, sf, udp, ssf) =>
+        this.runCommand(name, a, qa, sf, udp, ssf),
       buildExportedEnv: () => this.buildExportedEnv(),
-      executeUserScript: (path, a, s) => this.executeUserScript(path, a, s),
+      executeUserScript: (path, a) => this.executeUserScript(path, a),
     };
 
     // Try builtin dispatch first
@@ -1200,7 +1147,6 @@ export class Interpreter {
       commandName,
       args,
       quotedArgs,
-      stdin,
       skipFunctions,
       useDefaultPath,
       stdinSourceFd,
@@ -1215,7 +1161,6 @@ export class Interpreter {
       dispatchCtx,
       commandName,
       args,
-      stdin,
       useDefaultPath,
     );
   }
@@ -1231,17 +1176,14 @@ export class Interpreter {
     return findCommandInPathHelper(this.ctx, commandName);
   }
 
-  private async executeSubshell(
-    node: SubshellNode,
-    stdin = "",
-  ): Promise<ExecResult> {
-    return executeSubshellHelper(this.ctx, node, stdin, (stmt) =>
+  private async executeSubshell(node: SubshellNode): Promise<ExecResult> {
+    return executeSubshellHelper(this.ctx, node, (stmt) =>
       this.executeStatement(stmt),
     );
   }
 
-  private async executeGroup(node: GroupNode, stdin = ""): Promise<ExecResult> {
-    return executeGroupHelper(this.ctx, node, stdin, (stmt) =>
+  private async executeGroup(node: GroupNode): Promise<ExecResult> {
+    return executeGroupHelper(this.ctx, node, (stmt) =>
       this.executeStatement(stmt),
     );
   }

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -11,17 +11,22 @@ import {
   stdoutAsBytes,
 } from "../encoding.js";
 import { _performanceNow } from "../security/trusted-globals.js";
+import { StdinStream } from "../stdin-stream.js";
 import type { ExecResult } from "../types.js";
 import { BadSubstitutionError, ErrexitError, ExitError } from "./errors.js";
 import { OK } from "./helpers/result.js";
 import type { InterpreterContext } from "./types.js";
 
 /**
- * Type for executeCommand callback
+ * Type for executeCommand callback.
+ *
+ * `pipeStdin` is the stream carrying the previous stage's output, or
+ * `null` for the first stage / a single command, which inherits the
+ * enclosing stdin.
  */
 export type ExecuteCommandFn = (
   node: CommandNode,
-  stdin: string,
+  pipeStdin: StdinStream | null,
 ) => Promise<ExecResult>;
 
 /**
@@ -35,7 +40,9 @@ export async function executePipeline(
   // Record start time for timed pipelines
   const startTime = node.timed ? _performanceNow() : 0;
 
-  let stdin = "";
+  // The next stage's stdin; null means "inherit the enclosing stdin"
+  // (only the first stage inherits, matching bash fd inheritance).
+  let pipeStdin: StdinStream | null = null;
   let lastResult: ExecResult = OK;
   let pipefailExitCode = 0; // Track rightmost failing command
   const pipestatusExitCodes: number[] = []; // Track all exit codes for PIPESTATUS
@@ -50,21 +57,12 @@ export async function executePipeline(
   for (let i = 0; i < node.commands.length; i++) {
     const command = node.commands[i];
     const isLast = i === node.commands.length - 1;
-    const isFirst = i === 0;
 
     // In a multi-command pipeline, each command runs in a subshell context
     // where $_ starts empty (subshells don't inherit $_ from parent in same way)
     if (isMultiCommandPipeline) {
       // Clear $_ for each pipeline command - they each get fresh subshell context
       ctx.state.lastArg = "";
-
-      // After the first command, clear groupStdin so subsequent commands
-      // only see stdin from the pipeline (even if empty), not the original groupStdin
-      // This prevents commands like head from incorrectly falling back to groupStdin
-      // when they receive empty output from a previous command (e.g., grep with no matches)
-      if (!isFirst) {
-        ctx.state.groupStdin = undefined;
-      }
     }
 
     // Determine if this command runs in a subshell context
@@ -79,7 +77,7 @@ export async function executePipeline(
 
     let result: ExecResult;
     try {
-      result = await executeCommand(command, stdin);
+      result = await executeCommand(command, pipeStdin);
     } catch (error) {
       // BadSubstitutionError should fail the command but not abort the script
       if (error instanceof BadSubstitutionError) {
@@ -140,12 +138,13 @@ export async function executePipeline(
         // |& pipes stderr + stdout. stderr is text (no producer marks it
         // binary today); UTF-8 encode it before concatenating with the
         // stdout bytes so the merged stream is byte-shaped end-to-end.
-        stdin =
+        pipeStdin = new StdinStream(
           latin1FromBytes(encodeUtf8ToBytes(result.stderr)) +
-          latin1FromBytes(stdoutAsBytes(result));
+            latin1FromBytes(stdoutAsBytes(result)),
+        );
       } else {
         // Regular | only pipes stdout; stderr goes to the parent
-        stdin = latin1FromBytes(stdoutAsBytes(result));
+        pipeStdin = new StdinStream(latin1FromBytes(stdoutAsBytes(result)));
         accumulatedStderr += result.stderr;
       }
       lastResult = {

--- a/packages/just-bash/src/interpreter/stdin-redirect.ts
+++ b/packages/just-bash/src/interpreter/stdin-redirect.ts
@@ -1,0 +1,197 @@
+/**
+ * Stdin Redirect Resolution
+ *
+ * The single implementation of "what does fd 0 contain?" for every
+ * construct that accepts stdin redirections: simple commands, compound
+ * commands (if/for/while/until/case), subshells, and groups.
+ *
+ * Resolution produces latin1-shaped byte content (per the pipeline
+ * contract in encoding.ts); installation wraps it in a `StdinStream`
+ * scoped to the construct via `withStdin`. Nothing outside this module
+ * needs to know how heredocs, here-strings, `< file`, or `<&N` turn
+ * into stdin bytes.
+ */
+
+import type { HereDocNode, RedirectionNode, WordNode } from "../ast/types.js";
+import {
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  readBytesFrom,
+} from "../encoding.js";
+import { StdinStream } from "../stdin-stream.js";
+import type { ExecResult } from "../types.js";
+import { expandWord } from "./expansion.js";
+import { checkFdLimit, failure } from "./helpers/result.js";
+import { parseRwFdContent } from "./helpers/word-matching.js";
+import type { InterpreterContext } from "./types.js";
+
+export interface ResolvedStdin {
+  /**
+   * Latin1 byte content for fd 0, or null when the redirections carry no
+   * stdin redirect (caller keeps its inherited stream).
+   */
+  stdin: string | null;
+  /**
+   * When stdin came from `<&N` on a read-write fd, the source fd number so
+   * `read` can advance the fd's stored position. -1 otherwise.
+   */
+  stdinSourceFd: number;
+}
+
+export type ResolveStdinResult = ResolvedStdin | { error: ExecResult };
+
+/**
+ * Resolve `<<`, `<<-`, `<<<`, `<`, and `<&` redirections to stdin content.
+ *
+ * Processes redirections left to right (last stdin redirect wins, matching
+ * bash). Heredocs targeting a non-zero fd are stored in the fd table for
+ * `read -u` instead of becoming stdin.
+ *
+ * Returns `{ error }` when a `< file` target doesn't exist; the caller
+ * returns it without executing the construct.
+ */
+export async function resolveStdinRedirections(
+  ctx: InterpreterContext,
+  redirections: RedirectionNode[],
+): Promise<ResolveStdinResult> {
+  let stdin: string | null = null;
+  let stdinSourceFd = -1;
+
+  for (const redir of redirections) {
+    if (
+      (redir.operator === "<<" || redir.operator === "<<-") &&
+      redir.target.type === "HereDoc"
+    ) {
+      const hereDoc = redir.target as HereDocNode;
+      let content = await expandWord(ctx, hereDoc.content);
+      // <<- strips leading tabs from each line
+      if (hereDoc.stripTabs) {
+        content = content
+          .split("\n")
+          .map((line) => line.replace(/^\t+/, ""))
+          .join("\n");
+      }
+      // Heredocs land here as JS Unicode text; the pipeline contract
+      // expects stdin to be a latin1 byte buffer. UTF-8 encode the
+      // text once at the source so byte consumers downstream see real
+      // bytes and binary writes don't truncate codepoints to their
+      // low byte.
+      content = latin1FromBytes(encodeUtf8ToBytes(content));
+      // If this is a non-standard fd (not 0), store in fileDescriptors for -u option
+      const fd = redir.fd ?? 0;
+      if (fd !== 0) {
+        if (!ctx.state.fileDescriptors) {
+          ctx.state.fileDescriptors = new Map();
+        }
+        checkFdLimit(ctx);
+        ctx.state.fileDescriptors.set(fd, content);
+      } else {
+        stdin = content;
+        stdinSourceFd = -1;
+      }
+      continue;
+    }
+
+    if (redir.operator === "<<<" && redir.target.type === "Word") {
+      // Same byte-encoding step as heredoc — here-strings deliver
+      // JS Unicode text and need to land as bytes.
+      stdin = latin1FromBytes(
+        encodeUtf8ToBytes(
+          `${await expandWord(ctx, redir.target as WordNode)}\n`,
+        ),
+      );
+      stdinSourceFd = -1;
+      continue;
+    }
+
+    if (redir.operator === "<" && redir.target.type === "Word") {
+      const target = await expandWord(ctx, redir.target as WordNode);
+      try {
+        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
+        // Read as raw bytes — `<` is a transparent file-to-stdin
+        // pipe and we don't want the smart-utf8 read path turning
+        // valid bytes into U+FFFD replacement chars.
+        stdin = latin1FromBytes(await readBytesFrom(ctx.fs, filePath));
+        stdinSourceFd = -1;
+      } catch {
+        return {
+          error: failure(`bash: ${target}: No such file or directory\n`),
+        };
+      }
+      continue;
+    }
+
+    // Handle <& input redirection from file descriptor
+    if (redir.operator === "<&" && redir.target.type === "Word") {
+      const target = await expandWord(ctx, redir.target as WordNode);
+      const sourceFd = Number.parseInt(target, 10);
+      if (!Number.isNaN(sourceFd) && ctx.state.fileDescriptors) {
+        const fdContent = ctx.state.fileDescriptors.get(sourceFd);
+        if (fdContent !== undefined) {
+          // Handle different FD content formats
+          if (fdContent.startsWith("__rw__:")) {
+            // Read/write mode: format is __rw__:pathLength:path:position:content
+            const parsed = parseRwFdContent(fdContent);
+            if (parsed) {
+              // Return content starting from current position
+              stdin = parsed.content.slice(parsed.position);
+              stdinSourceFd = sourceFd;
+            }
+          } else if (
+            fdContent.startsWith("__file__:") ||
+            fdContent.startsWith("__file_append__:")
+          ) {
+            // These are output-only, can't read from them
+          } else {
+            // Plain content (from exec N< file or here-docs)
+            stdin = fdContent;
+            stdinSourceFd = -1;
+          }
+        }
+      }
+    }
+  }
+
+  return { stdin, stdinSourceFd };
+}
+
+/**
+ * Run `fn` with `stream` installed as the scope's stdin, restoring the
+ * previous stream afterwards. This is the only way stdin changes hands:
+ * pipeline stages, stdin redirects, and top-level exec all install a
+ * stream here and inherit it everywhere below by reference.
+ */
+export async function withStdin<T>(
+  ctx: InterpreterContext,
+  stream: StdinStream,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const saved = ctx.state.stdin;
+  ctx.state.stdin = stream;
+  try {
+    return await fn();
+  } finally {
+    ctx.state.stdin = saved;
+  }
+}
+
+/**
+ * Resolve stdin redirections and run `fn` with the resulting stream
+ * installed (or unchanged stdin when no stdin redirect is present).
+ * Returns the resolution error instead of running `fn` when a `< file`
+ * target is missing.
+ */
+export async function withStdinRedirects(
+  ctx: InterpreterContext,
+  redirections: RedirectionNode[],
+  fn: () => Promise<ExecResult>,
+): Promise<ExecResult> {
+  const resolved = await resolveStdinRedirections(ctx, redirections);
+  if ("error" in resolved) {
+    return resolved.error;
+  }
+  if (resolved.stdin === null) {
+    return fn();
+  }
+  return withStdin(ctx, new StdinStream(resolved.stdin), fn);
+}

--- a/packages/just-bash/src/interpreter/subshell-group.ts
+++ b/packages/just-bash/src/interpreter/subshell-group.ts
@@ -6,11 +6,9 @@
 
 import type {
   GroupNode,
-  HereDocNode,
   ScriptNode,
   StatementNode,
   SubshellNode,
-  WordNode,
 } from "../ast/types.js";
 import { Parser } from "../parser/parser.js";
 import type { ParseException } from "../parser/types.js";
@@ -25,9 +23,8 @@ import {
   ReturnError,
   SubshellExitError,
 } from "./errors.js";
-import { expandWord } from "./expansion.js";
 import { getErrorMessage } from "./helpers/errors.js";
-import { checkFdLimit, failure, result } from "./helpers/result.js";
+import { failure, result } from "./helpers/result.js";
 import {
   applyRedirections,
   preOpenOutputRedirects,
@@ -47,7 +44,6 @@ export type ExecuteStatementFn = (stmt: StatementNode) => Promise<ExecResult>;
 export async function executeSubshell(
   ctx: InterpreterContext,
   node: SubshellNode,
-  stdin: string,
   executeStatement: ExecuteStatementFn,
 ): Promise<ExecResult> {
   // Pre-open output redirects to truncate files BEFORE executing body
@@ -109,11 +105,10 @@ export async function executeSubshell(
   const savedBashPid = ctx.state.bashPid;
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
 
-  // Save any existing groupStdin and set new one from pipeline
-  const savedGroupStdin = ctx.state.groupStdin;
-  if (stdin) {
-    ctx.state.groupStdin = stdin;
-  }
+  // Note: stdin (pipeline or redirect) was installed as a shared stream by
+  // the command dispatcher. The subshell deliberately shares it with the
+  // parent — like a real fd, consuming input inside the subshell advances
+  // the offset for the parent too.
 
   let stdout = "";
   let stderr = "";
@@ -130,7 +125,6 @@ export async function executeSubshell(
     ctx.state.fullyUnsetLocals = savedFullyUnsetLocals;
     ctx.state.loopDepth = savedLoopDepth;
     ctx.state.parentHasLoopContext = savedParentHasLoopContext;
-    ctx.state.groupStdin = savedGroupStdin;
     ctx.state.bashPid = savedBashPid;
     ctx.state.lastArg = savedLastArg;
   };
@@ -216,7 +210,6 @@ export async function executeSubshell(
 export async function executeGroup(
   ctx: InterpreterContext,
   node: GroupNode,
-  stdin: string,
   executeStatement: ExecuteStatementFn,
 ): Promise<ExecResult> {
   let stdout = "";
@@ -232,51 +225,9 @@ export async function executeGroup(
     return fdVarError;
   }
 
-  // Process heredoc and input redirections to get stdin content
-  let effectiveStdin = stdin;
-  for (const redir of node.redirections) {
-    if (
-      (redir.operator === "<<" || redir.operator === "<<-") &&
-      redir.target.type === "HereDoc"
-    ) {
-      const hereDoc = redir.target as HereDocNode;
-      let content = await expandWord(ctx, hereDoc.content);
-      if (hereDoc.stripTabs) {
-        content = content
-          .split("\n")
-          .map((line) => line.replace(/^\t+/, ""))
-          .join("\n");
-      }
-      // If this is a non-standard fd (not 0), store in fileDescriptors for -u option
-      const fd = redir.fd ?? 0;
-      if (fd !== 0) {
-        if (!ctx.state.fileDescriptors) {
-          ctx.state.fileDescriptors = new Map();
-        }
-        checkFdLimit(ctx);
-        ctx.state.fileDescriptors.set(fd, content);
-      } else {
-        effectiveStdin = content;
-      }
-    } else if (redir.operator === "<<<" && redir.target.type === "Word") {
-      effectiveStdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
-    } else if (redir.operator === "<" && redir.target.type === "Word") {
-      try {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        effectiveStdin = await ctx.fs.readFile(filePath);
-      } catch {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        return result("", `bash: ${target}: No such file or directory\n`, 1);
-      }
-    }
-  }
-
-  // Save any existing groupStdin and set new one from pipeline
-  const savedGroupStdin = ctx.state.groupStdin;
-  if (effectiveStdin) {
-    ctx.state.groupStdin = effectiveStdin;
-  }
+  // Stdin redirections were already resolved and installed as the scope's
+  // stdin stream by the command dispatcher; body commands consume it from
+  // ctx.state.stdin by reference.
 
   try {
     for (const stmt of node.body) {
@@ -286,8 +237,6 @@ export async function executeGroup(
       exitCode = res.exitCode;
     }
   } catch (error) {
-    // Restore groupStdin before handling error
-    ctx.state.groupStdin = savedGroupStdin;
     // ExecutionLimitError must always propagate - these are safety limits
     if (error instanceof ExecutionLimitError) {
       throw error;
@@ -302,9 +251,6 @@ export async function executeGroup(
     }
     return result(stdout, `${stderr}${getErrorMessage(error)}\n`, 1);
   }
-
-  // Restore groupStdin
-  ctx.state.groupStdin = savedGroupStdin;
 
   // Apply output redirections
   const bodyResult = result(stdout, stderr, exitCode);
@@ -325,7 +271,6 @@ export async function executeUserScript(
   ctx: InterpreterContext,
   scriptPath: string,
   args: string[],
-  stdin: string,
   executeScript: ExecuteScriptFn,
 ): Promise<ExecResult> {
   // Read the script content
@@ -353,16 +298,13 @@ export async function executeUserScript(
   const savedParentHasLoopContext = ctx.state.parentHasLoopContext;
   const savedLastArg = ctx.state.lastArg;
   const savedBashPid = ctx.state.bashPid;
-  const savedGroupStdin = ctx.state.groupStdin;
   const savedSource = ctx.state.currentSource;
 
-  // Set up subshell-like environment
+  // Set up subshell-like environment. Stdin is inherited by reference
+  // from the caller's scope (installed by redirect/pipeline, if any).
   ctx.state.parentHasLoopContext = savedLoopDepth > 0;
   ctx.state.loopDepth = 0;
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
-  if (stdin) {
-    ctx.state.groupStdin = stdin;
-  }
   ctx.state.currentSource = scriptPath;
 
   // Set positional parameters ($1, $2, etc.) from args
@@ -387,7 +329,6 @@ export async function executeUserScript(
     ctx.state.parentHasLoopContext = savedParentHasLoopContext;
     ctx.state.lastArg = savedLastArg;
     ctx.state.bashPid = savedBashPid;
-    ctx.state.groupStdin = savedGroupStdin;
     ctx.state.currentSource = savedSource;
   };
 

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -11,6 +11,7 @@ import type {
 import type { IFileSystem } from "../fs/interface.js";
 import type { ExecutionLimits } from "../limits.js";
 import type { SecureFetch } from "../network/index.js";
+import type { StdinStream } from "../stdin-stream.js";
 import type {
   CommandRegistry,
   ExecResult,
@@ -305,8 +306,16 @@ export interface ProcessState {
  * Used for process substitution, here-documents, and compound command stdin.
  */
 export interface IOState {
-  /** Stdin available for commands in compound commands (groups, subshells, while loops with piped input) */
-  groupStdin?: string;
+  /**
+   * Standard input for the current scope — the interpreter's fd 0.
+   *
+   * Shared by reference like a real file descriptor: consuming input
+   * anywhere (a command's `readAll()`, `read`'s `advance(n)`) advances it
+   * for every other holder, including across subshell and pipeline-stage
+   * boundaries. Redirects and pipeline stages install a fresh stream for
+   * their scope (save/install/restore); nothing ever copies the content.
+   */
+  stdin: StdinStream;
   /** File descriptors for process substitution and here-docs */
   fileDescriptors?: Map<number, string>;
   /** Next available file descriptor for {varname}>file allocation (starts at 10) */
@@ -423,7 +432,10 @@ export interface InterpreterContext {
   ) => Promise<ExecResult>;
   executeScript: (node: ScriptNode) => Promise<ExecResult>;
   executeStatement: (node: StatementNode) => Promise<ExecResult>;
-  executeCommand: (node: CommandNode, stdin: string) => Promise<ExecResult>;
+  executeCommand: (
+    node: CommandNode,
+    pipeStdin: StdinStream | null,
+  ) => Promise<ExecResult>;
   /** Optional secure fetch function for network-enabled commands */
   fetch?: SecureFetch;
   /** Optional sleep function for testing with mock clocks */

--- a/packages/just-bash/src/interpreter/while-loop-stdin.test.ts
+++ b/packages/just-bash/src/interpreter/while-loop-stdin.test.ts
@@ -1,0 +1,429 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+describe("while loop stdin with pipeline in body", () => {
+  it("simple pipeline in body reads all lines", async () => {
+    const bash = new Bash({ files: { "/f": "a\nb\nc\n" } });
+    const result = await bash.exec(
+      'while IFS= read -r line; do echo "$line" | cat; done < /f',
+    );
+    expect(result.stdout).toBe("a\nb\nc\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("multi-stage pipeline in body reads all lines", async () => {
+    const bash = new Bash({ files: { "/f": "a\nb\nc\n" } });
+    const result = await bash.exec(
+      'while IFS= read -r line; do echo "$line" | tr a-z A-Z | cat; done < /f',
+    );
+    expect(result.stdout).toBe("A\nB\nC\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("pipeline body does not consume loop stdin", async () => {
+    const bash = new Bash({ files: { "/f": "x\ny\nz\n" } });
+    const result = await bash.exec(
+      "while IFS= read -r line; do echo extra | cat; done < /f",
+    );
+    expect(result.stdout).toBe("extra\nextra\nextra\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("without IFS= also works with pipeline in body", async () => {
+    const bash = new Bash({ files: { "/f": "a\nb\nc\n" } });
+    const result = await bash.exec(
+      'while read -r line; do echo "$line" | cat; done < /f',
+    );
+    expect(result.stdout).toBe("a\nb\nc\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("nested loops each with a pipeline", async () => {
+    const bash = new Bash({
+      files: { "/outer": "A\nB\n", "/inner": "1\n2\n" },
+    });
+    const result = await bash.exec(`
+      while IFS= read -r o; do
+        while IFS= read -r i; do
+          echo "$o:$i" | cat
+        done < /inner
+      done < /outer
+    `);
+    expect(result.stdout).toBe("A:1\nA:2\nB:1\nB:2\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("group command reading extra line advances position", async () => {
+    const bash = new Bash({ files: { "/f": "A\nB\nC\nD\n" } });
+    const result = await bash.exec(`
+      while IFS= read -r line; do
+        { IFS= read -r extra; echo "$line+$extra"; } | cat
+      done < /f
+    `);
+    expect(result.stdout).toBe("A+B\nC+D\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("group with heredoc does not consume loop stdin", async () => {
+    const bash = new Bash({ files: { "/f": "1\n2\n" } });
+    const result = await bash.exec(`
+      while IFS= read -r line; do
+        { IFS= read -r x; echo "$line:$x"; } <<'EOF'
+hello
+EOF
+      done < /f
+    `);
+    expect(result.stdout).toBe("1:hello\n2:hello\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("works with stdin passed to exec()", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'while IFS= read -r line; do echo "$line" | tr a-z A-Z; done',
+      { stdin: "hello\nworld\n" },
+    );
+    expect(result.stdout).toBe("HELLO\nWORLD\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("cat with no args reads from loop stdin and advances the stream", async () => {
+    // read consumes "first", cat drains the rest via the shared stdin stream
+    const bash = new Bash({ files: { "/f": "first\nsecond\nthird\n" } });
+    const result = await bash.exec(`
+      while IFS= read -r line; do
+        echo "read:$line"
+        cat
+      done < /f
+    `);
+    expect(result.stdout).toBe("read:first\nsecond\nthird\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("grep with no args reads remaining loop stdin", async () => {
+    // read gets "apple", grep filters remaining lines; cursor exhausted after grep
+    const bash = new Bash({ files: { "/f": "apple\nbanana\napricot\n" } });
+    const result = await bash.exec(`
+      while IFS= read -r line; do
+        grep "^b"
+      done < /f
+    `);
+    expect(result.stdout).toBe("banana\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("if condition reads from stdin redirect", async () => {
+    const bash = new Bash({ files: { "/f": "hello\n" } });
+    const result = await bash.exec(
+      'if IFS= read -r line; then echo "got: $line"; fi < /f',
+    );
+    expect(result.stdout).toBe("got: hello\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("if body reads from stdin redirect", async () => {
+    const bash = new Bash({ files: { "/f": "line1\nline2\n" } });
+    const result = await bash.exec(`
+      if true; then
+        IFS= read -r a
+        IFS= read -r b
+        echo "$a $b"
+      fi < /f
+    `);
+    expect(result.stdout).toBe("line1 line2\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("c-style for loop body reads from stdin redirect", async () => {
+    const bash = new Bash({ files: { "/f": "x\ny\nz\n" } });
+    const result = await bash.exec(`
+      for ((i=0; i<3; i++)); do
+        IFS= read -r line
+        echo "$i: $line"
+      done < /f
+    `);
+    expect(result.stdout).toBe("0: x\n1: y\n2: z\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("case body reads from stdin redirect", async () => {
+    const bash = new Bash({ files: { "/f": "hello\nworld\n" } });
+    const result = await bash.exec(`
+      case 1 in
+        1) IFS= read -r a; IFS= read -r b; echo "$a $b";;
+      esac < /f
+    `);
+    expect(result.stdout).toBe("hello world\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("for loop with stdin redirect lets body read from file", async () => {
+    const bash = new Bash({ files: { "/f": "line1\nline2\nline3\n" } });
+    const result = await bash.exec(`
+      for i in 1 2 3; do
+        IFS= read -r line
+        echo "$i: $line"
+      done < /f
+    `);
+    expect(result.stdout).toBe("1: line1\n2: line2\n3: line3\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("for loop body pipeline reads from stdin redirect", async () => {
+    const bash = new Bash({ files: { "/f": "a\nb\nc\n" } });
+    const result = await bash.exec(`
+      for i in 1 2 3; do
+        IFS= read -r line
+        echo "$line" | tr a-z A-Z
+      done < /f
+    `);
+    expect(result.stdout).toBe("A\nB\nC\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("until loop with pipeline in body reads all lines", async () => {
+    const bash = new Bash({ files: { "/f": "a\nb\nc\n" } });
+    const result = await bash.exec(
+      'until ! IFS= read -r line; do echo "$line" | cat; done < /f',
+    );
+    expect(result.stdout).toBe("a\nb\nc\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("if body reads from heredoc", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(`
+      if true; then
+        IFS= read -r a
+        IFS= read -r b
+        echo "$a $b"
+      fi <<'EOF'
+hello
+world
+EOF
+    `);
+    expect(result.stdout).toBe("hello world\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("if body reads from herestring", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'if true; then IFS= read -r line; echo "got: $line"; fi <<< "herestring"',
+    );
+    expect(result.stdout).toBe("got: herestring\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("for loop body reads from heredoc", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(`
+      for i in 1 2 3; do
+        IFS= read -r line
+        echo "$i: $line"
+      done <<'EOF'
+alpha
+beta
+gamma
+EOF
+    `);
+    expect(result.stdout).toBe("1: alpha\n2: beta\n3: gamma\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("for loop body reads from herestring", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'for i in 1; do IFS= read -r line; echo "$i: $line"; done <<< "word"',
+    );
+    expect(result.stdout).toBe("1: word\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("c-style for loop body reads from heredoc", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(`
+      for ((i=0; i<2; i++)); do
+        IFS= read -r line
+        echo "$i: $line"
+      done <<'EOF'
+foo
+bar
+EOF
+    `);
+    expect(result.stdout).toBe("0: foo\n1: bar\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("c-style for loop body reads from herestring", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'for ((i=0; i<1; i++)); do IFS= read -r line; echo "$line"; done <<< "hi"',
+    );
+    expect(result.stdout).toBe("hi\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("until loop body reads from heredoc", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(`
+      until ! IFS= read -r line; do
+        echo "got: $line"
+      done <<'EOF'
+one
+two
+EOF
+    `);
+    expect(result.stdout).toBe("got: one\ngot: two\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("until loop body reads from herestring", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'until ! IFS= read -r line; do echo "$line"; done <<< "only"',
+    );
+    expect(result.stdout).toBe("only\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("case body reads from heredoc", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(`
+      case 1 in
+        1) IFS= read -r a; IFS= read -r b; echo "$a $b";;
+      esac <<'EOF'
+first
+second
+EOF
+    `);
+    expect(result.stdout).toBe("first second\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("case body reads from herestring", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'case 1 in 1) IFS= read -r line; echo "$line";; esac <<< "only"',
+    );
+    expect(result.stdout).toBe("only\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("cat as first pipeline stage reads loop stdin", async () => {
+    // cat (first in pipeline, no file args) consumes remaining cursor content
+    const bash = new Bash({ files: { "/f": "line1\nline2\n" } });
+    const result = await bash.exec(`
+      while IFS= read -r line; do
+        cat | tr a-z A-Z
+      done < /f
+    `);
+    // read gets "line1", cat drains "line2\n" and pipes it through tr
+    expect(result.stdout).toBe("LINE2\n");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("stdin redirect edge cases", () => {
+  // <<- strip-tabs path
+  it("while loop body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'while IFS= read -r line; do echo "got: $line"; done <<-EOF\n\thello\n\tworld\nEOF\n',
+    );
+    expect(result.stdout).toBe("got: hello\ngot: world\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("if body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'if true; then IFS= read -r a; echo "$a"; fi <<-EOF\n\tstripped\nEOF\n',
+    );
+    expect(result.stdout).toBe("stripped\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("for loop body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'for i in 1; do IFS= read -r line; echo "$i: $line"; done <<-EOF\n\ttabbed\nEOF\n',
+    );
+    expect(result.stdout).toBe("1: tabbed\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("c-style for loop body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'for ((i=0; i<1; i++)); do IFS= read -r line; echo "$line"; done <<-EOF\n\ttabbed\nEOF\n',
+    );
+    expect(result.stdout).toBe("tabbed\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("until loop body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'until ! IFS= read -r line; do echo "$line"; done <<-EOF\n\ttabbed\nEOF\n',
+    );
+    expect(result.stdout).toBe("tabbed\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("case body reads from strip-tabs heredoc (<<-)", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'case 1 in 1) IFS= read -r line; echo "$line";; esac <<-EOF\n\ttabbed\nEOF\n',
+    );
+    expect(result.stdout).toBe("tabbed\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  // file-not-found error path for < redirect
+  it("while loop errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'while IFS= read -r line; do echo "$line"; done < /nope',
+    );
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("if errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec("if true; then echo hi; fi < /nope");
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("for loop errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec('for i in 1; do echo "$i"; done < /nope');
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("c-style for loop errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec(
+      'for ((i=0; i<1; i++)); do echo "$i"; done < /nope',
+    );
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("until loop errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec("until false; do echo hi; done < /nope");
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it("case errors when stdin file does not exist", async () => {
+    const bash = new Bash();
+    const result = await bash.exec("case 1 in 1) echo hi;; esac < /nope");
+    expect(result.stderr).toContain("No such file or directory");
+    expect(result.exitCode).not.toBe(0);
+  });
+});

--- a/packages/just-bash/src/security/attacks/defense-context-invariant.test.ts
+++ b/packages/just-bash/src/security/attacks/defense-context-invariant.test.ts
@@ -4,9 +4,9 @@ import { awkCommand2 } from "../../commands/awk/awk2.js";
 import { jqCommand } from "../../commands/jq/jq.js";
 import { sedCommand } from "../../commands/sed/sed.js";
 import { yqCommand } from "../../commands/yq/yq.js";
-import { EMPTY_BYTES, unsafeBytesFromLatin1 } from "../../encoding.js";
 import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import { createDefenseAwareCommandContext } from "../../interpreter/defense-aware-command-context.js";
+import { StdinStream } from "../../stdin-stream.js";
 import type { CommandContext } from "../../types.js";
 import { awaitWithDefenseContext } from "../defense-context.js";
 import {
@@ -21,7 +21,7 @@ function createCommandContext(
     fs: new InMemoryFs(),
     cwd: "/",
     env: new Map([["PATH", "/usr/bin:/bin"]]),
-    stdin: EMPTY_BYTES,
+    stdin: new StdinStream(),
     requireDefenseContext: true,
     ...overrides,
   };
@@ -98,7 +98,7 @@ describe("Defense context invariant", () => {
     await expect(
       awkCommand2.execute(
         ["{ print $0 }"],
-        createCommandContext({ stdin: unsafeBytesFromLatin1("x\n") }),
+        createCommandContext({ stdin: new StdinStream("x\n") }),
       ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
@@ -109,7 +109,7 @@ describe("Defense context invariant", () => {
     await expect(
       sedCommand.execute(
         ["s/a/b/"],
-        createCommandContext({ stdin: unsafeBytesFromLatin1("a\n") }),
+        createCommandContext({ stdin: new StdinStream("a\n") }),
       ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
@@ -120,7 +120,7 @@ describe("Defense context invariant", () => {
     await expect(
       jqCommand.execute(
         ["."],
-        createCommandContext({ stdin: unsafeBytesFromLatin1("{}\n") }),
+        createCommandContext({ stdin: new StdinStream("{}\n") }),
       ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });
@@ -131,7 +131,7 @@ describe("Defense context invariant", () => {
     await expect(
       yqCommand.execute(
         ["."],
-        createCommandContext({ stdin: unsafeBytesFromLatin1("x: 1\n") }),
+        createCommandContext({ stdin: new StdinStream("x: 1\n") }),
       ),
     ).rejects.toBeInstanceOf(SecurityViolationError);
   });

--- a/packages/just-bash/src/spec-tests/test-commands.ts
+++ b/packages/just-bash/src/spec-tests/test-commands.ts
@@ -112,7 +112,7 @@ export const readFromFdCommand: Command = defineCommand(
       let content = "";
       if (fd === 0) {
         // FD 0 is stdin — diagnostic only, byte-clean passthrough
-        content = latin1FromBytes(ctx.stdin) || "";
+        content = latin1FromBytes(ctx.stdin.readAll()) || "";
       } else if (ctx.fileDescriptors) {
         // Other FDs from the fileDescriptors map
         content = ctx.fileDescriptors.get(fd) || "";

--- a/packages/just-bash/src/stdin-stream.test.ts
+++ b/packages/just-bash/src/stdin-stream.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { latin1FromBytes } from "./encoding.js";
+import { StdinStream } from "./stdin-stream.js";
+
+describe("StdinStream", () => {
+  it("peek returns full content initially without consuming", () => {
+    const s = new StdinStream("hello\nworld\n");
+    expect(latin1FromBytes(s.peek())).toBe("hello\nworld\n");
+    expect(latin1FromBytes(s.peek())).toBe("hello\nworld\n");
+    expect(s.exhausted).toBe(false);
+  });
+
+  it("defaults to empty content", () => {
+    const s = new StdinStream();
+    expect(latin1FromBytes(s.peek())).toBe("");
+    expect(s.exhausted).toBe(true);
+  });
+
+  it("exhausted is true on empty content", () => {
+    expect(new StdinStream("").exhausted).toBe(true);
+  });
+
+  it("advance moves position forward", () => {
+    const s = new StdinStream("hello\nworld\n");
+    s.advance(6);
+    expect(latin1FromBytes(s.peek())).toBe("world\n");
+  });
+
+  it("advance clamps to content length", () => {
+    const s = new StdinStream("abc");
+    s.advance(1000);
+    expect(latin1FromBytes(s.peek())).toBe("");
+    expect(s.exhausted).toBe(true);
+  });
+
+  it("advance by zero or negative does nothing", () => {
+    const s = new StdinStream("abc");
+    s.advance(0);
+    s.advance(-5);
+    expect(latin1FromBytes(s.peek())).toBe("abc");
+    expect(s.exhausted).toBe(false);
+  });
+
+  it("readAll returns remaining and exhausts the stream", () => {
+    const s = new StdinStream("hello\nworld\n");
+    s.advance(6);
+    expect(latin1FromBytes(s.readAll())).toBe("world\n");
+    expect(s.exhausted).toBe(true);
+    expect(latin1FromBytes(s.peek())).toBe("");
+  });
+
+  it("readAll on empty content returns empty string", () => {
+    const s = new StdinStream("");
+    expect(latin1FromBytes(s.readAll())).toBe("");
+    expect(s.exhausted).toBe(true);
+  });
+
+  it("readAll after exhaustion returns empty string", () => {
+    const s = new StdinStream("abc");
+    s.readAll();
+    expect(latin1FromBytes(s.readAll())).toBe("");
+  });
+
+  it("multiple advances accumulate correctly", () => {
+    const s = new StdinStream("abcdef");
+    s.advance(2);
+    s.advance(2);
+    expect(latin1FromBytes(s.peek())).toBe("ef");
+    expect(s.exhausted).toBe(false);
+  });
+
+  it("exhausted becomes true after advance to exact end", () => {
+    const s = new StdinStream("abc");
+    s.advance(3);
+    expect(s.exhausted).toBe(true);
+    expect(latin1FromBytes(s.peek())).toBe("");
+  });
+
+  it("consumption is shared across holders of the same reference", () => {
+    const s = new StdinStream("a\nb\nc\n");
+    const alias = s;
+    alias.advance(2);
+    expect(latin1FromBytes(s.peek())).toBe("b\nc\n");
+    s.readAll();
+    expect(alias.exhausted).toBe(true);
+  });
+});

--- a/packages/just-bash/src/stdin-stream.ts
+++ b/packages/just-bash/src/stdin-stream.ts
@@ -1,0 +1,55 @@
+import { type ByteString, unsafeBytesFromLatin1 } from "./encoding.js";
+
+/**
+ * StdinStream — the single representation of standard input.
+ *
+ * Models stdin the way bash models a file descriptor: one object holding
+ * the content bytes and a read offset, shared by reference. A while loop
+ * with `< file`, every command in its body, and every pipeline stage that
+ * inherits stdin all see the same object, so consuming input in one place
+ * advances it everywhere — including across subshell boundaries, where a
+ * copied string field would silently lose the advance.
+ *
+ * Reading is consuming: `readAll()` returns the remaining bytes and
+ * advances to EOF, so a command cannot read stdin and forget to consume
+ * it. Commands that forward stdin to a subcommand without consuming it
+ * (`timeout`, `time`, `env`) use `peek()`. Partial consumers (`read`,
+ * `mapfile`) use `peek()` + `advance(n)`.
+ *
+ * Content is a latin1-shaped byte buffer (one char = one byte) per the
+ * pipeline contract in encoding.ts. Redirect/heredoc sources UTF-8 encode
+ * text before constructing a stream.
+ */
+export class StdinStream {
+  private pos = 0;
+
+  constructor(private readonly content: string = "") {}
+
+  /** Remaining bytes without consuming them (for stdin forwarders). */
+  peek(): ByteString {
+    return unsafeBytesFromLatin1(this.content.slice(this.pos));
+  }
+
+  /** Consume and return all remaining bytes, advancing to EOF. */
+  readAll(): ByteString {
+    const rest = this.content.slice(this.pos);
+    this.pos = this.content.length;
+    return unsafeBytesFromLatin1(rest);
+  }
+
+  /**
+   * Consume `n` bytes without returning them (clamped to the remaining
+   * length). Partial consumers call `peek()` to parse, then advance by
+   * what they actually used.
+   */
+  advance(n: number): void {
+    if (n > 0) {
+      this.pos = Math.min(this.pos + n, this.content.length);
+    }
+  }
+
+  /** True when all input has been consumed. */
+  get exhausted(): boolean {
+    return this.pos >= this.content.length;
+  }
+}

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -1,7 +1,7 @@
-import type { ByteString } from "./encoding.js";
 import type { IFileSystem } from "./fs/interface.js";
 import type { ExecutionLimits } from "./limits.js";
 import type { SecureFetch } from "./network/index.js";
+import type { StdinStream } from "./stdin-stream.js";
 
 /**
  * Lightweight interface for feature coverage tracking during fuzzing.
@@ -141,18 +141,25 @@ export interface CommandContext {
    */
   exportedEnv?: Record<string, string>;
   /**
-   * Standard input as a byte buffer. Opaque on purpose — see `encoding.ts`.
+   * Standard input as a shared, consumable stream — the shell's fd 0.
    *
-   * Pipelines carry bytes (a previous command's stdout becomes this stdin).
-   * Choose a conversion at the use site:
-   *   - `latin1FromBytes(ctx.stdin)` to forward bytes unchanged (cat, head,
+   * Reading is consuming: `ctx.stdin.readAll()` returns the remaining
+   * bytes and advances the stream, for this command AND for every other
+   * holder of the same stream (e.g. the next iteration of a `while read`
+   * loop whose stdin this command just drained — exactly how bash file
+   * descriptors behave). Commands that forward stdin to a subcommand
+   * without consuming it (`timeout`, `time`, `env`) use `ctx.stdin.peek()`.
+   *
+   * Both return an opaque `ByteString` (pipelines carry bytes; see
+   * `encoding.ts`). Choose a conversion at the use site:
+   *   - `latin1FromBytes(...)` to forward bytes unchanged (cat, head,
    *     tee, base64 -d, gzip, ...).
-   *   - `decodeBytesToUtf8(ctx.stdin)` to interpret as UTF-8 text (jq, sed,
+   *   - `decodeBytesToUtf8(...)` to interpret as UTF-8 text (jq, sed,
    *     grep, awk, parsers, code execution, char-position math, ...).
    * Mixing the two — calling string methods on a latin1 byte buffer that
-   * actually holds UTF-8 — is the bug class this type prevents.
+   * actually holds UTF-8 — is the bug class the type prevents.
    */
-  stdin: ByteString;
+  stdin: StdinStream;
   /**
    * Execution limits configuration.
    * Available when running commands via BashEnv interpreter.

--- a/packages/just-bash/src/utils/file-reader.ts
+++ b/packages/just-bash/src/utils/file-reader.ts
@@ -67,10 +67,10 @@ export async function readFiles(
     batchSize = DEFAULT_BATCH_SIZE,
   } = options;
 
-  // No files - read from stdin
+  // No files - read from stdin (consuming it, like a process draining fd 0)
   if (files.length === 0) {
     return {
-      files: [{ filename: "", content: ctx.stdin }],
+      files: [{ filename: "", content: ctx.stdin.readAll() }],
       stderr: "",
       exitCode: 0,
     };
@@ -86,9 +86,11 @@ export async function readFiles(
     const batchResults = await Promise.all(
       batch.map(async (file) => {
         if (allowStdinMarker && file === "-") {
+          // First "-" drains stdin; later ones see it exhausted (as in
+          // bash, where `cat - -` reads stdin only once).
           return {
             filename: "-",
-            content: ctx.stdin,
+            content: ctx.stdin.readAll(),
             error: null as string | null,
           };
         }


### PR DESCRIPTION
Fixes stdin position tracking in loops and compound commands:

```bash
while IFS= read -r line; do
  echo "$line" | cat   # cat consumed all remaining stdin — loop stopped after first line
done <<< $'a\nb\nc'

# Before: a <-- stops here
# After:  a
#         b
#         c
```

`groupStdin` was a string snapshot. This fix makes stdin stream-like: one shared object that tracks the offset already read, so any consumer advances the position for everyone.

## What

Replaces the interpreter's `IOState.groupStdin?: string` snapshot with a single `StdinStream` object — the only representation of stdin anywhere in the interpreter. It works like a bash file descriptor: content bytes plus a read offset, shared by reference. **Reading is consuming**: a command that drains stdin advances the offset for every other holder of the stream, including across subshell and pipeline-stage boundaries.

> Note: this supersedes the earlier `StdinCursor` design on this branch. That version kept stdin in two parallel forms (a threaded `stdin: string` parameter plus a cursor in interpreter state) with precedence rules at every consumer, and required each of ~30 commands to remember to call `consumeStdin()` — a convention-enforced invariant. The redesign makes the invariant structural: `ctx.stdin.readAll()` is the only way to get the content, so "read stdin but forgot to advance it" is impossible by construction.

## Why

The old string-snapshot approach had a recurring bug class: commands inside a `while read` loop body (pipelines, `cat`, `grep`, `tr`, …) consumed the loop's stdin without advancing the shared position, so the next iteration re-read the same input. The fallback rules (`stdin || groupStdin`) were duplicated across `builtin-dispatch`, `read`, `mapfile`, and the pipeline glue, and `pipeline-execution.ts` cleared `groupStdin` without restoring it.

## Design

- **`src/stdin-stream.ts`** — `StdinStream` with `readAll()` (consume), `peek()` (forward without consuming; used by `timeout`/`time`/`env`/`bash`), `advance(n)` (partial consumers: `read`, `mapfile`).
- **`src/interpreter/stdin-redirect.ts`** — one resolver for `<`, `<<`, `<<-`, `<<<`, `<&`, shared by simple commands, **all** compound commands (`if`/`for`/`while`/`until`/`case`/subshell/group), and function-def redirects; plus `withStdin()` for scoped install/restore. This replaces four diverged copies of the redirect-processing loop and fixes the heredoc UTF-8 byte-encoding those copies were missing.
- **Pipeline stages** install a fresh stream per stage; the first stage inherits the enclosing stream by reference (bash fd-inheritance semantics). Empty pipe output can no longer fall back to the enclosing scope's stdin.
- **`CommandContext.stdin` is now a `StdinStream`** (breaking, TypeScript): commands call `ctx.stdin.readAll()`; `StdinStream` is exported from the package root. A changeset (`minor`) documents the migration.

Behavior fixes verified against real bash: subshells share the stdin offset with the parent; function definition redirects apply per call and win over piped stdin; a missing redirect file on a function errors without running the body; `diff - -` compares stdin against itself; `cat - -` reads stdin once.

## Test coverage

- **`src/interpreter/while-loop-stdin.test.ts` — 40 tests** covering stdin redirects (`<`, `<<`, `<<-`, `<<<`, file-not-found) on all six compound commands, pipelines inside loop bodies, and `read` position tracking. Carried over from the previous design and passing **unchanged** — the rewrite preserves all of its behavior.
- **`src/comparison-tests/stdin-consumption.comparison.test.ts` — 15 new comparison tests** with fixtures recorded from real bash: consumption by `cat`/`grep`/`tr` in loop and group bodies, subshell offset sharing, pipeline-stage isolation, piped-loop position keeping, function redirect-vs-pipe precedence, missing-file redirect errors, `cat - -`, `diff - -`, empty-pipe no-fallback, nested loop redirects, and `eval` consuming group stdin.
- **`src/stdin-stream.test.ts` — 12 unit tests** for the stream primitive itself (consume/peek/advance/exhaustion/shared-reference semantics).
- Full suite: `pnpm typecheck`, lint, knip, spec tests (3825 passed), comparison tests (553 passed), and unit tests (13k+) all green. The only failures in a full run are pre-existing python3/WASM tests caused by unmaterialized git-LFS blobs in the local checkout (identical on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
