### PR TITLE
fix(interpreter): preserve executable script exit status

### DIFF
--- a/packages/just-bash/src/interpreter/executable-script.test.ts
+++ b/packages/just-bash/src/interpreter/executable-script.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+describe("executable scripts", () => {
+  it.each([
+    2, 1,
+  ])("continues a semicolon list after a script exits %i", async (exitCode) => {
+    const env = new Bash({
+      files: {
+        "/scripts/fail.sh": `exit ${exitCode}\n`,
+      },
+    });
+    await env.exec("chmod +x /scripts/fail.sh");
+
+    const result = await env.exec("/scripts/fail.sh ; echo $?");
+
+    expect(result).toMatchObject({
+      stdout: `${exitCode}\n`,
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("does not continue an AND list after a script fails", async () => {
+    const env = new Bash({
+      files: {
+        "/scripts/fail.sh": "exit 2\n",
+      },
+    });
+    await env.exec("chmod +x /scripts/fail.sh");
+
+    const result = await env.exec("/scripts/fail.sh && echo $?");
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      exitCode: 2,
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/subshell-group.ts
+++ b/packages/just-bash/src/interpreter/subshell-group.ts
@@ -400,9 +400,10 @@ export async function executeUserScript(
   } catch (error) {
     cleanup();
 
-    // ExitError propagates up (but with output from this script)
+    // Executable scripts run in a subshell-like environment, so exit only
+    // ends the script and returns its status to the surrounding command list.
     if (error instanceof ExitError) {
-      throw error;
+      return result(error.stdout, error.stderr, error.exitCode);
     }
 
     // ExecutionLimitError must always propagate


### PR DESCRIPTION
## Summary

- return an executable script's `exit` status to its parent command list
- add regression coverage for `;` and `&&` after executable scripts exit nonzero

## Why

Executable scripts run in a subshell-like context, but their internal `ExitError` was rethrown after the script state was restored. That terminated the surrounding command list, so:

```sh
./fail.sh ; echo $?

never reached echo.

The script boundary now converts ExitError into a normal command result. This preserves the exit status while allowing the parent list to apply standard ; and && behavior.

## Verification

- pnpm vitest run src/interpreter/executable-script.test.ts