### PR TITLE
fix(interpreter): deliver redirected output to each fd's final target

### DIFF
--- a/.changeset/redirect-dup-routing.md
+++ b/.changeset/redirect-dup-routing.md
@@ -1,0 +1,28 @@
+---
+"just-bash": patch
+---
+
+interpreter: deliver redirected output to each fd's final target (fixes `cmd > file 2>&1` leaking stderr to stdout)
+
+`applyRedirections()` processed a command's redirection list sequentially over
+the result's stdout/stderr strings, moving content at each step. The
+duplication operators (`2>&1`, `1>&2`) merged into the live stream regardless
+of where the source fd pointed, so the canonical `cmd > file 2>&1` wrote
+stdout to the file but leaked stderr onto the caller's stdout — including
+"command not found" errors and custom-command stderr. Any wrapper protocol
+that parses the enclosing script's stdout (e.g. a runner emitting a JSON
+payload after `eval "$CMD" > "$OUT" 2>&1`) saw the leaked stderr corrupt its
+stream. Ordering variants were wrong in other ways: `cmd 2>&1 > file` put
+stderr in the file instead of on stdout, and `cmd > a > b` wrote content to
+`a` instead of `b`.
+
+The pass now mirrors how bash sets up fds before running the command: each
+output redirection only opens/truncates its target and re-points the fd's
+sink (file, /dev/null, or a snapshot of the caller-visible stream), and
+duplication operators copy the source fd's current sink. Stream content is
+delivered once, after the whole list is processed, to each fd's final sink.
+This makes `cmd > file 2>&1` send stderr to the file, `cmd 2>&1 > file` keep
+stderr on the caller's stdout, `cmd > all 2>&1 2> err` let the later `2> err`
+reclaim stderr, and `cmd > a > b` truncate `a` while writing content to `b`.
+The `/dev/null`-as-regular-VFS-file behavior for stdout redirects is
+preserved.

--- a/packages/just-bash/src/interpreter/redirections.dup-routing.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-routing.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { defineCommand } from "../custom-commands.js";
+
+/**
+ * `applyRedirections` processes a command's redirection list sequentially, so a
+ * duplication operator must deliver to wherever its source fd points at that
+ * moment in the list — not unconditionally to the live stream.
+ *
+ * The canonical failure this guards against: `cmd > file 2>&1` wrote stdout to
+ * the file but leaked stderr onto the caller's stdout, because `2>&1` ignored
+ * that fd 1 had already been redirected. Any wrapper protocol that parses the
+ * enclosing script's stdout (e.g. a runner emitting a JSON payload after
+ * `eval "$CMD" > "$OUT" 2>&1`) sees the leaked stderr corrupt its stream.
+ */
+describe("fd duplication after redirection (> file 2>&1)", () => {
+  it("sends command-not-found stderr to the file, not the caller's stdout", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd > /tmp/f 2>&1");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(127);
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("bash: nosuchcmd: command not found\n");
+  });
+
+  it("sends a custom command's stderr to the file", async () => {
+    const fail403 = defineCommand("vercel", async () => ({
+      stdout: "",
+      stderr: "Error! Forbidden (403)\n",
+      exitCode: 1,
+    }));
+    const env = new Bash({ customCommands: [fail403] });
+    const result = await env.exec("vercel flags > /tmp/f 2>&1");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("Error! Forbidden (403)\n");
+  });
+
+  it("keeps a wrapper script's stdout clean (runner-payload shape)", async () => {
+    const fail = defineCommand("failing-tool", async () => ({
+      stdout: "",
+      stderr: "tool error\n",
+      exitCode: 1,
+    }));
+    const env = new Bash({ customCommands: [fail] });
+    const result = await env.exec(
+      'CMD="failing-tool"; eval "$CMD" > /tmp/out 2>&1; echo \'{"ok":true}\'',
+    );
+    expect(result.stdout).toBe('{"ok":true}\n');
+    expect(result.stderr).toBe("");
+    const f = await env.exec("cat /tmp/out");
+    expect(f.stdout).toBe("tool error\n");
+  });
+
+  it("interleaves group stdout and stderr into the file", async () => {
+    const env = new Bash();
+    const result = await env.exec("{ echo o; nosuchcmd; } > /tmp/f 2>&1");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("o\nbash: nosuchcmd: command not found\n");
+  });
+
+  it("appends stderr after >> file 2>&1", async () => {
+    const env = new Bash({ files: { "/tmp/f": "x\n" } });
+    const result = await env.exec("nosuchcmd >> /tmp/f 2>&1");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("x\nbash: nosuchcmd: command not found\n");
+  });
+
+  it("routes stdout to fd 2's file for cmd 2> file 1>&2", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi 2> /tmp/e 1>&2");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const e = await env.exec("cat /tmp/e");
+    expect(e.stdout).toBe("hi\n");
+  });
+
+  it("discards stderr for > /dev/null 2>&1", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd > /dev/null 2>&1");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(127);
+  });
+
+  it("lets a later 2> file reclaim stderr after > all 2>&1", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "{ echo out; nosuchcmd; } > /tmp/all 2>&1 2> /tmp/err",
+    );
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const all = await env.exec("cat /tmp/all");
+    expect(all.stdout).toBe("out\n");
+    const err = await env.exec("cat /tmp/err");
+    expect(err.stdout).toBe("bash: nosuchcmd: command not found\n");
+  });
+
+  it("keeps stderr on the caller's stdout for 2>&1 > file (dup before redirect)", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd 2>&1 > /tmp/f");
+    expect(result.stdout).toBe("bash: nosuchcmd: command not found\n");
+    expect(result.stderr).toBe("");
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("");
+  });
+
+  it("only truncates intermediate redirect targets (1>&2 > leak > /dev/null)", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "echo hi 1>&2 > /tmp/leak > /dev/null 2> /dev/null",
+    );
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const leak = await env.exec("cat /tmp/leak");
+    expect(leak.stdout).toBe("");
+    expect(leak.exitCode).toBe(0); // file exists (was opened), just empty
+  });
+
+  it("writes content to the last target for cmd > a > b", async () => {
+    const env = new Bash();
+    await env.exec("echo hi > /tmp/a > /tmp/b");
+    const a = await env.exec("cat /tmp/a");
+    expect(a.stdout).toBe("");
+    expect(a.exitCode).toBe(0); // truncated but created
+    const b = await env.exec("cat /tmp/b");
+    expect(b.stdout).toBe("hi\n");
+  });
+
+  it("keeps content in the file for > file > /dev/stdout (self-dup no-op)", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi > /tmp/a > /dev/stdout");
+    expect(result.stdout).toBe("");
+    const a = await env.exec("cat /tmp/a");
+    expect(a.stdout).toBe("hi\n");
+  });
+
+  it("routes stderr to fd 1's file for 2> /dev/stdout after > file", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd > /tmp/f 2> /dev/stdout");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const f = await env.exec("cat /tmp/f");
+    expect(f.stdout).toBe("bash: nosuchcmd: command not found\n");
+  });
+
+  it("treats > f 2> f as independent descriptors, not a shared cursor", async () => {
+    const env = new Bash();
+    await env.exec("{ echo out; nosuchcmd; } > /tmp/f 2> /tmp/f");
+    const f = await env.exec("cat /tmp/f");
+    // Each redirect writes from its own start position; the later non-empty
+    // write clobbers the earlier one (bash's independent-open behavior).
+    expect(f.stdout).toBe("bash: nosuchcmd: command not found\n");
+    const env2 = new Bash();
+    await env2.exec("echo hi > /tmp/f 2> /tmp/f");
+    const f2 = await env2.exec("cat /tmp/f");
+    expect(f2.stdout).toBe("hi\n");
+  });
+
+  it("keeps the ENOSPC diagnostic visible for 2> /dev/full", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd 2> /dev/full");
+    expect(result.stderr).toContain("No space left on device");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("still merges to live stdout for a bare 2>&1", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd 2>&1");
+    expect(result.stdout).toBe("bash: nosuchcmd: command not found\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(127);
+  });
+
+  it("still routes plain 2> file without a dup", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd 2> /tmp/e");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    const e = await env.exec("cat /tmp/e");
+    expect(e.stdout).toBe("bash: nosuchcmd: command not found\n");
+  });
+});

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -427,6 +427,22 @@ export async function applyRedirections(
   const getStdoutEncoding = (_content: string): "binary" | "utf8" =>
     stdoutFileEncoding;
 
+  // Where fds 1 and 2 currently point as the redirection list is processed
+  // left to right. File redirections write their stream eagerly and update
+  // the fd's sink; duplication operators (`2>&1`, `1>&2`) only re-point the
+  // fd to a snapshot of the source fd's current sink. Content still held in
+  // a stream when the list ends is delivered to that fd's final sink below —
+  // so `cmd > file 2>&1` sends stderr to `file`, `cmd 2>&1 > file` sends
+  // stderr to the caller's stdout, and `cmd > all 2>&1 2> err` lets the
+  // later `2> err` reclaim stderr.
+  type RedirectSink =
+    | { kind: "live-stdout" }
+    | { kind: "live-stderr" }
+    | { kind: "file"; path: string; append: boolean }
+    | { kind: "discard" };
+  let fd1Sink: RedirectSink = { kind: "live-stdout" };
+  let fd2Sink: RedirectSink = { kind: "live-stderr" };
+
   for (let i = 0; i < redirections.length; i++) {
     const redir = redirections[i];
     if (redir.target.type === "HereDoc") {
@@ -483,152 +499,75 @@ export async function applyRedirections(
 
     switch (redir.operator) {
       case ">":
-      case ">|": {
-        const fd = redir.fd ?? 1;
-        const isClobber = redir.operator === ">|";
-        if (fd === 1) {
-          // /dev/stdout is a no-op for stdout - output stays on stdout
-          if (target === "/dev/stdout") {
-            break;
-          }
-          // /dev/stderr redirects stdout to stderr
-          if (target === "/dev/stderr") {
-            stderr += stdout;
-            stdout = "";
-            break;
-          }
-          // /dev/full always returns ENOSPC when written to
-          if (target === "/dev/full") {
-            stderr += `bash: echo: write error: No space left on device\n`;
-            exitCode = 1;
-            stdout = "";
-            break;
-          }
-          const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-          const error = await checkOutputRedirectTarget(ctx, filePath, target, {
-            checkNoclobber: true,
-            isClobber,
-          });
-          if (error) {
-            stderr += error;
-            exitCode = 1;
-            stdout = "";
-            break;
-          }
-          // Smart encoding: binary for byte data, UTF-8 for Unicode text
-          await ctx.fs.writeFile(filePath, stdout, getStdoutEncoding(stdout));
-          stdout = "";
-        } else if (fd === 2) {
-          // /dev/stderr is a no-op for stderr - output stays on stderr
-          if (target === "/dev/stderr") {
-            break;
-          }
-          // /dev/stdout redirects stderr to stdout
-          if (target === "/dev/stdout") {
-            stdout += stderr;
-            stderr = "";
-            break;
-          }
-          // /dev/full always returns ENOSPC when written to
-          if (target === "/dev/full") {
-            stderr += `bash: echo: write error: No space left on device\n`;
-            exitCode = 1;
-            break;
-          }
-          if (target === "/dev/null") {
-            stderr = "";
-          } else {
-            const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-            const error = await checkOutputRedirectTarget(
-              ctx,
-              filePath,
-              target,
-              {
-                checkNoclobber: true,
-                isClobber,
-              },
-            );
-            if (error) {
-              stderr += error;
-              exitCode = 1;
-              break;
-            }
-            // Smart encoding: binary for byte data, UTF-8 for Unicode text
-            await ctx.fs.writeFile(filePath, stderr, getFileEncoding(stderr));
-            stderr = "";
-          }
-        }
-        break;
-      }
-
+      case ">|":
       case ">>": {
         const fd = redir.fd ?? 1;
+        if (fd !== 1 && fd !== 2) {
+          break;
+        }
+        const isAppend = redir.operator === ">>";
+        const isClobber = redir.operator === ">|";
+        // Opening /dev/stdout or /dev/stderr duplicates the CURRENT target
+        // of fd 1 / fd 2, like `N>&1` / `N>&2`: `> /dev/stderr` re-points
+        // fd 1 to wherever fd 2 points right now, and the self-referential
+        // forms (`> /dev/stdout`, `2> /dev/stderr`) are no-ops — after
+        // `> a > /dev/stdout` content still goes to `a`.
+        if (target === "/dev/stdout") {
+          if (fd === 2) {
+            fd2Sink = fd1Sink;
+          }
+          break;
+        }
+        if (target === "/dev/stderr") {
+          if (fd === 1) {
+            fd1Sink = fd2Sink;
+          }
+          break;
+        }
+        // /dev/full always returns ENOSPC when written to. The diagnostic
+        // stays on live stderr and the fd's sink is left unchanged.
+        if (target === "/dev/full") {
+          stderr += `bash: echo: write error: No space left on device\n`;
+          exitCode = 1;
+          if (fd === 1) {
+            stdout = "";
+          }
+          break;
+        }
+        // /dev/null on fd 2 drops stderr without touching the VFS node.
+        // /dev/null on fd 1 intentionally falls through to the generic file
+        // path: in this VFS it is a regular file, not a true discard device
+        // (see overlay-fs.security.test.ts "/dev file overwrite behavior").
+        if (target === "/dev/null" && fd === 2) {
+          fd2Sink = { kind: "discard" };
+          break;
+        }
+        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
+        const error = await checkOutputRedirectTarget(ctx, filePath, target, {
+          ...(isAppend ? {} : { checkNoclobber: true, isClobber }),
+        });
+        if (error) {
+          stderr += error;
+          exitCode = 1;
+          if (fd === 1) {
+            stdout = "";
+          }
+          break;
+        }
+        // Opening the target is a side effect of processing the redirection
+        // list even when the fd is re-pointed again later: `>` truncates and
+        // `>>` creates the file if missing. Content is delivered to each
+        // fd's FINAL sink after the list is processed, so `cmd > a > b`
+        // truncates `a` but writes to `b`.
+        if (isAppend) {
+          await ctx.fs.appendFile(filePath, "", "binary");
+        } else {
+          await ctx.fs.writeFile(filePath, "", "binary");
+        }
         if (fd === 1) {
-          // /dev/stdout is a no-op for stdout - output stays on stdout
-          if (target === "/dev/stdout") {
-            break;
-          }
-          // /dev/stderr redirects stdout to stderr
-          if (target === "/dev/stderr") {
-            stderr += stdout;
-            stdout = "";
-            break;
-          }
-          // /dev/full always returns ENOSPC when written to
-          if (target === "/dev/full") {
-            stderr += `bash: echo: write error: No space left on device\n`;
-            exitCode = 1;
-            stdout = "";
-            break;
-          }
-          const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-          const error = await checkOutputRedirectTarget(
-            ctx,
-            filePath,
-            target,
-            {},
-          );
-          if (error) {
-            stderr += error;
-            exitCode = 1;
-            stdout = "";
-            break;
-          }
-          // Smart encoding: binary for byte data, UTF-8 for Unicode text
-          await ctx.fs.appendFile(filePath, stdout, getStdoutEncoding(stdout));
-          stdout = "";
-        } else if (fd === 2) {
-          // /dev/stderr is a no-op for stderr - output stays on stderr
-          if (target === "/dev/stderr") {
-            break;
-          }
-          // /dev/stdout redirects stderr to stdout
-          if (target === "/dev/stdout") {
-            stdout += stderr;
-            stderr = "";
-            break;
-          }
-          // /dev/full always returns ENOSPC when written to
-          if (target === "/dev/full") {
-            stderr += `bash: echo: write error: No space left on device\n`;
-            exitCode = 1;
-            break;
-          }
-          const filePath2 = ctx.fs.resolvePath(ctx.state.cwd, target);
-          const error2 = await checkOutputRedirectTarget(
-            ctx,
-            filePath2,
-            target,
-            {},
-          );
-          if (error2) {
-            stderr += error2;
-            exitCode = 1;
-            break;
-          }
-          // Smart encoding: binary for byte data, UTF-8 for Unicode text
-          await ctx.fs.appendFile(filePath2, stderr, getFileEncoding(stderr));
-          stderr = "";
+          fd1Sink = { kind: "file", path: filePath, append: isAppend };
+        } else {
+          fd2Sink = { kind: "file", path: filePath, append: isAppend };
         }
         break;
       }
@@ -686,18 +625,19 @@ export async function applyRedirections(
           }
           break;
         }
-        // >&2, 1>&2, 1<&2: redirect stdout to stderr
+        // >&2, 1>&2, 1<&2: duplicate fd 1 from fd 2 — fd 1 now points to a
+        // snapshot of wherever fd 2 points at this spot in the list. Content
+        // is not moved here: a later redirection may still repoint fd 1, so
+        // remaining stdout is delivered once the whole list is processed.
         if (target === "2" || target === "&2") {
           if (fd === 1) {
-            stderr += stdout;
-            stdout = "";
+            fd1Sink = fd2Sink;
           }
         }
-        // 2>&1, 2<&1: redirect stderr to stdout
+        // 2>&1, 2<&1: duplicate fd 2 from fd 1 — same deferred delivery.
         else if (target === "1" || target === "&1") {
           if (fd === 2) {
-            stdout += stderr;
-            stderr = "";
+            fd2Sink = fd1Sink;
           } else {
             // 1>&1 is a no-op, but other fds redirect to stdout
             stdout += stderr;
@@ -817,28 +757,19 @@ export async function applyRedirections(
               stdout = "";
               break;
             }
+            // Truncate now; content is delivered to the final sinks after
+            // the whole redirection list is processed.
+            await ctx.fs.writeFile(filePath, "", "binary");
             if (redir.fd == null) {
-              // >&word (no explicit fd) - write both stdout and stderr to the file
-              const combined = stdout + stderr;
-              await ctx.fs.writeFile(
-                filePath,
-                combined,
-                getStdoutEncoding(combined),
-              );
-              stdout = "";
-              stderr = "";
+              // >&word (no explicit fd) - both stdout and stderr to the file
+              fd1Sink = { kind: "file", path: filePath, append: false };
+              fd2Sink = fd1Sink;
             } else if (fd === 1) {
               // 1>&word - redirect stdout to file
-              await ctx.fs.writeFile(
-                filePath,
-                stdout,
-                getStdoutEncoding(stdout),
-              );
-              stdout = "";
+              fd1Sink = { kind: "file", path: filePath, append: false };
             } else if (fd === 2) {
               // 2>&word - redirect stderr to file
-              await ctx.fs.writeFile(filePath, stderr, getFileEncoding(stderr));
-              stderr = "";
+              fd2Sink = { kind: "file", path: filePath, append: false };
             }
           }
         }
@@ -863,11 +794,11 @@ export async function applyRedirections(
           stdout = "";
           break;
         }
-        // Smart encoding: binary for byte data, UTF-8 for Unicode text
-        const combined = stdout + stderr;
-        await ctx.fs.writeFile(filePath, combined, getStdoutEncoding(combined));
-        stdout = "";
-        stderr = "";
+        // Truncate now; content is delivered to the final sinks after the
+        // whole redirection list is processed.
+        await ctx.fs.writeFile(filePath, "", "binary");
+        fd1Sink = { kind: "file", path: filePath, append: false };
+        fd2Sink = fd1Sink;
         break;
       }
 
@@ -892,16 +823,78 @@ export async function applyRedirections(
           stdout = "";
           break;
         }
-        // Smart encoding: binary for byte data, UTF-8 for Unicode text
-        const combined = stdout + stderr;
-        await ctx.fs.appendFile(
-          filePath,
-          combined,
-          getStdoutEncoding(combined),
-        );
-        stdout = "";
-        stderr = "";
+        // Create if missing; content is delivered to the final sinks after
+        // the whole redirection list is processed.
+        await ctx.fs.appendFile(filePath, "", "binary");
+        fd1Sink = { kind: "file", path: filePath, append: true };
+        fd2Sink = fd1Sink;
         break;
+      }
+    }
+  }
+
+  // Deliver content still held in the streams to each fd's final sink.
+  // "live-stdout" / "live-stderr" mean the caller's own streams as they were
+  // before any redirection — a dup snapshot of a live fd keeps pointing
+  // there even if a later redirection sends the source fd elsewhere.
+  //
+  // A duplication (`2>&1`) shares the source fd's sink OBJECT — one open
+  // descriptor, so both streams go through it in order. Two independent
+  // redirects that happen to name the same path (`> f 2> f`) are separate
+  // descriptors, each writing from its own start position, so the later
+  // non-empty write clobbers the earlier one — matching bash's
+  // independent-open behavior.
+  if (stdout !== "" || stderr !== "") {
+    const pendingStdout = stdout;
+    const pendingStderr = stderr;
+    stdout = "";
+    stderr = "";
+    const deliverToFile = async (
+      sink: { path: string; append: boolean },
+      content: string,
+      encoding: "binary" | "utf8",
+    ) => {
+      if (sink.append) {
+        await ctx.fs.appendFile(sink.path, content, encoding);
+      } else {
+        await ctx.fs.writeFile(sink.path, content, encoding);
+      }
+    };
+    if (fd1Sink === fd2Sink && fd1Sink.kind === "file") {
+      // stdout-then-stderr order, not the command's temporal write order:
+      // ExecResult accumulates the two streams separately, so interleaving
+      // is not recorded anywhere in the interpreter. This matches the
+      // convention of the live-stream merge (`stdout += stderr`) used for a
+      // bare `2>&1`.
+      const combined = pendingStdout + pendingStderr;
+      if (combined !== "") {
+        await deliverToFile(fd1Sink, combined, getStdoutEncoding(combined));
+      }
+    } else {
+      for (const [content, sink, isStdout] of [
+        [pendingStdout, fd1Sink, true],
+        [pendingStderr, fd2Sink, false],
+      ] as const) {
+        if (content === "") {
+          continue;
+        }
+        switch (sink.kind) {
+          case "live-stdout":
+            stdout += content;
+            break;
+          case "live-stderr":
+            stderr += content;
+            break;
+          case "file":
+            await deliverToFile(
+              sink,
+              content,
+              isStdout ? getStdoutEncoding(content) : getFileEncoding(content),
+            );
+            break;
+          case "discard":
+            break;
+        }
       }
     }
   }


### PR DESCRIPTION
## Problem

`cmd > file 2>&1` leaks stderr onto the caller's stdout instead of sending it to the file. `applyRedirections()` processes the redirection list sequentially over the result's accumulated stdout/stderr strings, moving content at each step — so `2>&1` merged stderr into the live stream regardless of where fd 1 pointed at that spot in the list. "Command not found" errors and custom-command stderr both leak this way.

This corrupts any wrapper protocol that parses the enclosing script's stdout. Concrete case: a Bash-tool runner that executes `eval "$CMD" > "$OUTPUT_FILE" 2>&1` and then prints a JSON payload on stdout — a stubbed command's stderr (`Error! Forbidden (403): …`) lands glued to the front of the JSON, the payload fails to parse, and the agent sees a runner error instead of the injected 403. In omniagent's eval suite (via `@vercel/sandbox-mock`), this contaminated 17% of gpt-5.5 trials and 9% of opus trials in a full run, because gpt-5.5 prefers the Bash tool's `args` form, which can't express redirects that would dodge the leak.

Other orderings were wrong in related ways:

- `cmd 2>&1 > file` put stderr in the file instead of on stdout
- `cmd > all 2>&1 2> err` couldn't reclaim stderr with the later `2> err`
- `cmd > a > b` wrote content to `a` instead of `b`
- `cmd > f 2> /dev/stdout` merged stderr into `f`'s content instead of routing it to fd 1's target

## Changes

The pass now mirrors how bash sets up fds before running the command:

- Each output redirection (`>`, `>|`, `>>`, `>&word`, `&>`, `&>>`) only performs its open side effect (truncate or create) and re-points the fd's sink — a file (with open mode), `/dev/null` discard, or a snapshot of a caller-visible stream.
- Duplication operators (`2>&1`, `1>&2`, and `/dev/stdout` / `/dev/stderr` targets) copy the source fd's current sink object; the self-referential forms (`> /dev/stdout` on fd 1, `2> /dev/stderr`) are no-ops.
- Stream content is delivered once, after the whole list is processed, to each fd's final sink. A dup-shared sink object (one descriptor) receives both streams in order; two independent redirects naming the same path stay separate descriptors, so the later non-empty write clobbers the earlier one, as with real independent opens.

Behavior preserved deliberately:

- `/dev/null` on stdout redirects still writes the VFS node (documented in `overlay-fs.security.test.ts` as "not a true discard device"); `2> /dev/null` still drops without writing.
- `/dev/full` still surfaces the ENOSPC diagnostic on live stderr.
- User-fd (3+) duplication paths and persistent `exec` fd handling are untouched.

Known limitation (pre-existing): when both streams merge into one file, delivery is stdout-then-stderr, not the command's temporal write order — `ExecResult` accumulates the streams separately, so interleaving is not recorded anywhere in the interpreter. Same convention as the live-stream merge used for a bare `2>&1`.