### PR TITLE
ci: add weekly deep-fuzz workflow (test:fuzz:long)

### DIFF
--- a/.github/workflows/fuzz-deep.yml
+++ b/.github/workflows/fuzz-deep.yml
@@ -1,0 +1,32 @@
+name: Deep Fuzz
+
+on:
+  schedule:
+    - cron: "0 3 * * 1"
+  workflow_dispatch:
+
+jobs:
+  deep-fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run deep fuzz
+        run: pnpm --filter just-bash test:fuzz:long


### PR DESCRIPTION
## Summary

The fuzzing suite (`src/security/fuzzing/`, 4 fuzz test files + generators + DoS/sandbox oracles) already runs on every PR inside `test:unit` — but only with the default budget (50–100 runs per test, `FUZZ_RUNS` unset). The deep run that the repo already defines, `test:fuzz:long` (`FUZZ_RUNS=10000`), never runs in any workflow.

This adds `.github/workflows/fuzz-deep.yml`:

- **Triggers**: weekly schedule (Mondays 03:00 UTC) + `workflow_dispatch` for manual runs — deliberately not on push/PR (cost).
- **Job**: single ubuntu-latest job, `timeout-minutes: 60`, setup mirroring `unit-tests.yml` (LFS, pnpm, Node 20), running `pnpm --filter just-bash test:fuzz:long`.
- A crash or oracle violation fails the workflow (no `continue-on-error`) — that's the signal.

This gives low-probability DoS/sandbox regressions (only visible with a large budget) continuous coverage without adding PR latency.

Related: #295 (separate, independent change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)