### PR TITLE
fix(interpreter): handle unclosed POSIX case patterns

### DIFF
--- a/.changeset/fix-unclosed-posix-case-pattern.md
+++ b/.changeset/fix-unclosed-posix-case-pattern.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Treat unmatched outer brackets around POSIX classes as literals during shell pattern matching instead of throwing a JavaScript regular-expression error.

--- a/packages/just-bash/src/interpreter/conditionals.ts
+++ b/packages/just-bash/src/interpreter/conditionals.ts
@@ -621,7 +621,7 @@ function patternToRegexStr(pattern: string, extglob: boolean): string {
     } else if (char === "?") {
       regex += ".";
     } else if (char === "[") {
-      const closeIdx = pattern.indexOf("]", i + 1);
+      const closeIdx = findPatternCharClassEnd(pattern, i);
       if (closeIdx !== -1) {
         regex += pattern.slice(i, closeIdx + 1);
         i = closeIdx;
@@ -635,6 +635,60 @@ function patternToRegexStr(pattern: string, extglob: boolean): string {
     }
   }
   return regex;
+}
+
+/**
+ * Find the closing bracket for a shell pattern character class.
+ *
+ * A bracket expression such as `[[:alpha:]]` contains an inner `:]` that
+ * closes the POSIX class, not the surrounding shell character class. A plain
+ * `indexOf("]")` therefore turns a malformed outer class like `[[:alpha:]`
+ * into the invalid regular expression `[[:alpha:]`. Bash instead treats the
+ * unmatched outer `[` literally and continues parsing the remaining pattern.
+ */
+function findPatternCharClassEnd(pattern: string, start: number): number {
+  let i = start + 1;
+
+  if (i < pattern.length && (pattern[i] === "!" || pattern[i] === "^")) {
+    i++;
+  }
+
+  // A closing bracket in the first position is part of the class.
+  if (i < pattern.length && pattern[i] === "]") {
+    i++;
+  }
+
+  while (i < pattern.length) {
+    if (pattern[i] === "\\" && i + 1 < pattern.length) {
+      i += 2;
+      continue;
+    }
+
+    // POSIX character classes, collating symbols, and equivalence classes are
+    // nested bracket constructs whose closing bracket is not the outer one.
+    if (
+      pattern[i] === "[" &&
+      i + 1 < pattern.length &&
+      (pattern[i + 1] === ":" ||
+        pattern[i + 1] === "." ||
+        pattern[i + 1] === "=")
+    ) {
+      const marker = pattern[i + 1];
+      const nestedEnd = pattern.indexOf(`${marker}]`, i + 2);
+      if (nestedEnd !== -1) {
+        i = nestedEnd + 2;
+        continue;
+      }
+    }
+
+    if (pattern[i] === "]") {
+      return i;
+    }
+
+    i++;
+  }
+
+  return -1;
 }
 
 /**

--- a/packages/just-bash/src/interpreter/control-flow.test.ts
+++ b/packages/just-bash/src/interpreter/control-flow.test.ts
@@ -398,6 +398,21 @@ describe("control flow execution", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("should treat an unmatched outer POSIX class bracket literally", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        for x in B '[a' '[x'; do
+          case "$x" in
+            [[:alpha:]) echo "$x:match" ;;
+            *) echo "$x:no" ;;
+          esac
+        done
+      `);
+      expect(result.stdout).toBe("B:no\n[a:match\n[x:no\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
     it("should match with multiple patterns", async () => {
       const env = new Bash();
       const result = await env.exec(`


### PR DESCRIPTION
Fixes #301.

## Summary

- scan shell character classes without mistaking an inner POSIX `:]`, collating `.]`, or equivalence `=]` terminator for the outer closing bracket
- preserve the Bash literal-`[` fallback when the outer bracket is unmatched
- add a regression covering both the non-match and literal-prefix match behavior
- add a patch changeset

## Verification

- `pnpm --filter just-bash exec vitest run src/interpreter/control-flow.test.ts`
- `pnpm --filter just-bash test:comparison` (560 passed)
- `pnpm --filter just-bash test:unit` (13,187 passed, 97 skipped)
- `pnpm --filter just-bash build`
- `pnpm --filter just-bash typecheck`
- `pnpm --filter just-bash lint`
- `pnpm --filter just-bash knip`