### PR TITLE
fix(python): resolve runpy paths in virtual filesystem

### DIFF
--- a/packages/just-bash/src/commands/python3/python3.files.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.files.test.ts
@@ -133,6 +133,31 @@ describe("python3 file I/O", () => {
       expect(result.stdout).toBe("line1\nline2\n");
       expect(result.exitCode).toBe(0);
     });
+
+    it("should execute a file with runpy.run_path", async () => {
+      const env = new Bash({ python: true });
+      await env.exec(`cat > /tmp/runpy_target.py << 'EOF'
+print(f"executed: {__file__}")
+value = 42
+EOF`);
+      const result = await env.exec(
+        `python3 -c "import runpy; result = runpy.run_path('/tmp/runpy_target.py'); print(result['value'])"`,
+      );
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("executed: /tmp/runpy_target.py\n42\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should accept a Path in runpy.run_path", async () => {
+      const env = new Bash({ python: true });
+      await env.exec("echo 'value = 42' > /tmp/runpy_path.py");
+      const result = await env.exec(
+        `python3 -c "import runpy; from pathlib import Path; print(runpy.run_path(Path('/tmp/runpy_path.py'))['value'])"`,
+      );
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("42\n");
+      expect(result.exitCode).toBe(0);
+    });
   });
 
   describe("directory operations", () => {

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -830,9 +830,18 @@ def _redir_scandir(path='.'):
     return _orig_scandir(path)
 os.scandir = _redir_scandir
 
-# io.open
+# io.open and io.open_code
 import io as _io_module
 _io_module.open = builtins.open
+
+# runpy uses io.open_code rather than builtins.open/io.open. Redirect it
+# separately so code loading keeps the logical path in __file__ and argv.
+_orig_open_code = _io_module.open_code
+def _redir_open_code(path):
+    if _should_redirect(path):
+        path = '/host' + path
+    return _orig_open_code(path)
+_io_module.open_code = _redir_open_code
 
 # shutil
 import shutil as _shutil_module


### PR DESCRIPTION
## Summary
- redirect `io.open_code()` through the Python virtual filesystem mount so `runpy.run_path()` can execute sandbox files
- preserve logical paths in `__file__` instead of exposing the internal `/host` mount
- add coverage for absolute paths, returned globals, and `pathlib.Path` inputs

## Test plan
- [x] `pnpm exec vitest run --config vitest.wasm.config.ts src/commands/python3/python3.files.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm exec biome check src/commands/python3/worker.ts src/commands/python3/python3.files.test.ts`

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d4a677e543944346bd8834bfa046822d)