### PR TITLE
fix(grep): handle double-dash option terminator

### DIFF
--- a/.changeset/fuzzy-pandas-grep.md
+++ b/.changeset/fuzzy-pandas-grep.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Treat `--` as the end of options in `grep`.

--- a/packages/just-bash/src/commands/grep/grep.options.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.options.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+function expectResult(
+  result: { stdout: string; stderr: string; exitCode: number },
+  expected: { stdout: string; stderr: string; exitCode: number },
+): void {
+  expect({
+    stdout: result.stdout,
+    stderr: result.stderr,
+    exitCode: result.exitCode,
+  }).toEqual(expected);
+}
+
+describe("grep option parsing", () => {
+  it("stops parsing options after --", async () => {
+    const env = new Bash({
+      files: {
+        "/patterns.txt": "match\n-x\n--help\n",
+        "/-input.txt": "match\n",
+      },
+    });
+
+    const pattern = await env.exec("grep -- match /patterns.txt");
+    expectResult(pattern, {
+      stdout: "match\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const dashedPattern = await env.exec("grep -- -x /patterns.txt");
+    expectResult(dashedPattern, {
+      stdout: "-x\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const helpPattern = await env.exec("grep -- --help /patterns.txt");
+    expectResult(helpPattern, {
+      stdout: "--help\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const dashedFile = await env.exec("grep match -- -input.txt");
+    expectResult(dashedFile, {
+      stdout: "match\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("allows option-like values as option arguments", async () => {
+    const env = new Bash({
+      files: {
+        "/patterns.txt": "--\nmatch\n",
+      },
+    });
+
+    const result = await env.exec("grep -e -- /patterns.txt");
+    expectResult(result, {
+      stdout: "--\n",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const helpPattern = await env.exec("grep -e --help /patterns.txt");
+    expectResult(helpPattern, {
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    });
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -8,7 +8,7 @@ import type {
   RuntimeCommandContext,
 } from "../../types.js";
 import { matchGlob } from "../../utils/glob.js";
-import { hasHelpFlag, showHelp, unknownOption } from "../help.js";
+import { showHelp, unknownOption } from "../help.js";
 import { buildRegex, searchContent } from "../search-engine/index.js";
 
 /** File entry with optional type info from glob expansion */
@@ -88,10 +88,6 @@ export const grepCommand: RuntimeCommand = {
     args: string[],
     ctx: RuntimeCommandContext,
   ): Promise<ExecResult> {
-    if (hasHelpFlag(args)) {
-      return showHelp(grepHelp);
-    }
-
     let ignoreCase = false;
     let showLineNumbers = false;
     let invertMatch = false;
@@ -115,12 +111,22 @@ export const grepCommand: RuntimeCommand = {
     const excludeDirPatterns: string[] = [];
     let pattern: string | null = null;
     const files: string[] = [];
+    let parseOptions = true;
 
     // Parse arguments
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
 
-      if (arg.startsWith("-") && arg !== "-") {
+      if (parseOptions && arg === "--") {
+        parseOptions = false;
+        continue;
+      }
+
+      if (parseOptions && arg === "--help") {
+        return showHelp(grepHelp);
+      }
+
+      if (parseOptions && arg.startsWith("-") && arg !== "-") {
         if (arg === "-e" && i + 1 < args.length) {
           pattern = args[++i];
           continue;


### PR DESCRIPTION
Treat `--` as the end-of-options marker in `grep` instead of reporting it as an unrecognized option.

The command used a hand-written argument parser that treated every dash-prefixed argument as an option and checked for `--help` before parsing. Track parser state after the terminator so dash-prefixed patterns and filenames remain positional, while option arguments such as `-e --` and `-e --help` are still consumed correctly.

Adds focused regression coverage and a patch changeset.

Validation:
- `pnpm exec vitest run src/commands/grep` — 207 passed, 8 skipped
- `pnpm lint`
- `pnpm knip`
- `pnpm typecheck`
- `pnpm test:run` — 14,288 passed; four xz tests failed because the optional local `node-liblzma` dependency could not build without `pkg-config`, and one unrelated interpreter state-transaction test failed