### PR TITLE
feat(fs): add allowNestedMounts to MountableFs

### DIFF
--- a/.changeset/hungry-moons-mount-nested.md
+++ b/.changeset/hungry-moons-mount-nested.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add `allowNestedMounts` to `MountableFs`, letting a mount sit inside another mount. With the option set, mounting `/data/private` inside an existing `/data` mount shadows that subtree the way an OS mount does: the deepest mount owning a path wins, so `/data/private/key` routes to the inner filesystem while `/data/notes.txt` stays with the outer one, and unmounting reveals the outer filesystem's contents again. This makes it possible to hide a subdirectory of a mounted filesystem behind a restricted one without wrapping the whole filesystem in a decorator. The option defaults to `false`, which keeps the existing behavior of rejecting overlapping mounts.

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -95,6 +95,28 @@ describe("MountableFs", () => {
       );
     });
 
+    it("should allow nested mounts with allowNestedMounts (new inside existing)", () => {
+      const fs = new MountableFs({ allowNestedMounts: true });
+      const mounted1 = new InMemoryFs();
+      const mounted2 = new InMemoryFs();
+
+      fs.mount("/mnt", mounted1);
+      fs.mount("/mnt/sub", mounted2);
+
+      expect(fs.getMounts()).toHaveLength(2);
+    });
+
+    it("should allow nested mounts with allowNestedMounts (existing inside new)", () => {
+      const fs = new MountableFs({ allowNestedMounts: true });
+      const mounted1 = new InMemoryFs();
+      const mounted2 = new InMemoryFs();
+
+      fs.mount("/mnt/sub", mounted1);
+      fs.mount("/mnt", mounted2);
+
+      expect(fs.getMounts()).toHaveLength(2);
+    });
+
     it("should allow sibling mounts", () => {
       const fs = new MountableFs();
       const mounted1 = new InMemoryFs();
@@ -660,6 +682,161 @@ describe("MountableFs", () => {
       // Base fs is empty but mount parent should still work
       const entries = await fs.readdir("/mnt");
       expect(entries).toContain("data");
+    });
+  });
+
+  describe("nested mounts", () => {
+    const makeNested = () => {
+      const outer = new InMemoryFs({
+        "/notes.txt": "outer notes",
+        "/private/secret.txt": "outer secret",
+      });
+      const inner = new InMemoryFs({ "/key.txt": "inner key" });
+      const fs = new MountableFs({ allowNestedMounts: true });
+      fs.mount("/data", outer);
+      fs.mount("/data/private", inner);
+      return { fs, inner, outer };
+    };
+
+    it("should route to the deepest mount owning a path", async () => {
+      const { fs } = makeNested();
+
+      expect(await fs.readFile("/data/notes.txt")).toBe("outer notes");
+      expect(await fs.readFile("/data/private/key.txt")).toBe("inner key");
+    });
+
+    it("should route regardless of mount order", async () => {
+      const outer = new InMemoryFs({ "/notes.txt": "outer notes" });
+      const inner = new InMemoryFs({ "/key.txt": "inner key" });
+      const fs = new MountableFs({ allowNestedMounts: true });
+      // Inner first: routing must not depend on insertion order.
+      fs.mount("/data/private", inner);
+      fs.mount("/data", outer);
+
+      expect(await fs.readFile("/data/notes.txt")).toBe("outer notes");
+      expect(await fs.readFile("/data/private/key.txt")).toBe("inner key");
+    });
+
+    it("should shadow what the outer filesystem holds under the mount point", async () => {
+      const { fs } = makeNested();
+
+      await expect(fs.readFile("/data/private/secret.txt")).rejects.toThrow();
+      expect(await fs.readdir("/data/private")).toEqual(["key.txt"]);
+    });
+
+    it("should resolve a traversal into the nested mount", async () => {
+      const { fs } = makeNested();
+
+      expect(await fs.readFile("/data/notes/../private/key.txt")).toBe(
+        "inner key",
+      );
+    });
+
+    it("should keep the nested mount out of writes to the outer filesystem", async () => {
+      const { fs, inner, outer } = makeNested();
+
+      await fs.writeFile("/data/private/new.txt", "written");
+
+      expect(await inner.readFile("/new.txt")).toBe("written");
+      await expect(outer.readFile("/private/new.txt")).rejects.toThrow();
+    });
+
+    it("should list the nested mount point once in the parent", async () => {
+      const { fs } = makeNested();
+
+      const entries = await fs.readdir("/data");
+      expect(entries).toEqual(["notes.txt", "private"]);
+    });
+
+    it("should refuse to remove a directory containing a nested mount", async () => {
+      const { fs } = makeNested();
+
+      await expect(fs.rm("/data/private", { recursive: true })).rejects.toThrow(
+        "EBUSY",
+      );
+    });
+
+    it("should exclude shadowed paths from getAllPaths", async () => {
+      const { fs } = makeNested();
+
+      const paths = fs.getAllPaths();
+      expect(paths).toContain("/data/notes.txt");
+      expect(paths).toContain("/data/private/key.txt");
+      expect(paths).not.toContain("/data/private/secret.txt");
+    });
+
+    it("should reconstruct realpath against the deepest mount", async () => {
+      const { fs } = makeNested();
+
+      expect(await fs.realpath("/data/private/key.txt")).toBe(
+        "/data/private/key.txt",
+      );
+    });
+
+    it("should copy the nested mount's contents when both sides share a filesystem", async () => {
+      // Source and destination both route to `outer`, which is what makes this
+      // eligible for the same-filesystem fast path that would bypass the mount.
+      const outer = new InMemoryFs({
+        "/src/notes.txt": "outer notes",
+        "/src/private/secret.txt": "outer secret",
+      });
+      const inner = new InMemoryFs({ "/key.txt": "inner key" });
+      const fs = new MountableFs({ allowNestedMounts: true });
+      fs.mount("/data", outer);
+      fs.mount("/data/src/private", inner);
+
+      await fs.cp("/data/src", "/data/copy", { recursive: true });
+
+      expect(await fs.readFile("/data/copy/private/key.txt")).toBe("inner key");
+      await expect(
+        fs.readFile("/data/copy/private/secret.txt"),
+      ).rejects.toThrow();
+    });
+
+    it("should copy the nested mount's contents, not the shadowed ones", async () => {
+      const { fs } = makeNested();
+
+      await fs.cp("/data", "/copy", { recursive: true });
+
+      expect(await fs.readFile("/copy/private/key.txt")).toBe("inner key");
+      await expect(fs.readFile("/copy/private/secret.txt")).rejects.toThrow();
+    });
+
+    it("should refuse to move a directory containing a nested mount", async () => {
+      const { fs } = makeNested();
+
+      await expect(fs.mv("/data", "/moved")).rejects.toThrow("EBUSY");
+    });
+
+    it("should move into a nested mount rather than under it", async () => {
+      // Moving onto `/data/y` lands part of the source beneath `/data/y/private`.
+      // Delegating to `outer` would put those files where the mount shadows
+      // them, so they would silently vanish from the namespace.
+      const outer = new InMemoryFs({
+        "/x/note.txt": "plain",
+        "/x/private/hidden.txt": "must stay reachable",
+      });
+      const inner = new InMemoryFs({ "/key.txt": "inner key" });
+      const fs = new MountableFs({ allowNestedMounts: true });
+      fs.mount("/data", outer);
+      fs.mount("/data/y/private", inner);
+
+      await fs.mv("/data/x", "/data/y");
+
+      expect(await fs.readFile("/data/y/note.txt")).toBe("plain");
+      expect(await fs.readFile("/data/y/private/hidden.txt")).toBe(
+        "must stay reachable",
+      );
+    });
+
+    it("should restore the outer filesystem's view after unmount", async () => {
+      const { fs } = makeNested();
+
+      fs.unmount("/data/private");
+
+      expect(await fs.readFile("/data/private/secret.txt")).toBe(
+        "outer secret",
+      );
     });
   });
 });

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -33,6 +33,11 @@ export interface MountConfig {
  * Options for creating a MountableFs
  */
 export interface MountableFsOptions {
+  /**
+   * Allow a mount to sit inside another mount (defaults to false, which
+   * rejects it). See {@link MountableFs.mount} for the semantics.
+   */
+  allowNestedMounts?: boolean;
   /** Base filesystem used for unmounted paths (defaults to InMemoryFs) */
   base?: IFileSystem;
   /** Initial mounts to configure */
@@ -62,10 +67,12 @@ interface MountEntry {
  * ```
  */
 export class MountableFs implements IFileSystem {
+  private allowNestedMounts: boolean;
   private baseFs: IFileSystem;
   private mounts: Map<string, MountEntry> = new Map();
 
   constructor(options?: MountableFsOptions) {
+    this.allowNestedMounts = options?.allowNestedMounts ?? false;
     this.baseFs = options?.base ?? new InMemoryFs();
 
     // Add initial mounts
@@ -79,9 +86,17 @@ export class MountableFs implements IFileSystem {
   /**
    * Mount a filesystem at the specified virtual path.
    *
+   * With `allowNestedMounts`, mounts may nest: mounting `/data/private` inside
+   * an existing `/data` mount shadows that subtree, the way an OS mount does.
+   * The deepest mount owning a path wins, so `/data/private/key` routes to the
+   * inner filesystem while `/data/notes.txt` stays with the outer one, and
+   * unmounting reveals the outer filesystem's contents again. Without the
+   * option, an overlapping mount is rejected.
+   *
    * @param mountPoint - The virtual path where the filesystem will be accessible
    * @param filesystem - The filesystem to mount
-   * @throws Error if mounting at root '/' or inside an existing mount
+   * @throws Error if mounting at root '/', or inside an existing mount unless
+   * `allowNestedMounts` is set
    */
   mount(mountPoint: string, filesystem: IFileSystem): void {
     // Validate original path first (before normalization)
@@ -156,6 +171,10 @@ export class MountableFs implements IFileSystem {
       throw new Error("Cannot mount at root '/'");
     }
 
+    if (this.allowNestedMounts) {
+      return;
+    }
+
     // Check for nested mounts (but allow remounting at same path)
     for (const existingMount of this.mounts.keys()) {
       if (existingMount === mountPoint) {
@@ -219,6 +238,60 @@ export class MountableFs implements IFileSystem {
 
     // No mount found - use base filesystem
     return { fs: this.baseFs, relativePath: normalized };
+  }
+
+  /**
+   * The deepest mount point owning a normalized path, or null for the base fs.
+   * Mirrors the routing in {@link routePath}, so callers that reconstruct a
+   * full path from a mount-relative one pick the same mount that served it.
+   */
+  private owningMountPoint(normalized: string): string | null {
+    let owner: string | null = null;
+
+    for (const mountPoint of this.mounts.keys()) {
+      if (
+        (normalized === mountPoint ||
+          normalized.startsWith(`${mountPoint}/`)) &&
+        (owner === null || mountPoint.length > owner.length)
+      ) {
+        owner = mountPoint;
+      }
+    }
+
+    return owner;
+  }
+
+  /**
+   * True when any mount point lives strictly below this path, i.e. the subtree
+   * is not owned end-to-end by whichever filesystem serves the path itself.
+   */
+  private hasMountUnder(path: string): boolean {
+    const normalized = normalizePath(path);
+
+    for (const mountPoint of this.mounts.keys()) {
+      if (mountPoint.startsWith(`${normalized}/`)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * True when a deeper mount shadows this path, so the value the outer
+   * filesystem reports for it is not what a caller would actually reach.
+   */
+  private isShadowedByDeeperMount(path: string, ownerMount: string): boolean {
+    for (const mountPoint of this.mounts.keys()) {
+      if (
+        mountPoint.length > ownerMount.length &&
+        path.startsWith(`${mountPoint}/`)
+      ) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   /**
@@ -474,8 +547,14 @@ export class MountableFs implements IFileSystem {
     const srcRoute = this.routePath(src);
     const destRoute = this.routePath(dest);
 
-    // If same filesystem, delegate directly
-    if (srcRoute.fs === destRoute.fs) {
+    // If same filesystem, delegate directly -- unless a nested mount sits
+    // under either side, in which case the owning filesystem's own view is
+    // stale and the walk has to go back through this facade.
+    if (
+      srcRoute.fs === destRoute.fs &&
+      !this.hasMountUnder(src) &&
+      !this.hasMountUnder(dest)
+    ) {
       return srcRoute.fs.cp(
         srcRoute.relativePath,
         destRoute.relativePath,
@@ -495,11 +574,17 @@ export class MountableFs implements IFileSystem {
       throw new Error(`EBUSY: mount point, cannot move '${src}'`);
     }
 
+    // Moving a directory out from under a mount would orphan that mount, the
+    // same reason rm refuses it.
+    if (this.hasMountUnder(src)) {
+      throw new Error(`EBUSY: contains mount points, cannot move '${src}'`);
+    }
+
     const srcRoute = this.routePath(src);
     const destRoute = this.routePath(dest);
 
     // If same filesystem, delegate directly
-    if (srcRoute.fs === destRoute.fs) {
+    if (srcRoute.fs === destRoute.fs && !this.hasMountUnder(dest)) {
       return srcRoute.fs.mv(srcRoute.relativePath, destRoute.relativePath);
     }
 
@@ -536,8 +621,13 @@ export class MountableFs implements IFileSystem {
       for (const p of entry.filesystem.getAllPaths()) {
         if (p === "/") {
           allPaths.add(mountPoint);
-        } else {
-          allPaths.add(`${mountPoint}${p}`);
+          continue;
+        }
+        const fullPath = `${mountPoint}${p}`;
+        // A nested mount hides whatever this filesystem holds underneath it,
+        // so those paths are unreachable and must not be listed.
+        if (!this.isShadowedByDeeperMount(fullPath, mountPoint)) {
+          allPaths.add(fullPath);
         }
       }
     }
@@ -605,15 +695,11 @@ export class MountableFs implements IFileSystem {
     // Get realpath from the underlying filesystem
     const resolvedRelative = await fs.realpath(relativePath);
 
-    // Find the mount point for this path
-    for (const [mp, _entry] of this.mounts) {
-      if (normalized === mp || normalized.startsWith(`${mp}/`)) {
-        // Path is within this mount - reconstruct full path
-        if (resolvedRelative === "/") {
-          return mp;
-        }
-        return `${mp}${resolvedRelative}`;
-      }
+    // Reconstruct against the mount that actually served the path, which with
+    // nested mounts is the deepest one and not simply the first that matches.
+    const owner = this.owningMountPoint(normalized);
+    if (owner !== null) {
+      return resolvedRelative === "/" ? owner : `${owner}${resolvedRelative}`;
     }
 
     // Path is in the base filesystem


### PR DESCRIPTION
I mount an agent's working directory into the sandbox and need one subdirectory inside it hidden. Mounting an empty filesystem over that subdirectory would do it, but `MountableFs` rejects a mount inside an existing mount — so hiding one path means wrapping the entire filesystem in a decorator that reimplements every `IFileSystem` method.

```ts
const fs = new MountableFs({ allowNestedMounts: true });
fs.mount("/work", new ReadWriteFs({ root }));
fs.mount("/work/.private", new InMemoryFs()); // shadows the subtree
```

Off by default, so the existing rejection and its error messages are unchanged. Semantics follow an OS mount: deepest mount wins, the subtree is shadowed while mounted, unmounting reveals the outer contents again, and mount order doesn't matter.

`routePath` already resolves by longest matching prefix — unreachable today, since validation guarantees at most one mount can prefix-match a path. Four sites assumed a path belongs to exactly one mount:

- `realpath` rebased onto the first matching mount, not the deepest
- `getAllPaths` listed outer entries under a nested mount point, which are shadowed and unopenable
- `cp` took a same-filesystem fast path that bypassed the facade and read the shadowed contents
- `mv` did the same on the destination side, landing part of the source beneath a mount where it's unreachable; it also now refuses to move a directory containing a mount, matching `rm`

16 new tests, plus the two existing rejection tests kept as-is for the default. Each of the four fixes was reverted individually to confirm its own test fails. Full `test:run` green, changeset included.

Happy to make nesting the default instead, or to close this if it's not a direction you want in `MountableFs`.

Authored with Opus 4.8.
