### PR TITLE
fix(interpreter): seed cd dash from OLDPWD exec option

### DIFF
--- a/packages/just-bash/src/Bash.exec-options.test.ts
+++ b/packages/just-bash/src/Bash.exec-options.test.ts
@@ -193,6 +193,29 @@ describe("exec options", () => {
       const envResult = await env.exec("echo $MODE");
       expect(envResult.stdout).toBe("dev\n");
     });
+
+    it("should use OLDPWD from per-exec env for cd dash", async () => {
+      const env = new Bash({ cwd: "/" });
+      await env.exec("mkdir -p /tmp/old /tmp/new");
+
+      const firstCd = await env.exec("cd /tmp/old", {
+        cwd: "/",
+        env: env.getEnv(),
+      });
+      const secondCd = await env.exec("cd ../new", {
+        cwd: firstCd.env.PWD,
+        env: firstCd.env,
+      });
+
+      const result = await env.exec("cd -", {
+        cwd: secondCd.env.PWD,
+        env: secondCd.env,
+      });
+
+      expect(result.stdout).toBe("/tmp/old\n");
+      expect(result.env.PWD).toBe("/tmp/old");
+      expect(result.env.OLDPWD).toBe("/tmp/new");
+    });
   });
 
   describe("error handling", () => {

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -635,6 +635,7 @@ export class Bash {
       ...this.state,
       env: execEnv,
       cwd: newCwd,
+      previousDir: options?.env?.OLDPWD ?? this.state.previousDir,
       // Deep copy mutable objects to prevent interference
       functions: new Map(this.state.functions),
       localScopes: [...this.state.localScopes],


### PR DESCRIPTION
## Summary

- seed the per-exec interpreter `previousDir` from `OLDPWD` when callers pass an env snapshot into `exec()`
- add regression coverage for `cd -` across isolated `exec()` calls using persisted `cwd` and `env`

## Why

`exec()` supports per-call `cwd` and `env`, which lets callers preserve shell state between isolated executions. `cd` updates `OLDPWD` in the returned env, but `cd -` reads the interpreter's internal `previousDir` state instead.

That means a caller can pass the returned `PWD` and `OLDPWD` into the next `exec()` call and still get stale `cd -` behavior.

## Verification

- `pnpm --filter just-bash test:run src/Bash.exec-options.test.ts src/interpreter/builtins/cd.test.ts`
- `pnpm --filter just-bash test:run src/spec-tests/bash/spec.test.ts -t 'cd - without OLDPWD'`
- `pnpm lint`
- `pnpm knip`
- `pnpm --filter just-bash typecheck`
- `pnpm --filter just-bash build`