### PR TITLE
feat(curl): add GET data aggregation

### DIFF
--- a/.changeset/calm-cats-curl-data.md
+++ b/.changeset/calm-cats-curl-data.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add curl `-G`/`--get` query-string data handling and preserve command-line order when repeated `-d`, `--data-raw`, `--data-binary`, and `--data-urlencode` options are mixed, including `@file` forms. Data requests now also set curl's standard `application/x-www-form-urlencoded` content type unless the caller supplies one.

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -10,7 +10,7 @@ import { getErrorMessage } from "../../interpreter/helpers/errors.js";
 import { _Headers } from "../../security/trusted-globals.js";
 import type { Command, CommandContext, ExecResult } from "../../types.js";
 import { hasHelpFlag, showHelp } from "../help.js";
-import { generateMultipartBody } from "./form.js";
+import { encodeCurlData, generateMultipartBody } from "./form.js";
 import { curlHelp } from "./help.js";
 import { parseOptions } from "./parse.js";
 import {
@@ -21,65 +21,52 @@ import {
 import type { CurlOptions } from "./types.js";
 
 /**
- * Resolve the body for `-d`/`--data`/`--data-binary` (and their `@file`
- * forms). Real curl strips CR and LF from `-d @file` reads (ascii mode);
- * `--data-binary @file` is sent verbatim. Inline values are returned as-is.
- */
-async function resolveDataBody(
-  options: CurlOptions,
-  ctx: CommandContext,
-): Promise<string | undefined> {
-  if (options.dataFile) {
-    const filePath = ctx.fs.resolvePath(ctx.cwd, options.dataFile.path);
-    let content = await ctx.fs.readFile(filePath);
-    if (options.dataFile.mode === "ascii") {
-      content = content.replace(/[\r\n]/g, "");
-    }
-    // `--data-urlencode` arguments that appear *after* a `-d @file` keep
-    // accumulating into `options.data`; preserve that concatenation so a
-    // mixed invocation like `-d @file --data-urlencode "x=1"` still emits
-    // both payloads joined with `&`.
-    return options.data ? `${content}&${options.data}` : content;
-  }
-  return options.data;
-}
-
-/**
- * Append `--data-urlencode @file` and `--data-urlencode name@file` payloads
- * to the existing inline urlencode payload. File contents are URL-encoded
- * after read and joined with `&`, matching real curl's behavior.
+ * Resolve every `-d`/`--data*`/`--data-urlencode` part into a single payload,
+ * reading any `@file` references and joining the parts with `&` — matching
+ * real curl's concatenation of repeated data flags. Returns undefined when no
+ * data flags were given.
  *
- * Note: file contents are passed through `encodeURIComponent` directly
- * rather than the inline-form helper. The inline helper (`encodeFormData`)
- * splits on the first `=` to separate `name=value` arguments, which would
- * mis-encode any `=` byte inside the file. For `@file` (and `name@file`)
- * forms the entire file body is the value — `=` bytes must be percent-
- * encoded like every other reserved character.
+ * Per-part `@file` handling mirrors real curl:
+ *   - ascii (`-d`/`--data` @file): strip CR and LF after reading.
+ *   - binary (`--data-binary` @file): send the bytes verbatim.
+ *   - urlencode (`--data-urlencode` @file/name@file): URL-encode the whole
+ *     file body as one value (so a `=` byte inside the file is percent-encoded
+ *     rather than treated as a name/value separator), with an optional
+ *     `name=` prefix.
  */
-async function resolveUrlencodeFiles(
+async function resolveData(
   options: CurlOptions,
   ctx: CommandContext,
-  base: string | undefined,
 ): Promise<string | undefined> {
-  if (options.urlencodeFiles.length === 0) return base;
-  const parts: string[] = base ? [base] : [];
-  for (const entry of options.urlencodeFiles) {
-    const filePath = ctx.fs.resolvePath(ctx.cwd, entry.path);
-    const content = await ctx.fs.readFile(filePath);
-    const encoded = encodeURIComponent(content);
-    parts.push(
-      entry.name ? `${encodeURIComponent(entry.name)}=${encoded}` : encoded,
-    );
+  if (options.dataParts.length === 0) return undefined;
+  const parts: string[] = [];
+  for (const part of options.dataParts) {
+    if (part.file) {
+      const filePath = ctx.fs.resolvePath(ctx.cwd, part.file.path);
+      const content = await ctx.fs.readFile(filePath);
+      if (part.file.mode === "ascii") {
+        parts.push(content.replace(/[\r\n]/g, ""));
+      } else if (part.file.mode === "binary") {
+        parts.push(content);
+      } else {
+        const encoded = encodeCurlData(content);
+        parts.push(part.file.name ? `${part.file.name}=${encoded}` : encoded);
+      }
+    } else {
+      parts.push(part.value ?? "");
+    }
   }
   return parts.join("&");
 }
 
 /**
- * Prepare request body from options, reading files if needed
+ * Prepare request body from options, reading files if needed. `resolvedData`
+ * is the already-joined `-d`/`--data*` payload (see resolveData).
  */
 async function prepareRequestBody(
   options: CurlOptions,
   ctx: CommandContext,
+  resolvedData: string | undefined,
 ): Promise<{ body?: string; contentType?: string }> {
   // Handle -T/--upload-file
   if (options.uploadFile) {
@@ -116,18 +103,32 @@ async function prepareRequestBody(
     };
   }
 
-  // Handle -d/--data/--data-binary/--data-raw (inline + @file) and
-  // accumulated --data-urlencode files. The two flavors are merged with `&`
-  // because real curl lets you mix `-d foo --data-urlencode @file` and
-  // concatenates the payloads.
-  let body = await resolveDataBody(options, ctx);
-  body = await resolveUrlencodeFiles(options, ctx, body);
-  if (body !== undefined) {
-    return { body };
+  // Handle -d/--data/--data-binary/--data-raw/--data-urlencode (inline +
+  // @file). In -G/--get mode the payload goes onto the URL query string
+  // instead of the body (handled by the caller), so emit no body here.
+  if (resolvedData !== undefined && !options.getMode) {
+    return {
+      body: resolvedData,
+      contentType: "application/x-www-form-urlencoded",
+    };
   }
 
   // @banned-pattern-ignore: returns typed object with known keys (body, contentType), not user data
   return {};
+}
+
+function appendDataToUrl(url: string, data: string | undefined): string {
+  if (!data) return url;
+  const hashIndex = url.indexOf("#");
+  const base = hashIndex === -1 ? url : url.slice(0, hashIndex);
+  const fragment = hashIndex === -1 ? "" : url.slice(hashIndex);
+  const separator =
+    base.endsWith("?") || base.endsWith("&")
+      ? ""
+      : base.includes("?")
+        ? "&"
+        : "?";
+  return `${base}${separator}${data}${fragment}`;
 }
 
 /**
@@ -274,8 +275,20 @@ export const curlCommand: Command = {
     }
 
     try {
+      // Resolve -d/--data* payloads (reading any @file references) once, then
+      // either append to the URL (-G/--get) or send as the body.
+      const resolvedData = await resolveData(options, ctx);
+
+      if (options.getMode) {
+        url = appendDataToUrl(url, resolvedData);
+      }
+
       // Prepare body and headers
-      const { body, contentType } = await prepareRequestBody(options, ctx);
+      const { body, contentType } = await prepareRequestBody(
+        options,
+        ctx,
+        resolvedData,
+      );
       const headers = prepareHeaders(options, contentType);
 
       const result = await ctx.fetch(url, {

--- a/packages/just-bash/src/commands/curl/form.ts
+++ b/packages/just-bash/src/commands/curl/form.ts
@@ -4,9 +4,17 @@
 
 import type { FormField } from "./types.js";
 
+export function encodeCurlData(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16)}`)
+    .replace(/%20/g, "+")
+    .replace(/%[0-9A-F]{2}/g, (percentEscape) => percentEscape.toLowerCase());
+}
+
 /**
  * URL-encode form data in curl's --data-urlencode format
- * Supports: name=content, =content, name@file, @file
+ * Supports: name=content, =content, content. The `@file` / `name@file` forms
+ * are detected in parseOptions and deferred to execute time (see resolveData).
  */
 export function encodeFormData(input: string): string {
   // Check for name=value format
@@ -14,13 +22,11 @@ export function encodeFormData(input: string): string {
   if (eqIndex >= 0) {
     const name = input.slice(0, eqIndex);
     const value = input.slice(eqIndex + 1);
-    if (name) {
-      return `${encodeURIComponent(name)}=${encodeURIComponent(value)}`;
-    }
-    return encodeURIComponent(value);
+    const encoded = encodeCurlData(value);
+    return name ? `${name}=${encoded}` : encoded;
   }
   // Plain value
-  return encodeURIComponent(input);
+  return encodeCurlData(input);
 }
 
 /**

--- a/packages/just-bash/src/commands/curl/help.ts
+++ b/packages/just-bash/src/commands/curl/help.ts
@@ -15,6 +15,7 @@ export const curlHelp: {
     "-X, --request METHOD  HTTP method (GET, POST, PUT, DELETE, etc.)",
     "-H, --header HEADER   Add header (can be used multiple times)",
     "-d, --data DATA       HTTP POST data (DATA=@file reads from file, strips newlines)",
+    "-G, --get             Append data payloads to URL query string",
     "    --data-raw DATA   HTTP POST data (no @ interpretation)",
     "    --data-binary DATA  HTTP POST binary data (DATA=@file reads file verbatim)",
     "    --data-urlencode DATA  URL-encode and POST data (supports @file and name@file)",

--- a/packages/just-bash/src/commands/curl/parse.ts
+++ b/packages/just-bash/src/commands/curl/parse.ts
@@ -9,35 +9,26 @@ import { encodeFormData, parseFormField } from "./form.js";
 import type { CurlOptions } from "./types.js";
 
 /**
- * Apply `-d`/`--data`/`--data-binary`/`--data-raw` value.
+ * Push a `-d`/`--data`/`--data-binary`/`--data-raw` value as a data part.
  *
  * Real curl interprets a leading `@` as "read from file" for `-d`/`--data`
- * and `--data-binary`, but NOT for `--data-raw`. When `allowFile` is true
- * and the value begins with `@`, the path is recorded for execute-time
- * resolution and inline `data` is cleared; otherwise the value is taken
- * verbatim.
- *
- * `dataFile` and `data` are mutually exclusive: each `-d`/`--data*`
- * occurrence overwrites the previous one. This is the just-bash status quo
- * for these flags and intentionally differs from real curl, which combines
- * repeated `-d` flags with `&`. The narrower scope avoids changing
- * established behavior for inline values while still fixing the `@file`
- * gap. `--data-urlencode` retains its own per-flag accumulation path.
+ * and `--data-binary`, but NOT for `--data-raw`. When `allowFile` is true and
+ * the value begins with `@`, the path is recorded for execute-time resolution
+ * (the VFS read is async); otherwise the value is taken verbatim. Parts
+ * accumulate in order and are joined with `&` at execute time, matching real
+ * curl's combination of repeated data flags.
  */
-function applyDataArg(
+function pushDataPart(
   options: CurlOptions,
   value: string,
   spec: { binary: boolean; allowFile: boolean },
 ): void {
   if (spec.allowFile && value.startsWith("@")) {
-    options.dataFile = {
-      mode: spec.binary ? "binary" : "ascii",
-      path: value.slice(1),
-    };
-    options.data = undefined;
+    options.dataParts.push({
+      file: { path: value.slice(1), mode: spec.binary ? "binary" : "ascii" },
+    });
   } else {
-    options.data = value;
-    options.dataFile = undefined;
+    options.dataParts.push({ value });
   }
   if (spec.binary) {
     options.dataBinary = true;
@@ -45,33 +36,38 @@ function applyDataArg(
 }
 
 /**
- * Apply a `--data-urlencode` value. Real curl supports five forms:
+ * Push a `--data-urlencode` value as a data part. Real curl supports five
+ * forms:
  *   content       → encode content
  *   =content      → encode content (no `name=`)
  *   name=content  → `name=` + encode(content)
  *   @filename     → encode contents of file
  *   name@filename → `name=` + encode(contents of file)
  *
- * File forms are deferred to execute time so the VFS read is async-safe;
- * the inline forms keep the existing eager encoding behavior so multiple
- * `--data-urlencode` flags continue to concatenate with `&`.
+ * The `@file` forms are deferred to execute time so the VFS read is
+ * async-safe; the inline forms are encoded eagerly. Either way the result is
+ * one ordered data part joined with `&` alongside the other data flags.
  */
-function applyUrlencodeArg(options: CurlOptions, value: string): void {
+function pushUrlencodePart(options: CurlOptions, value: string): void {
   if (value.startsWith("@")) {
-    options.urlencodeFiles.push({ path: value.slice(1) });
+    options.dataParts.push({
+      file: { path: value.slice(1), mode: "urlencode" },
+    });
     return;
   }
   const atIndex = value.indexOf("@");
   const eqIndex = value.indexOf("=");
   if (atIndex > 0 && (eqIndex < 0 || atIndex < eqIndex)) {
-    options.urlencodeFiles.push({
-      name: value.slice(0, atIndex),
-      path: value.slice(atIndex + 1),
+    options.dataParts.push({
+      file: {
+        path: value.slice(atIndex + 1),
+        mode: "urlencode",
+        name: value.slice(0, atIndex),
+      },
     });
     return;
   }
-  options.data =
-    (options.data ? `${options.data}&` : "") + encodeFormData(value);
+  options.dataParts.push({ value: encodeFormData(value) });
 }
 
 /**
@@ -81,8 +77,9 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
   const options: CurlOptions = {
     method: "GET",
     headers: new _Headers(),
+    dataParts: [],
     dataBinary: false,
-    urlencodeFiles: [],
+    getMode: false,
     formFields: [],
     useRemoteName: false,
     headOnly: false,
@@ -95,16 +92,20 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
   };
 
   let impliesPost = false;
+  let explicitMethod = false;
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
 
     if (arg === "-X" || arg === "--request") {
       options.method = args[++i] ?? "GET";
+      explicitMethod = true;
     } else if (arg.startsWith("-X")) {
       options.method = arg.slice(2);
+      explicitMethod = true;
     } else if (arg.startsWith("--request=")) {
       options.method = arg.slice(10);
+      explicitMethod = true;
     } else if (arg === "-H" || arg === "--header") {
       const header = args[++i];
       if (header) {
@@ -123,41 +124,44 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
         const value = header.slice(colonIndex + 1).trim();
         options.headers.append(name, value);
       }
+    } else if (arg === "-G" || arg === "--get") {
+      options.getMode = true;
+      if (!explicitMethod) options.method = "GET";
     } else if (arg === "-d" || arg === "--data") {
-      applyDataArg(options, args[++i] ?? "", {
+      pushDataPart(options, args[++i] ?? "", {
         binary: false,
         allowFile: true,
       });
       impliesPost = true;
     } else if (arg === "--data-raw") {
-      applyDataArg(options, args[++i] ?? "", {
+      pushDataPart(options, args[++i] ?? "", {
         binary: false,
         allowFile: false,
       });
       impliesPost = true;
     } else if (arg.startsWith("-d")) {
-      applyDataArg(options, arg.slice(2), { binary: false, allowFile: true });
+      pushDataPart(options, arg.slice(2), { binary: false, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data=")) {
-      applyDataArg(options, arg.slice(7), { binary: false, allowFile: true });
+      pushDataPart(options, arg.slice(7), { binary: false, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data-raw=")) {
-      applyDataArg(options, arg.slice(11), {
+      pushDataPart(options, arg.slice(11), {
         binary: false,
         allowFile: false,
       });
       impliesPost = true;
     } else if (arg === "--data-binary") {
-      applyDataArg(options, args[++i] ?? "", { binary: true, allowFile: true });
+      pushDataPart(options, args[++i] ?? "", { binary: true, allowFile: true });
       impliesPost = true;
     } else if (arg.startsWith("--data-binary=")) {
-      applyDataArg(options, arg.slice(14), { binary: true, allowFile: true });
+      pushDataPart(options, arg.slice(14), { binary: true, allowFile: true });
       impliesPost = true;
     } else if (arg === "--data-urlencode") {
-      applyUrlencodeArg(options, args[++i] ?? "");
+      pushUrlencodePart(options, args[++i] ?? "");
       impliesPost = true;
     } else if (arg.startsWith("--data-urlencode=")) {
-      applyUrlencodeArg(options, arg.slice(17));
+      pushUrlencodePart(options, arg.slice(17));
       impliesPost = true;
     } else if (arg === "-F" || arg === "--form") {
       const formData = args[++i] ?? "";
@@ -245,6 +249,7 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
     } else if (arg === "-I" || arg === "--head") {
       options.headOnly = true;
       options.method = "HEAD";
+      explicitMethod = true;
     } else if (arg === "-i" || arg === "--include") {
       options.includeHeaders = true;
     } else if (arg === "-s" || arg === "--silent") {
@@ -287,6 +292,7 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
           case "I":
             options.headOnly = true;
             options.method = "HEAD";
+            explicitMethod = true;
             break;
           case "i":
             options.includeHeaders = true;
@@ -297,6 +303,10 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
           case "v":
             options.verbose = true;
             break;
+          case "G":
+            options.getMode = true;
+            if (!explicitMethod) options.method = "GET";
+            break;
           default:
             return unknownOption("curl", `-${c}`);
         }
@@ -306,8 +316,9 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
     }
   }
 
-  // Data/form options imply POST when no explicit method was set
-  if (impliesPost && options.method === "GET") {
+  // Data/form options imply POST when no explicit method was set. `-G`/`--get`
+  // keeps the request a GET and sends the payload as a query string instead.
+  if (impliesPost && !explicitMethod && !options.getMode) {
     options.method = "POST";
   }
 

--- a/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
@@ -164,7 +164,7 @@ describe("curl @file interpretation", () => {
         "curl --data-urlencode @/note.txt https://api.example.com/test",
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("hello%20world%20%26%20friends");
+      expect(lastRequest?.options.body).toBe("hello+world+%26+friends");
     });
 
     it("URL-encodes the file contents with name when value is name@file", async () => {
@@ -173,7 +173,7 @@ describe("curl @file interpretation", () => {
         "curl --data-urlencode note@/note.txt https://api.example.com/test",
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("note=value%20with%20space");
+      expect(lastRequest?.options.body).toBe("note=value+with+space");
     });
 
     it("concatenates inline and @file urlencode values with &", async () => {
@@ -182,20 +182,20 @@ describe("curl @file interpretation", () => {
         'curl --data-urlencode "a=1" --data-urlencode note@/note.txt https://api.example.com/test',
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("a=1&note=from%20file");
+      expect(lastRequest?.options.body).toBe("a=1&note=from+file");
     });
 
     it("percent-encodes `=` inside file contents (no name=value split)", async () => {
       // Real file contents may contain `=` bytes that must NOT be treated as
       // a name/value separator. encodeFormData would split on `=` and emit
       // `a=b%26c`; the @file form must treat the whole body as one value:
-      // every `=` percent-encodes to %3D.
+      // every `=` percent-encodes to %3d.
       const env = createEnv({ "/note.txt": "a=b&c" });
       const result = await env.exec(
         "curl --data-urlencode @/note.txt https://api.example.com/test",
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("a%3Db%26c");
+      expect(lastRequest?.options.body).toBe("a%3db%26c");
     });
 
     it("percent-encodes `=` inside file contents for the name@file form", async () => {
@@ -204,7 +204,7 @@ describe("curl @file interpretation", () => {
         "curl --data-urlencode payload@/note.txt https://api.example.com/test",
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("payload=k%3Dv");
+      expect(lastRequest?.options.body).toBe("payload=k%3dv");
     });
 
     it("supports --data-urlencode=@file form", async () => {
@@ -213,7 +213,7 @@ describe("curl @file interpretation", () => {
         "curl --data-urlencode=@/note.txt https://api.example.com/test",
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toBe("hi%20there");
+      expect(lastRequest?.options.body).toBe("hi+there");
     });
   });
 

--- a/packages/just-bash/src/commands/curl/tests/data-options.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/data-options.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for curl data aggregation and -G/--get behavior.
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Bash } from "../../../Bash.js";
+
+const originalFetch = global.fetch;
+let lastRequest: { url: string; options: RequestInit } | null = null;
+
+const mockFetch = vi.fn(async (url: string, options?: RequestInit) => {
+  lastRequest = { url, options: options ?? {} };
+  return new Response("ok", { status: 200 });
+});
+
+beforeAll(() => {
+  global.fetch = mockFetch as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+function createEnv(files?: Record<string, string>): Bash {
+  return new Bash({
+    files,
+    network: {
+      allowedUrlPrefixes: ["https://api.example.com"],
+      allowedMethods: ["GET", "POST"],
+    },
+  });
+}
+
+describe("curl data options", () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    lastRequest = null;
+  });
+
+  it("appends repeated data flags in command-line order", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -d 'a=1' --data 'b=2' --data-raw 'c=3' https://api.example.com/post",
+    );
+
+    const headers = new Headers(lastRequest?.options.headers as HeadersInit);
+    expect(result.exitCode).toBe(0);
+    expect(lastRequest).toEqual({
+      url: "https://api.example.com/post",
+      options: expect.objectContaining({
+        method: "POST",
+        body: "a=1&b=2&c=3",
+      }),
+    });
+    expect(headers.get("Content-Type")).toBe(
+      "application/x-www-form-urlencoded",
+    );
+  });
+
+  it("preserves a user-supplied content type", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -H 'Content-Type: text/plain' -d 'hello' https://api.example.com/post",
+    );
+
+    const headers = new Headers(lastRequest?.options.headers as HeadersInit);
+    expect(result.exitCode).toBe(0);
+    expect(headers.get("Content-Type")).toBe("text/plain");
+  });
+
+  it("moves ordered data to the URL in -G mode", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -G 'https://api.example.com/query?fixed=1#section' -d 'a=1' --data-urlencode 'b=hello world*' -d 'c=3'",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(lastRequest).toEqual({
+      url: "https://api.example.com/query?fixed=1&a=1&b=hello+world%2a&c=3#section",
+      options: expect.objectContaining({
+        method: "GET",
+      }),
+    });
+    expect(lastRequest?.options.body).toBeUndefined();
+  });
+
+  it("supports every inline --data-urlencode form", async () => {
+    const env = createEnv();
+
+    await env.exec(
+      "curl -G https://api.example.com/ --data-urlencode 'name=a b'",
+    );
+    expect(lastRequest?.url).toBe("https://api.example.com/?name=a+b");
+
+    await env.exec("curl -G https://api.example.com/ --data-urlencode '=a b'");
+    expect(lastRequest?.url).toBe("https://api.example.com/?a+b");
+
+    await env.exec("curl -G https://api.example.com/ --data-urlencode 'a b'");
+    expect(lastRequest?.url).toBe("https://api.example.com/?a+b");
+  });
+
+  it("does not duplicate an existing empty query delimiter", async () => {
+    const env = createEnv();
+
+    await env.exec("curl -G 'https://api.example.com/?' -d 'q=1'");
+    expect(lastRequest?.url).toBe("https://api.example.com/?q=1");
+
+    await env.exec("curl -G 'https://api.example.com/?fixed=1&' -d 'q=1'");
+    expect(lastRequest?.url).toBe("https://api.example.com/?fixed=1&q=1");
+  });
+
+  it("keeps an explicit request method regardless of -G ordering", async () => {
+    const env = createEnv();
+
+    await env.exec(
+      "curl -X POST -G https://api.example.com/ --data-urlencode 'q=1'",
+    );
+    expect(lastRequest).toEqual({
+      url: "https://api.example.com/?q=1",
+      options: expect.objectContaining({ method: "POST" }),
+    });
+    expect(lastRequest?.options.body).toBeUndefined();
+
+    await env.exec(
+      "curl -G -X POST https://api.example.com/ --data-urlencode 'q=1'",
+    );
+    expect(lastRequest).toEqual({
+      url: "https://api.example.com/?q=1",
+      options: expect.objectContaining({ method: "POST" }),
+    });
+    expect(lastRequest?.options.body).toBeUndefined();
+  });
+
+  it("preserves order when inline and file-backed parts are mixed", async () => {
+    const env = createEnv({ "/payload.txt": "a=1\n" });
+    const result = await env.exec(
+      "curl -d @/payload.txt --data-urlencode 'q=a b*' --data-raw 'c=3' https://api.example.com/post",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(lastRequest?.options.body).toBe("a=1&q=a+b%2a&c=3");
+  });
+});

--- a/packages/just-bash/src/commands/curl/tests/form.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/form.test.ts
@@ -50,7 +50,7 @@ describe("curl form data", () => {
         "curl --data-urlencode 'message=hello world' https://api.example.com/post",
       );
 
-      expect(lastRequest?.options.body).toBe("message=hello%20world");
+      expect(lastRequest?.options.body).toBe("message=hello+world");
     });
 
     it("encodes special characters", async () => {
@@ -64,7 +64,7 @@ describe("curl form data", () => {
         "curl --data-urlencode 'data=a&b=c' https://api.example.com/post",
       );
 
-      expect(lastRequest?.options.body).toBe("data=a%26b%3Dc");
+      expect(lastRequest?.options.body).toBe("data=a%26b%3dc");
     });
 
     it("appends multiple --data-urlencode values", async () => {

--- a/packages/just-bash/src/commands/curl/tests/parse.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/parse.test.ts
@@ -145,7 +145,7 @@ describe("curl option parsing", () => {
         'curl -s --data-urlencode "name=John Doe" https://api.example.com/test',
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toContain("John%20Doe");
+      expect(lastRequest?.options.body).toContain("John+Doe");
     });
 
     it("should handle --data-urlencode=value form", async () => {
@@ -154,7 +154,7 @@ describe("curl option parsing", () => {
         'curl -s --data-urlencode="foo=bar baz" https://api.example.com/test',
       );
       expect(result.exitCode).toBe(0);
-      expect(lastRequest?.options.body).toContain("bar%20baz");
+      expect(lastRequest?.options.body).toContain("bar+baz");
     });
 
     it("should append multiple --data-urlencode values", async () => {

--- a/packages/just-bash/src/commands/curl/types.ts
+++ b/packages/just-bash/src/commands/curl/types.ts
@@ -9,42 +9,46 @@ export interface FormField {
   contentType?: string;
 }
 
-export interface UrlencodeFile {
-  /** Optional field name; emits `name=` prefix before the encoded file contents. */
-  name?: string;
-  /** Path to read; resolved against ctx.cwd at execute time. */
-  path: string;
+/**
+ * A single `-d`/`--data`/`--data-binary`/`--data-raw`/`--data-urlencode`
+ * occurrence. Parts accumulate in command-line order and are joined with `&`
+ * at execute time, matching real curl's behavior of combining repeated data
+ * flags. Exactly one of `value` / `file` is set per part.
+ */
+export interface DataPart {
+  /**
+   * Inline value already in its final wire form: raw for `-d`/`--data`/
+   * `--data-raw`/`--data-binary`, URL-encoded for inline `--data-urlencode`.
+   * Undefined when the part is file-backed.
+   */
+  value?: string;
+  /** File-backed payload (`@file` forms), read at execute time. */
+  file?: DataPartFile;
 }
 
-export interface DataFile {
-  /**
-   * `ascii` matches `-d`/`--data` semantics: CR and LF are stripped after
-   * reading. `binary` matches `--data-binary`: file bytes are sent verbatim.
-   */
-  mode: "ascii" | "binary";
+export interface DataPartFile {
+  /** Path to read; resolved against ctx.cwd at execute time. */
   path: string;
+  /**
+   * `ascii` (`-d`/`--data` @file): CR and LF are stripped after reading.
+   * `binary` (`--data-binary` @file): file bytes are sent verbatim.
+   * `urlencode` (`--data-urlencode` @file/name@file): contents are
+   * URL-encoded after reading.
+   */
+  mode: "ascii" | "binary" | "urlencode";
+  /**
+   * `--data-urlencode name@file` emits a `name=` prefix before the encoded
+   * file contents. Undefined for the bare `@file` form.
+   */
+  name?: string;
 }
 
 export interface CurlOptions {
   method: string;
   headers: Headers;
-  data?: string;
+  dataParts: DataPart[];
   dataBinary: boolean;
-  /**
-   * File backing the `data` payload when `-d`/`--data`/`--data-binary` was
-   * given as `@filename`. Mutually exclusive with `data` — whichever form
-   * appears last on the command line wins. This last-write-wins shape is
-   * the established just-bash behavior for `-d`/`--data*` inline values
-   * and intentionally differs from real curl, which combines repeated
-   * `-d` payloads with `&`. The `@file` work here preserves that scope.
-   */
-  dataFile?: DataFile;
-  /**
-   * `--data-urlencode @file` and `--data-urlencode name@file` accumulate
-   * here. Each entry is encoded at execute time and joined with `&`
-   * alongside any inline urlencode payload accumulated in `data`.
-   */
-  urlencodeFiles: UrlencodeFile[];
+  getMode: boolean;
   formFields: FormField[];
   user?: string;
   uploadFile?: string;

--- a/packages/just-bash/src/comparison-tests/curl-data.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/curl-data.comparison.test.ts
@@ -1,0 +1,124 @@
+import { execFile } from "node:child_process";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+const execFileAsync = promisify(execFile);
+
+describe("curl data options - real curl comparison", () => {
+  const server = createServer((request, response) => {
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      const address = server.address() as AddressInfo;
+      const url = new URL(
+        request.url ?? "/",
+        `http://127.0.0.1:${address.port}`,
+      );
+      const body = Buffer.concat(chunks).toString("utf8");
+      const summary = {
+        method: request.method,
+        path: url.pathname,
+        query: [...url.searchParams.entries()],
+        body: body ? [...new URLSearchParams(body).entries()] : [],
+        contentType: request.headers["content-type"] ?? null,
+      };
+      response.writeHead(200, { "Content-Type": "application/json" });
+      response.end(JSON.stringify(summary));
+    });
+  });
+
+  let baseUrl: string;
+  let realCurlCwd: string;
+
+  beforeAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", () => resolve());
+    });
+    const address = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${address.port}`;
+    realCurlCwd = await mkdtemp(join(tmpdir(), "just-bash-curl-"));
+    await writeFile(join(realCurlCwd, "payload.txt"), "a=1\n");
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    await rm(realCurlCwd, { recursive: true, force: true });
+  });
+
+  async function runRealCurl(args: string[]): Promise<string> {
+    const { stdout } = await execFileAsync("curl", ["-sS", ...args], {
+      cwd: realCurlCwd,
+      encoding: "utf8",
+    });
+    return stdout;
+  }
+
+  function createEnv(files?: Record<string, string>): Bash {
+    return new Bash({
+      files,
+      network: {
+        allowedUrlPrefixes: [baseUrl],
+        allowedMethods: ["GET", "POST"],
+        denyPrivateRanges: false,
+      },
+    });
+  }
+
+  it("matches -G query aggregation", async () => {
+    const real = await runRealCurl([
+      "-G",
+      `${baseUrl}/echo?fixed=1`,
+      "--data-urlencode",
+      "query=a b*",
+      "-d",
+      "raw=1",
+    ]);
+    const result = await createEnv().exec(
+      `curl -sS -G '${baseUrl}/echo?fixed=1' --data-urlencode 'query=a b*' -d 'raw=1'`,
+    );
+
+    expect(result).toMatchObject({ stdout: real, stderr: "", exitCode: 0 });
+  });
+
+  it("matches ordered inline and file-backed POST data", async () => {
+    const real = await runRealCurl([
+      "-d",
+      "@payload.txt",
+      "--data-urlencode",
+      "q=a b*",
+      "--data-raw",
+      "c=3",
+      `${baseUrl}/echo`,
+    ]);
+    const result = await createEnv({ "/payload.txt": "a=1\n" }).exec(
+      `curl -sS -d @/payload.txt --data-urlencode 'q=a b*' --data-raw 'c=3' '${baseUrl}/echo'`,
+    );
+
+    expect(result).toMatchObject({ stdout: real, stderr: "", exitCode: 0 });
+  });
+
+  it("matches -G combined with an explicit request method", async () => {
+    const real = await runRealCurl([
+      "-X",
+      "POST",
+      "-G",
+      "--data-urlencode",
+      "q=1",
+      `${baseUrl}/echo`,
+    ]);
+    const result = await createEnv().exec(
+      `curl -sS -X POST -G --data-urlencode 'q=1' '${baseUrl}/echo'`,
+    );
+
+    expect(result).toMatchObject({ stdout: real, stderr: "", exitCode: 0 });
+  });
+});


### PR DESCRIPTION
## Summary

- Add curl `-G`/`--get` support so data options are appended to the query string.
- Preserve command-line order across repeated inline and file-backed data options.
- Match curl URL-encoding and default form content-type behavior.

## Why

The current implementation overwrites repeated data flags and cannot move their payload to the URL. It also diverges from curl for spaces, percent-escape casing, and the default content type.

## Validation

- 63 focused curl tests
- 3 live comparisons against system curl
- `pnpm lint`
- `pnpm knip`
- `pnpm --filter just-bash typecheck`
- `pnpm --filter just-bash build`
- Full `test:run`: 13,627 passed; one unrelated security hypothesis test was flaky in the combined run and passed on immediate isolated retry.
