### PR TITLE
fix(interpreter): interleave duplicated streams in write order

### DIFF
--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Interleave stdout and stderr in write order when a duplication operator sends both to one place, so `{ echo a; echo b 1>&2; echo c; } 2>&1` is `a b c` rather than `a c b`.

--- a/.changeset/olive-donkeys-shake.md
+++ b/.changeset/olive-donkeys-shake.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Interleave stdout and stderr in write order when a duplication operator sends both to one place, so `{ echo a; echo b 1>&2; echo c; } 2>&1` is `a b c` rather than `a c b`.
+Interleave stdout and stderr in write order when a duplication operator sends both to one place, so `{ echo a; echo b 1>&2; echo c; } 2>&1` is `a b c` rather than `a c b`. The order survives nested groups, subshells, functions, loops, `if`/`case`, and scopes left early by `break`, `exit` or `return`, and carries through `|&`. Each piece is written with the encoding of the stream it came from, so a byte-shaped stdout merged with a Unicode stderr reaches one file as UTF-8 instead of one of the two being re-encoded.

--- a/packages/just-bash/src/execution-output.ts
+++ b/packages/just-bash/src/execution-output.ts
@@ -1,7 +1,7 @@
 import { utf8ByteLength } from "./encoding.js";
 import type { ExecutionScope } from "./execution-scope.js";
 import { ControlFlowError } from "./interpreter/errors.js";
-import type { ExecResult } from "./types.js";
+import type { ExecResult, OutputChunk } from "./types.js";
 
 /**
  * Chunked interpreter-output sink backed by the one top-level execution
@@ -11,6 +11,9 @@ import type { ExecResult } from "./types.js";
 export class ExecutionOutputAccumulator {
   private readonly stdoutChunks: string[] = [];
   private readonly stderrChunks: string[] = [];
+  // The same pieces in arrival order, which is the order the shell produced
+  // them. Splitting them across the two arrays above is what discards it.
+  private readonly orderedChunks: OutputChunk[] = [];
   private stdoutBytes = 0;
   private stderrBytes = 0;
   private readonly attachedErrors = new WeakSet<ControlFlowError>();
@@ -41,6 +44,7 @@ export class ExecutionOutputAccumulator {
     }
     if (chunk) {
       (stream === "stdout" ? this.stdoutChunks : this.stderrChunks).push(chunk);
+      this.orderedChunks.push({ stream, text: chunk });
     }
     if (stream === "stdout") this.stdoutBytes += bytes;
     else this.stderrBytes += bytes;
@@ -65,6 +69,7 @@ export class ExecutionOutputAccumulator {
         : "text";
     const stdoutBytes =
       stdoutKind === "bytes" ? stdout.length : utf8ByteLength(stdout);
+    const orderMark = this.orderedChunks.length;
     this.append(
       "stdout",
       stdout,
@@ -76,6 +81,21 @@ export class ExecutionOutputAccumulator {
       result.stderr,
       result.internalOutputAccounting?.stderr ?? 0,
     );
+    // A child that recorded its own ordering knows better than the two entries
+    // just appended, which say stdout-then-stderr for the whole child. Swap
+    // them for the finer sequence so nesting does not flatten it a level at a
+    // time. Skipped when the caller overrode stdout, since the child's chunks
+    // then describe content this result no longer carries. Byte accounting is
+    // untouched either way: it was charged by the appends above.
+    const childChunks =
+      stdout === result.stdout ? result.outputChunks : undefined;
+    if (childChunks?.length) {
+      this.orderedChunks.splice(
+        orderMark,
+        this.orderedChunks.length - orderMark,
+        ...childChunks,
+      );
+    }
   }
 
   build(exitCode: number, extra?: Partial<ExecResult>): ExecResult {
@@ -84,6 +104,9 @@ export class ExecutionOutputAccumulator {
       stderr: this.stderrChunks.join(""),
       exitCode,
       ...extra,
+      ...(this.orderedChunks.length > 0 && {
+        outputChunks: this.orderedChunks,
+      }),
       internalOutputAccounting: {
         stdout: this.stdoutBytes,
         stderr: this.stderrBytes,

--- a/packages/just-bash/src/execution-output.ts
+++ b/packages/just-bash/src/execution-output.ts
@@ -1,6 +1,7 @@
-import { utf8ByteLength } from "./encoding.js";
+import { type OutputKind, utf8ByteLength } from "./encoding.js";
 import type { ExecutionScope } from "./execution-scope.js";
 import { ControlFlowError } from "./interpreter/errors.js";
+import { chunksDescribe } from "./output-chunks.js";
 import type { ExecResult, OutputChunk } from "./types.js";
 
 /**
@@ -27,7 +28,7 @@ export class ExecutionOutputAccumulator {
     stream: "stdout" | "stderr",
     chunk: string,
     alreadyAccountedBytes = 0,
-    kind: "text" | "bytes" = "text",
+    kind: OutputKind = "text",
   ): void {
     let bytes: number;
     try {
@@ -44,7 +45,7 @@ export class ExecutionOutputAccumulator {
     }
     if (chunk) {
       (stream === "stdout" ? this.stdoutChunks : this.stderrChunks).push(chunk);
-      this.orderedChunks.push({ stream, text: chunk });
+      this.orderedChunks.push({ stream, text: chunk, kind });
     }
     if (stream === "stdout") this.stdoutBytes += bytes;
     else this.stderrBytes += bytes;
@@ -59,12 +60,27 @@ export class ExecutionOutputAccumulator {
     if (!(error instanceof ControlFlowError)) return;
     if (this.attachedErrors.has(error)) return;
     this.attachedErrors.add(error);
-    error.prependOutput(this.stdout, this.stderr);
+    error.prependOutput(this.stdout, this.stderr, this.orderedChunks);
+  }
+
+  /**
+   * Absorb the output an aborted child carried out on a control-flow error,
+   * the way a subshell swallows `exit` and keeps what ran before it.
+   */
+  appendError(error: ControlFlowError): void {
+    const orderMark = this.orderedChunks.length;
+    this.append("stdout", error.stdout, error.internalOutputAccounting.stdout);
+    this.append("stderr", error.stderr, error.internalOutputAccounting.stderr);
+    this.adoptChunks(orderMark, error.outputChunks, error.stdout, error.stderr);
   }
 
   appendResult(result: ExecResult, stdout: string = result.stdout): void {
-    const stdoutKind =
-      result.stdoutKind === "bytes" || result.stdoutEncoding === "binary"
+    // The shape of what is appended, not of what the producer emitted: a
+    // caller that hands over decoded text in place of the result's own byte
+    // buffer is appending Unicode whatever the producer's shape was.
+    const stdoutKind: OutputKind =
+      stdout === result.stdout &&
+      (result.stdoutKind === "bytes" || result.stdoutEncoding === "binary")
         ? "bytes"
         : "text";
     const stdoutBytes =
@@ -81,22 +97,33 @@ export class ExecutionOutputAccumulator {
       result.stderr,
       result.internalOutputAccounting?.stderr ?? 0,
     );
-    // A child that recorded its own ordering knows better than the two entries
-    // just appended, which say stdout-then-stderr for the whole child. Swap
-    // them for the finer sequence so nesting does not flatten it a level at a
-    // time. Skipped when the caller overrode stdout, since the child's chunks
-    // then describe content this result no longer carries. Byte accounting is
-    // untouched either way: it was charged by the appends above.
-    const childChunks =
-      stdout === result.stdout ? result.outputChunks : undefined;
-    if (childChunks?.length) {
-      // Truncate and push rather than splicing the child's chunks in: a spread
-      // passes them as arguments, which overflows the stack once the array is
-      // long enough. Nothing bounds its length, so it must not be spread.
-      this.orderedChunks.length = orderMark;
-      for (const chunk of childChunks) {
-        this.orderedChunks.push(chunk);
-      }
+    this.adoptChunks(
+      orderMark,
+      result.internalOutputChunks,
+      stdout,
+      result.stderr,
+    );
+  }
+
+  /**
+   * Replace the two coarse entries a child's append just added with the finer
+   * sequence the child recorded, so nesting does not flatten the ordering a
+   * level at a time. Byte accounting is untouched: those bytes were charged by
+   * the appends this refines.
+   */
+  private adoptChunks(
+    orderMark: number,
+    chunks: OutputChunk[] | undefined,
+    stdout: string,
+    stderr: string,
+  ): void {
+    if (!chunksDescribe(chunks, stdout, stderr)) return;
+    // Truncate and push rather than splicing the child's chunks in: a spread
+    // passes them as arguments, which overflows the stack once the array is
+    // long enough. Nothing bounds its length, so it must not be spread.
+    this.orderedChunks.length = orderMark;
+    for (const chunk of chunks) {
+      this.orderedChunks.push(chunk);
     }
   }
 
@@ -107,7 +134,9 @@ export class ExecutionOutputAccumulator {
       exitCode,
       ...extra,
       ...(this.orderedChunks.length > 0 && {
-        outputChunks: this.orderedChunks,
+        // A copy: the array behind it keeps growing if this accumulator is
+        // appended to again, and a result already handed out must not change.
+        internalOutputChunks: [...this.orderedChunks],
       }),
       internalOutputAccounting: {
         stdout: this.stdoutBytes,
@@ -122,5 +151,10 @@ export class ExecutionOutputAccumulator {
 
   get stderr(): string {
     return this.stderrChunks.join("");
+  }
+
+  /** The write order recorded so far, for handing to an outer scope. */
+  get chunks(): OutputChunk[] {
+    return this.orderedChunks;
   }
 }

--- a/packages/just-bash/src/execution-output.ts
+++ b/packages/just-bash/src/execution-output.ts
@@ -90,11 +90,13 @@ export class ExecutionOutputAccumulator {
     const childChunks =
       stdout === result.stdout ? result.outputChunks : undefined;
     if (childChunks?.length) {
-      this.orderedChunks.splice(
-        orderMark,
-        this.orderedChunks.length - orderMark,
-        ...childChunks,
-      );
+      // Truncate and push rather than splicing the child's chunks in: a spread
+      // passes them as arguments, which overflows the stack once the array is
+      // long enough. Nothing bounds its length, so it must not be spread.
+      this.orderedChunks.length = orderMark;
+      for (const chunk of childChunks) {
+        this.orderedChunks.push(chunk);
+      }
     }
   }
 

--- a/packages/just-bash/src/interpreter/control-flow.ts
+++ b/packages/just-bash/src/interpreter/control-flow.ts
@@ -21,7 +21,8 @@ import type {
   WhileNode,
 } from "../ast/types.js";
 import { utf8ByteLength } from "../encoding.js";
-import type { ExecResult } from "../types.js";
+import { orderedOutput, textChunks } from "../output-chunks.js";
+import type { ExecResult, OutputChunk } from "../types.js";
 import { evaluateArithmetic } from "./arithmetic.js";
 import { matchPattern } from "./conditionals.js";
 import {
@@ -82,11 +83,16 @@ function resolveLoopStdin(
 class CompoundOutput {
   private stdoutChunks: string[] = [];
   private stderrChunks: string[] = [];
+  // The same pieces in the order they arrived, which is the order the body
+  // wrote them. Undefined once anything appended here brought no order of its
+  // own, since from that point on the sequence no longer accounts for the two
+  // strings above.
+  private orderedChunks: OutputChunk[] | undefined = [];
   private totalBytes = 0;
 
   constructor(private readonly ctx: InterpreterContext) {}
 
-  append(stdout: string, stderr: string): void {
+  append(stdout: string, stderr: string, chunks?: OutputChunk[]): void {
     const addedBytes = utf8ByteLength(stdout) + utf8ByteLength(stderr);
     if (addedBytes > this.ctx.limits.maxOutputSize - this.totalBytes) {
       throwExecutionLimit(
@@ -96,21 +102,33 @@ class CompoundOutput {
     }
     if (stdout) this.stdoutChunks.push(stdout);
     if (stderr) this.stderrChunks.push(stderr);
+    const added = orderedOutput(chunks, stdout, stderr);
+    if (this.orderedChunks && added) {
+      for (const chunk of added) this.orderedChunks.push(chunk);
+    } else {
+      this.orderedChunks = undefined;
+    }
     this.totalBytes += addedBytes;
+  }
+
+  /** Append a child result, keeping the order it recorded for its own body. */
+  appendResult(result: ExecResult): void {
+    this.append(result.stdout, result.stderr, result.internalOutputChunks);
   }
 
   /** Append output synthesized here rather than relayed from a child. */
   appendUnaccounted(stdout: string, stderr: string): void {
     this.ctx.executionScope.appendOutput("stdout", stdout, "control-flow");
     this.ctx.executionScope.appendOutput("stderr", stderr, "control-flow");
-    this.append(stdout, stderr);
+    this.append(stdout, stderr, textChunks(stdout, stderr));
   }
 
-  replace(stdout: string, stderr: string): void {
+  replace(stdout: string, stderr: string, chunks?: OutputChunk[]): void {
     this.stdoutChunks = [];
     this.stderrChunks = [];
+    this.orderedChunks = [];
     this.totalBytes = 0;
-    this.append(stdout, stderr);
+    this.append(stdout, stderr, chunks);
   }
 
   get stdout(): string {
@@ -121,6 +139,11 @@ class CompoundOutput {
     return this.stderrChunks.join("");
   }
 
+  /** The write order recorded so far, for handing to an outer scope. */
+  get chunks(): OutputChunk[] | undefined {
+    return this.orderedChunks;
+  }
+
   /** Preserve child accounting while relaying compound-command output. */
   build(exitCode: number): ExecResult {
     const stdout = this.stdout;
@@ -129,6 +152,9 @@ class CompoundOutput {
       stdout,
       stderr,
       exitCode,
+      ...(this.orderedChunks?.length && {
+        internalOutputChunks: [...this.orderedChunks],
+      }),
       internalOutputAccounting: {
         stdout: utf8ByteLength(stdout),
         stderr: utf8ByteLength(stderr),
@@ -146,7 +172,7 @@ async function executeBoundedStatements(
   try {
     for (const statement of statements) {
       const statementResult = await ctx.executeStatement(statement);
-      output.append(statementResult.stdout, statementResult.stderr);
+      output.appendResult(statementResult);
       exitCode = statementResult.exitCode;
     }
   } catch (error) {
@@ -157,7 +183,7 @@ async function executeBoundedStatements(
       error instanceof ExecutionLimitError ||
       error instanceof SubshellExitError
     ) {
-      error.prependOutput(output.stdout, output.stderr);
+      error.prependOutput(output.stdout, output.stderr, output.chunks);
       throw error;
     }
     output.appendUnaccounted("", `${getErrorMessage(error)}\n`);
@@ -184,7 +210,11 @@ async function executeIfBody(
   for (const clause of node.clauses) {
     // Condition evaluation should not trigger errexit
     const condResult = await executeCondition(ctx, clause.condition);
-    output.append(condResult.stdout, condResult.stderr);
+    output.append(
+      condResult.stdout,
+      condResult.stderr,
+      condResult.internalOutputChunks,
+    );
 
     if (condResult.exitCode === 0) {
       return executeBoundedStatements(ctx, clause.body, output);
@@ -263,7 +293,7 @@ async function executeForBody(
       try {
         for (const stmt of node.body) {
           const stmtResult = await ctx.executeStatement(stmt);
-          output.append(stmtResult.stdout, stmtResult.stderr);
+          output.appendResult(stmtResult);
           exitCode = stmtResult.exitCode;
         }
       } catch (error) {
@@ -272,8 +302,9 @@ async function executeForBody(
           output.stdout,
           output.stderr,
           ctx.state.loopDepth,
+          output.chunks,
         );
-        output.replace(loopResult.stdout, loopResult.stderr);
+        output.replace(loopResult.stdout, loopResult.stderr, loopResult.chunks);
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") continue;
         if (loopResult.action === "error") {
@@ -347,7 +378,7 @@ async function executeCStyleForBody(
       try {
         for (const stmt of node.body) {
           const stmtResult = await ctx.executeStatement(stmt);
-          output.append(stmtResult.stdout, stmtResult.stderr);
+          output.appendResult(stmtResult);
           exitCode = stmtResult.exitCode;
         }
       } catch (error) {
@@ -356,8 +387,9 @@ async function executeCStyleForBody(
           output.stdout,
           output.stderr,
           ctx.state.loopDepth,
+          output.chunks,
         );
-        output.replace(loopResult.stdout, loopResult.stderr);
+        output.replace(loopResult.stdout, loopResult.stderr, loopResult.chunks);
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") {
           // Still need to run the update expression on continue
@@ -433,27 +465,29 @@ async function executeWhileBody(
       try {
         for (const stmt of node.condition) {
           const result = await ctx.executeStatement(stmt);
-          output.append(result.stdout, result.stderr);
+          output.appendResult(result);
           conditionExitCode = result.exitCode;
         }
       } catch (error) {
         // break/continue in condition should affect THIS while loop
         if (error instanceof BreakError) {
-          output.append(error.stdout, error.stderr);
+          output.append(error.stdout, error.stderr, error.outputChunks);
           if (error.levels > 1 && ctx.state.loopDepth > 1) {
             error.levels--;
             error.stdout = output.stdout;
             error.stderr = output.stderr;
+            error.outputChunks = output.chunks;
             ctx.state.inCondition = savedInCondition;
             throw error;
           }
           shouldBreak = true;
         } else if (error instanceof ContinueError) {
-          output.append(error.stdout, error.stderr);
+          output.append(error.stdout, error.stderr, error.outputChunks);
           if (error.levels > 1 && ctx.state.loopDepth > 1) {
             error.levels--;
             error.stdout = output.stdout;
             error.stderr = output.stderr;
+            error.outputChunks = output.chunks;
             ctx.state.inCondition = savedInCondition;
             throw error;
           }
@@ -473,7 +507,7 @@ async function executeWhileBody(
       try {
         for (const stmt of node.body) {
           const stmtResult = await ctx.executeStatement(stmt);
-          output.append(stmtResult.stdout, stmtResult.stderr);
+          output.appendResult(stmtResult);
           exitCode = stmtResult.exitCode;
         }
       } catch (error) {
@@ -482,8 +516,9 @@ async function executeWhileBody(
           output.stdout,
           output.stderr,
           ctx.state.loopDepth,
+          output.chunks,
         );
-        output.replace(loopResult.stdout, loopResult.stderr);
+        output.replace(loopResult.stdout, loopResult.stderr, loopResult.chunks);
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") continue;
         if (loopResult.action === "error") {
@@ -544,14 +579,18 @@ async function executeUntilBody(
 
       // Condition evaluation should not trigger errexit
       const condResult = await executeCondition(ctx, node.condition);
-      output.append(condResult.stdout, condResult.stderr);
+      output.append(
+        condResult.stdout,
+        condResult.stderr,
+        condResult.internalOutputChunks,
+      );
 
       if (condResult.exitCode === 0) break;
 
       try {
         for (const stmt of node.body) {
           const stmtResult = await ctx.executeStatement(stmt);
-          output.append(stmtResult.stdout, stmtResult.stderr);
+          output.appendResult(stmtResult);
           exitCode = stmtResult.exitCode;
         }
       } catch (error) {
@@ -560,8 +599,9 @@ async function executeUntilBody(
           output.stdout,
           output.stderr,
           ctx.state.loopDepth,
+          output.chunks,
         );
-        output.replace(loopResult.stdout, loopResult.stderr);
+        output.replace(loopResult.stdout, loopResult.stderr, loopResult.chunks);
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") continue;
         if (loopResult.action === "error") {
@@ -633,7 +673,11 @@ async function executeCaseBody(
 
     if (matched) {
       const bodyResult = await executeBoundedStatements(ctx, item.body, output);
-      output.replace(bodyResult.stdout, bodyResult.stderr);
+      output.replace(
+        bodyResult.stdout,
+        bodyResult.stderr,
+        bodyResult.internalOutputChunks,
+      );
       exitCode = bodyResult.exitCode;
 
       // Handle different terminators:

--- a/packages/just-bash/src/interpreter/errors.ts
+++ b/packages/just-bash/src/interpreter/errors.ts
@@ -12,6 +12,8 @@
  * as they propagate through the execution stack.
  */
 import { utf8ByteLength } from "../encoding.js";
+import { orderedOutput } from "../output-chunks.js";
+import type { OutputChunk } from "../types.js";
 
 /**
  * Base class for all control flow errors.
@@ -19,6 +21,13 @@ import { utf8ByteLength } from "../encoding.js";
  */
 export abstract class ControlFlowError extends Error {
   internalOutputAccounting = { stdout: 0, stderr: 0 };
+  /**
+   * The two streams above in the order they were written, so a redirection
+   * that catches this error on the way out can still merge a duplication
+   * along it. Undefined once any scope it passed through contributed output
+   * whose order was not recorded.
+   */
+  outputChunks: OutputChunk[] | undefined = [];
   constructor(
     message: string,
     public stdout: string = "",
@@ -30,7 +39,10 @@ export abstract class ControlFlowError extends Error {
   /**
    * Prepend output from the current context before re-throwing.
    */
-  prependOutput(stdout: string, stderr: string): void {
+  prependOutput(stdout: string, stderr: string, chunks?: OutputChunk[]): void {
+    const prefix = orderedOutput(chunks, stdout, stderr);
+    const carried = orderedOutput(this.outputChunks, this.stdout, this.stderr);
+    this.outputChunks = prefix && carried ? [...prefix, ...carried] : undefined;
     this.stdout = stdout + this.stdout;
     this.stderr = stderr + this.stderr;
     this.internalOutputAccounting.stdout += utf8ByteLength(stdout);

--- a/packages/just-bash/src/interpreter/functions.ts
+++ b/packages/just-bash/src/interpreter/functions.ts
@@ -209,13 +209,18 @@ export async function callFunction(
       func.redirections,
       prepared.targets,
       prepared.dupSources,
+      prepared.openedEntries,
       prepared.standardRoutes,
     );
   } catch (error) {
     if (error instanceof ControlFlowError && prepared) {
       await routeControlFlowError(ctx, error, func.redirections, prepared);
       if (error instanceof ReturnError) {
-        return result(error.stdout, error.stderr, error.exitCode);
+        const returned = result(error.stdout, error.stderr, error.exitCode);
+        if (error.outputChunks?.length) {
+          returned.internalOutputChunks = error.outputChunks;
+        }
+        return returned;
       }
     }
     throw error;

--- a/packages/just-bash/src/interpreter/helpers/condition.ts
+++ b/packages/just-bash/src/interpreter/helpers/condition.ts
@@ -12,7 +12,11 @@ import type { InterpreterContext } from "../types.js";
 
 export type ConditionResult = Pick<
   ExecResult,
-  "stdout" | "stderr" | "exitCode" | "internalOutputAccounting"
+  | "stdout"
+  | "stderr"
+  | "exitCode"
+  | "internalOutputAccounting"
+  | "internalOutputChunks"
 >;
 
 /**

--- a/packages/just-bash/src/interpreter/helpers/loop.ts
+++ b/packages/just-bash/src/interpreter/helpers/loop.ts
@@ -5,6 +5,8 @@
  * (for, c-style for, while, until).
  */
 
+import { orderedOutput, textChunks } from "../../output-chunks.js";
+import type { OutputChunk } from "../../types.js";
 import {
   BreakError,
   ContinueError,
@@ -21,8 +23,18 @@ export interface LoopErrorResult {
   action: LoopAction;
   stdout: string;
   stderr: string;
+  /** The two streams above in write order, absent where it was not recorded. */
+  chunks?: OutputChunk[];
   exitCode?: number;
   error?: unknown;
+}
+
+/** Two sequences end to end, or nothing where either is unknown. */
+function concatOrder(
+  before: OutputChunk[] | undefined,
+  after: OutputChunk[] | undefined,
+): OutputChunk[] | undefined {
+  return before && after ? [...before, ...after] : undefined;
 }
 
 /**
@@ -32,6 +44,7 @@ export interface LoopErrorResult {
  * @param stdout - Current accumulated stdout
  * @param stderr - Current accumulated stderr
  * @param loopDepth - Current loop nesting depth from ctx.state.loopDepth
+ * @param chunks - Accumulated output in write order, where the loop kept it
  * @returns Result indicating what action the loop should take
  */
 export function handleLoopError(
@@ -39,35 +52,33 @@ export function handleLoopError(
   stdout: string,
   stderr: string,
   loopDepth: number,
+  chunks?: OutputChunk[],
 ): LoopErrorResult {
-  if (error instanceof BreakError) {
-    stdout += error.stdout;
-    stderr += error.stderr;
-    // Only propagate if levels > 1 AND we're not at the outermost loop
-    // Per bash docs: "If n is greater than the number of enclosing loops,
-    // the last enclosing loop is exited"
-    if (error.levels > 1 && loopDepth > 1) {
-      error.levels--;
-      error.stdout = stdout;
-      error.stderr = stderr;
-      return { action: "rethrow", stdout, stderr, error };
-    }
-    return { action: "break", stdout, stderr };
-  }
+  const accumulated = orderedOutput(chunks, stdout, stderr);
 
-  if (error instanceof ContinueError) {
+  if (error instanceof BreakError || error instanceof ContinueError) {
+    const combined = concatOrder(
+      accumulated,
+      orderedOutput(error.outputChunks, error.stdout, error.stderr),
+    );
     stdout += error.stdout;
     stderr += error.stderr;
     // Only propagate if levels > 1 AND we're not at the outermost loop
     // Per bash docs: "If n is greater than the number of enclosing loops,
-    // the last enclosing loop is resumed"
+    // the last enclosing loop is exited" (resumed, for continue)
     if (error.levels > 1 && loopDepth > 1) {
       error.levels--;
       error.stdout = stdout;
       error.stderr = stderr;
-      return { action: "rethrow", stdout, stderr, error };
+      error.outputChunks = combined;
+      return { action: "rethrow", stdout, stderr, chunks: combined, error };
     }
-    return { action: "continue", stdout, stderr };
+    return {
+      action: error instanceof BreakError ? "break" : "continue",
+      stdout,
+      stderr,
+      chunks: combined,
+    };
   }
 
   if (
@@ -76,8 +87,8 @@ export function handleLoopError(
     error instanceof ExitError ||
     error instanceof ExecutionLimitError
   ) {
-    error.prependOutput(stdout, stderr);
-    return { action: "rethrow", stdout, stderr, error };
+    error.prependOutput(stdout, stderr, accumulated);
+    return { action: "rethrow", stdout, stderr, chunks: accumulated, error };
   }
 
   // Generic error - return error result
@@ -86,6 +97,7 @@ export function handleLoopError(
     action: "error",
     stdout,
     stderr: `${stderr}${message}\n`,
+    chunks: concatOrder(accumulated, textChunks("", `${message}\n`)),
     exitCode: 1,
   };
 }

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -712,6 +712,7 @@ export class Interpreter {
           node.redirections,
           preparedRedirections.targets,
           preparedRedirections.dupSources,
+          preparedRedirections.openedEntries,
           preparedRedirections.standardRoutes,
         );
         transaction.finish();
@@ -970,6 +971,7 @@ export class Interpreter {
       node.redirections,
       preparedRedirections.targets,
       preparedRedirections.dupSources,
+      preparedRedirections.openedEntries,
       preparedRedirections.standardRoutes,
       cmdResult.internalProducerCommand ?? commandName,
       cmdResult.internalProducerOmitsShellPrefix,

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -5,12 +5,9 @@
  */
 
 import type { CommandNode, PipelineNode } from "../ast/types.js";
-import {
-  encodeUtf8ToBytes,
-  latin1FromBytes,
-  stdoutAsBytes,
-} from "../encoding.js";
+import { latin1FromBytes, stdoutAsBytes, stdoutKind } from "../encoding.js";
 import { relinquishPipelineOutput } from "../execution-scope.js";
+import { chunksToBytes, orderedOutput } from "../output-chunks.js";
 import { _performanceNow } from "../security/trusted-globals.js";
 import type { ExecResult } from "../types.js";
 import { BadSubstitutionError, ErrexitError, ExitError } from "./errors.js";
@@ -203,12 +200,23 @@ export async function executePipeline(
       // Check if this pipe is |& (pipe stderr to next command's stdin too)
       const pipeStderrToNext = node.pipeStderr?.[i] ?? false;
       if (pipeStderrToNext) {
-        // |& pipes stderr + stdout. stderr is text (no producer marks it
-        // binary today); UTF-8 encode it before concatenating with the
-        // stdout bytes so the merged stream is byte-shaped end-to-end.
-        stdin =
-          latin1FromBytes(encodeUtf8ToBytes(result.stderr)) +
-          latin1FromBytes(stdoutAsBytes(result));
+        // |& puts both streams on the pipe's write end, so the next stage
+        // reads them in the order they were written. Each piece is encoded by
+        // its own shape — stderr is Unicode text, stdout may already be bytes
+        // — so the merged stream is byte-shaped end-to-end.
+        //
+        // Without a recorded order there is nothing to interleave along, and
+        // the two streams go in one after the other.
+        stdin = chunksToBytes(
+          orderedOutput(
+            result.internalOutputChunks,
+            result.stdout,
+            result.stderr,
+          ) ?? [
+            { text: result.stderr, kind: "text" },
+            { text: result.stdout, kind: stdoutKind(result) },
+          ],
+        );
       } else {
         // Regular | only pipes stdout; stderr goes to the parent
         stdin = latin1FromBytes(stdoutAsBytes(result));

--- a/packages/just-bash/src/interpreter/redirections.dup-ordering.control-flow.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-ordering.control-flow.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * Compound commands relay their body's output through their own accumulator,
+ * and a scope that leaves on `break`, `exit` or `return` carries it out on the
+ * error instead. Both paths have to keep the write order, or a duplication
+ * outside them merges stdout-first however well the body recorded it.
+ */
+describe("fd duplication ordering through control flow", () => {
+  it("interleaves a for loop's iterations", async () => {
+    const result = await new Bash().exec(
+      "for i in 1 2; do echo O$i; echo E$i 1>&2; done 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\nE2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a C-style for loop", async () => {
+    const result = await new Bash().exec(
+      "for ((i=1; i<3; i++)); do echo O$i; echo E$i 1>&2; done 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\nE2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a while loop", async () => {
+    const result = await new Bash().exec(
+      'while [ -z "$d" ]; do echo O1; echo E1 1>&2; echo O2; d=1; done 2>&1',
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves an until loop", async () => {
+    const result = await new Bash().exec(
+      'until [ -n "$d" ]; do echo O1; echo E1 1>&2; d=1; done 2>&1',
+    );
+    expect(result.stdout).toBe("O1\nE1\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves an if body", async () => {
+    const result = await new Bash().exec(
+      "if true; then echo O1; echo E1 1>&2; echo O2; fi 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves an if condition's own output with the body's", async () => {
+    const result = await new Bash().exec(
+      "if echo C1; echo C2 1>&2; then echo O1; echo E1 1>&2; fi 2>&1",
+    );
+    expect(result.stdout).toBe("C1\nC2\nO1\nE1\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a matched case body", async () => {
+    const result = await new Bash().exec(
+      "case x in x) echo O1; echo E1 1>&2; echo O2;; esac 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a loop into a file", async () => {
+    const env = new Bash();
+    await env.exec("for i in 1 2; do echo O$i; echo E$i 1>&2; done > /f 2>&1");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\nE2\n");
+  });
+
+  it("keeps the order of output written before a break", async () => {
+    const result = await new Bash().exec(
+      "for i in 1 2; do echo O$i; echo E$i 1>&2; echo P$i; " +
+        "[ $i = 1 ] && break; done 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nP1\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps the order of output written before an exit", async () => {
+    const result = await new Bash().exec(
+      "{ echo O1; echo E1 1>&2; echo O2; exit 0; } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps the order of output written before a return", async () => {
+    const result = await new Bash().exec(
+      "f() { echo O1; echo E1 1>&2; echo O2; return 0; }; f 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps the order of a subshell that exits early", async () => {
+    const result = await new Bash().exec(
+      "( echo O1; echo E1 1>&2; echo O2; exit 0 ) 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+});
+
+/**
+ * A pipe carries whatever its write end is given. `|&` puts both streams on
+ * that end, so the reading stage sees them in the order they were written.
+ */
+describe("fd duplication ordering through pipelines", () => {
+  it("interleaves both streams into a |& pipe", async () => {
+    const result = await new Bash().exec(
+      "{ echo O1; echo E1 1>&2; echo O2; } |& cat",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a duplication feeding an ordinary pipe", async () => {
+    const result = await new Bash().exec(
+      "{ echo O1; echo E1 1>&2; echo O2; } 2>&1 | cat",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("leaves an ordinary pipe carrying stdout alone", async () => {
+    const result = await new Bash().exec(
+      "{ echo O1; echo E1 1>&2; echo O2; } | cat",
+    );
+    expect(result.stdout).toBe("O1\nO2\n");
+    expect(result.stderr).toBe("E1\n");
+  });
+});

--- a/packages/just-bash/src/interpreter/redirections.dup-ordering.encoding.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-ordering.encoding.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * The two streams reaching one descriptor need not agree on a shape: a
+ * byte-shaped stdout is a buffer of bytes already chosen, while stderr is JS
+ * text whose bytes are chosen on the way out. Merging them under a single
+ * encoding rewrites one or the other, so each piece is encoded by the shape it
+ * was recorded with.
+ *
+ * `café` is the fixture: `c a f 0xC3 0xA9` as UTF-8, but `c a f 0xE9` if a
+ * decoded string is written as bytes.
+ */
+const setup = async (): Promise<Bash> => {
+  const env = new Bash();
+  await env.exec("printf 'caf\\xc3\\xa9\\n' > /bytes.txt");
+  return env;
+};
+
+/** `cat` of a UTF-8 file, so stdout is bytes, beside a Unicode stderr. */
+const MIXED = "{ cat /bytes.txt; printf 'gr\\xc3\\xbcn\\n' 1>&2; }";
+const UTF8 = "   c   a   f 303 251  \\n   g   r 303 274   n  \\n\n";
+
+describe("fd duplication merges by each stream's own shape", () => {
+  it("writes both to a file as UTF-8", async () => {
+    const env = await setup();
+    await env.exec(`${MIXED} > /out 2>&1`);
+    const dumped = await env.exec("od -An -c /out");
+    expect(dumped.stdout).toBe(UTF8);
+    expect(dumped.stderr).toBe("");
+  });
+
+  it("writes both to a descriptor as UTF-8", async () => {
+    const env = await setup();
+    await env.exec(`exec 3> /out; ${MIXED} >&3 2>&3`);
+    const dumped = await env.exec("od -An -c /out");
+    expect(dumped.stdout).toBe(UTF8);
+    expect(dumped.stderr).toBe("");
+  });
+
+  it("puts both on a |& pipe as UTF-8", async () => {
+    const env = await setup();
+    const dumped = await env.exec(`${MIXED} |& od -An -c`);
+    expect(dumped.stdout).toBe(UTF8);
+    expect(dumped.stderr).toBe("");
+  });
+
+  it("hands both back to the caller as text", async () => {
+    const env = await setup();
+    const result = await env.exec(`${MIXED} 2>&1`);
+    expect(result.stdout).toBe("café\ngrün\n");
+    expect(result.stderr).toBe("");
+  });
+});

--- a/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
@@ -33,6 +33,13 @@ describe("fd duplication output ordering", () => {
     expect(f.stdout).toBe("O1\nE1\nO2\n");
   });
 
+  it("interleaves into a file the other fd opened", async () => {
+    const env = new Bash();
+    await env.exec("{ echo O1; echo E1 1>&2; echo O2; } 2> /f 1>&2");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\n");
+  });
+
   it("interleaves onto stderr for 1>&2", async () => {
     const result = await new Bash().exec(
       "( echo O1; echo E1 1>&2; echo O2 ) 1>&2",

--- a/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
@@ -87,4 +87,109 @@ describe("fd duplication output ordering", () => {
     const f = await env.exec("cat /f");
     expect(f.stdout).toBe("E1\n");
   });
+
+  it("interleaves into a file both fds were opened onto at once", async () => {
+    const env = new Bash();
+    await env.exec("{ echo O1; echo E1 1>&2; echo O2; } &> /f");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\n");
+  });
+
+  it("interleaves when appending", async () => {
+    const env = new Bash();
+    await env.exec("echo P > /f");
+    await env.exec("{ echo O1; echo E1 1>&2; echo O2; } >> /f 2>&1");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("P\nO1\nE1\nO2\n");
+  });
+});
+
+/**
+ * A scope's own redirection layer rebuilds the result it relays, so ordering
+ * has to survive that rebuild or an inner scope flattens before an outer
+ * `2>&1` ever sees it.
+ */
+describe("fd duplication ordering through nested scopes", () => {
+  it("keeps an inner group's order for an outer duplication", async () => {
+    const result = await new Bash().exec(
+      "{ { echo O1; echo E1 1>&2; echo O2; }; } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps the order of two sibling groups", async () => {
+    const result = await new Bash().exec(
+      "{ { echo O1; echo E1 1>&2; }; { echo O2; echo E2 1>&2; }; } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\nE2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps a subshell's order for an outer duplication", async () => {
+    const result = await new Bash().exec(
+      "{ ( echo O1; echo E1 1>&2; echo O2 ); } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps a function body's order at the call site", async () => {
+    const result = await new Bash().exec(
+      "f() { echo O1; echo E1 1>&2; echo O2; }; f 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps a function body's order for a redirection on its definition", async () => {
+    const result = await new Bash().exec(
+      "f() { echo O1; echo E1 1>&2; echo O2; } 2>&1; f",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps the order across repeated calls to one function", async () => {
+    const result = await new Bash().exec(
+      "f() { echo O1; echo E1 1>&2; }; { f; f; } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO1\nE1\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves a nested group into a file", async () => {
+    const env = new Bash();
+    await env.exec("{ { echo O1; echo E1 1>&2; echo O2; }; } > /f 2>&1");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\n");
+  });
+});
+
+/**
+ * Two fds are one descriptor when one open put them both there, which is what
+ * a duplication does. Naming the same path twice opens it twice, and an fd
+ * that still names an older open of that path is not the open the redirection
+ * beside it just made.
+ */
+describe("fd duplication descriptor identity", () => {
+  it("does not merge an inherited open with a fresh open of one path", async () => {
+    const env = new Bash();
+    await env.exec(
+      "exec 3> /f; exec 1>&3; { echo O1; echo E1 1>&2; echo O2; } > /f 2>&3",
+    );
+    const f = await env.exec("cat /f");
+    // `> /f` and fd 3 are two opens, so the two streams stay independent.
+    // Bash writes each at its own descriptor's offset and ends with
+    // "E1\nO2\n"; a delivery here writes whole strings from position 0, which
+    // is the same approximation `> f 2> f` above is pinned on.
+    expect(f.stdout).toBe("O1\nO2\nE1\n");
+  });
+
+  it("merges a duplication of a descriptor opened by exec", async () => {
+    const env = new Bash();
+    await env.exec("exec 3> /f; { echo O1; echo E1 1>&2; echo O2; } >&3 2>&3");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\n");
+  });
 });

--- a/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.dup-ordering.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { defineCommand } from "../custom-commands.js";
+
+/**
+ * A duplication operator points both fds at one descriptor, so what it carries
+ * is the two streams in the order they were written -- `{ echo a; echo b 1>&2;
+ * echo c; } 2>&1` is `a b c` in bash, not `a c b`.
+ *
+ * The interpreter accumulates stdout and stderr as separate strings, which
+ * discards that ordering, so merging them meant appending all of stderr after
+ * all of stdout. `ExecutionOutputAccumulator` already appends in the order the
+ * statements produced their output, so the sequence is recorded alongside the
+ * two strings and the merge follows it.
+ *
+ * Only statement-level ordering is recoverable this way. A single command hands
+ * back two already-separated strings, so `cmd 2>&1` still falls back to
+ * stdout-then-stderr for that command's own output.
+ */
+describe("fd duplication output ordering", () => {
+  it("interleaves a group's streams in write order", async () => {
+    const result = await new Bash().exec(
+      "{ echo O1; echo E1 1>&2; echo O2; echo E2 1>&2; } 2>&1",
+    );
+    expect(result.stdout).toBe("O1\nE1\nO2\nE2\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("interleaves into a file when both fds share it", async () => {
+    const env = new Bash();
+    await env.exec("{ echo O1; echo E1 1>&2; echo O2; } > /f 2>&1");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("O1\nE1\nO2\n");
+  });
+
+  it("interleaves onto stderr for 1>&2", async () => {
+    const result = await new Bash().exec(
+      "( echo O1; echo E1 1>&2; echo O2 ) 1>&2",
+    );
+    expect(result.stderr).toBe("O1\nE1\nO2\n");
+    expect(result.stdout).toBe("");
+  });
+
+  it("orders custom commands' streams by statement", async () => {
+    const out = defineCommand("out", async (args) => ({
+      stdout: `${args[0]}\n`,
+      stderr: "",
+      exitCode: 0,
+    }));
+    const err = defineCommand("err", async (args) => ({
+      stdout: "",
+      stderr: `${args[0]}\n`,
+      exitCode: 0,
+    }));
+    const result = await new Bash({ customCommands: [out, err] }).exec(
+      "{ out A; err B; out C; } 2>&1",
+    );
+    expect(result.stdout).toBe("A\nB\nC\n");
+  });
+
+  it("keeps the streams separate when nothing duplicates them", async () => {
+    const result = await new Bash().exec("echo O1; echo E1 1>&2; echo O2");
+    expect(result.stdout).toBe("O1\nO2\n");
+    expect(result.stderr).toBe("E1\n");
+  });
+
+  it("still merges a single command's own streams stdout-first", async () => {
+    const both = defineCommand("both", async () => ({
+      stdout: "OUT\n",
+      stderr: "ERR\n",
+      exitCode: 0,
+    }));
+    const result = await new Bash({ customCommands: [both] }).exec("both 2>&1");
+    expect(result.stdout).toBe("OUT\nERR\n");
+  });
+
+  it("leaves two independent redirects to one path clobbering", async () => {
+    const env = new Bash();
+    await env.exec("{ echo O1; echo E1 1>&2; } > /f 2> /f");
+    const f = await env.exec("cat /f");
+    expect(f.stdout).toBe("E1\n");
+  });
+});

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -1342,11 +1342,11 @@ export async function applyRedirections(
   // before any redirection — a dup snapshot of a live fd keeps pointing
   // there even if a later redirection sends the source fd elsewhere.
   //
-  // A duplication (`2>&1`) shares the source fd's sink OBJECT — one open
-  // descriptor, so both streams go through it in order. Two independent
-  // redirects that happen to name the same path (`> f 2> f`) are separate
-  // descriptors, each writing from its own start position, so the later
-  // non-empty write clobbers the earlier one — matching bash's
+  // A duplication (`2>&1`) puts both fds on one open descriptor (see
+  // `fdsShareOneDescriptor`), so both streams go through it in order. Two
+  // independent redirects that happen to name the same path (`> f 2> f`) are
+  // separate descriptors, each writing from its own start position, so the
+  // later non-empty write clobbers the earlier one — matching bash's
   // independent-open behavior.
   if (stdout !== "" || stderr !== "") {
     let pendingStdout = stdout;
@@ -1359,6 +1359,39 @@ export async function applyRedirections(
       exitCode = 1;
     }
     if (fd2Sink.kind === "invalid-output") pendingStderr = "";
+    // Whether both fds ended up on one open descriptor, which is what makes a
+    // duplication carry the two streams in the order they were written.
+    //
+    // Sharing the sink object is one way to be that descriptor (`&> f` points
+    // both fds at one open). The others come from a sink rebuilt rather than
+    // shared: the live streams are the caller's own stdout and stderr, of which
+    // there is only ever one each, and `> f 2>&1` leaves fd 1 on the file it
+    // opened while fd 2 holds a dup snapshot of that open — the same fd-table
+    // entry, whose alias list names the fd that opened it. Two independent
+    // redirects to one path (`> f 2> f`) each open their own entry, so they
+    // match none of these and keep clobbering.
+    const dupOfOpenFile = (
+      sink: RedirectSink,
+      opener: 1 | 2,
+      opened: Extract<RedirectSink, { kind: "file" }>,
+    ): boolean =>
+      sink.kind === "descriptor" &&
+      sink.source.entry.kind === "output" &&
+      sink.source.entry.path === opened.path &&
+      sink.source.entry.append === opened.append &&
+      sink.source.descriptors.includes(opener);
+    const fdsShareOneDescriptor = (): boolean => {
+      if (fd1Sink === fd2Sink) return true;
+      if (fd1Sink.kind === "live-stdout" && fd2Sink.kind === "live-stdout") {
+        return true;
+      }
+      if (fd1Sink.kind === "live-stderr" && fd2Sink.kind === "live-stderr") {
+        return true;
+      }
+      if (fd1Sink.kind === "file") return dupOfOpenFile(fd2Sink, 1, fd1Sink);
+      if (fd2Sink.kind === "file") return dupOfOpenFile(fd1Sink, 2, fd2Sink);
+      return false;
+    };
     const deliverToFile = async (
       sink: { path: string; append: boolean },
       content: string,
@@ -1370,11 +1403,9 @@ export async function applyRedirections(
         await ctx.fs.writeFile(sink.path, content, encoding);
       }
     };
-    if (fd1Sink === fd2Sink) {
+    if (fdsShareOneDescriptor()) {
       // One descriptor carries both streams, so they arrive at it in the order
-      // they were written. Identity, not equality: two redirects that name the
-      // same path are separate descriptors and keep the clobbering behaviour
-      // handled by the loop below.
+      // they were written.
       const combined = mergeInRecordedOrder(
         result.outputChunks,
         pendingStdout,

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -17,7 +17,7 @@ import {
   readBytesFrom,
   utf8ByteLength,
 } from "../encoding.js";
-import type { ExecResult } from "../types.js";
+import type { ExecResult, OutputChunk } from "../types.js";
 import {
   ControlFlowError,
   ErrexitError,
@@ -1095,6 +1095,38 @@ export async function withPreparedRedirections(
   }
 }
 
+/**
+ * The two streams merged into one, in the order the interpreter recorded them,
+ * so a duplication like `2>&1` splices stderr where it was written instead of
+ * appending it after all of stdout.
+ *
+ * Falls back to stdout-then-stderr whenever the recorded chunks no longer
+ * reconstruct both pending strings exactly -- a single command records no
+ * order, and the redirection list above may have rewritten a stream (an
+ * ambiguous-redirect message, a target that failed to open). Reconstructing
+ * rather than trusting the chunks keeps content authoritative: the merge can
+ * reorder, never invent or drop.
+ */
+function mergeInRecordedOrder(
+  chunks: OutputChunk[] | undefined,
+  pendingStdout: string,
+  pendingStderr: string,
+): string {
+  if (!chunks?.length) {
+    return pendingStdout + pendingStderr;
+  }
+  let recordedStdout = "";
+  let recordedStderr = "";
+  for (const chunk of chunks) {
+    if (chunk.stream === "stdout") recordedStdout += chunk.text;
+    else recordedStderr += chunk.text;
+  }
+  if (recordedStdout !== pendingStdout || recordedStderr !== pendingStderr) {
+    return pendingStdout + pendingStderr;
+  }
+  return chunks.map((chunk) => chunk.text).join("");
+}
+
 export async function applyRedirections(
   ctx: InterpreterContext,
   result: ExecResult,
@@ -1338,27 +1370,40 @@ export async function applyRedirections(
         await ctx.fs.writeFile(sink.path, content, encoding);
       }
     };
-    if (
-      fd1Sink === fd2Sink &&
-      (fd1Sink.kind === "file" || fd1Sink.kind === "descriptor")
-    ) {
-      // stdout-then-stderr order, not the command's temporal write order:
-      // ExecResult accumulates the two streams separately, so interleaving
-      // is not recorded anywhere in the interpreter. This matches the
-      // convention of the live-stream merge (`stdout += stderr`) used for a
-      // bare `2>&1`.
-      const combined = pendingStdout + pendingStderr;
+    if (fd1Sink === fd2Sink) {
+      // One descriptor carries both streams, so they arrive at it in the order
+      // they were written. Identity, not equality: two redirects that name the
+      // same path are separate descriptors and keep the clobbering behaviour
+      // handled by the loop below.
+      const combined = mergeInRecordedOrder(
+        result.outputChunks,
+        pendingStdout,
+        pendingStderr,
+      );
       if (combined !== "") {
-        if (fd1Sink.kind === "file") {
-          await deliverToFile(fd1Sink, combined, getStdoutEncoding(combined));
-        } else {
-          await writeFdEntry(
-            ctx,
-            fd1Sink.source.entry,
-            fd1Sink.source.descriptors,
-            combined,
-            getStdoutEncoding(combined),
-          );
+        switch (fd1Sink.kind) {
+          case "live-stdout":
+            stdout += combined;
+            break;
+          case "live-stderr":
+            stderr += combined;
+            break;
+          case "file":
+            await deliverToFile(fd1Sink, combined, getStdoutEncoding(combined));
+            break;
+          case "descriptor":
+            await writeFdEntry(
+              ctx,
+              fd1Sink.source.entry,
+              fd1Sink.source.descriptors,
+              combined,
+              getStdoutEncoding(combined),
+            );
+            break;
+          case "invalid-output":
+            break;
+          case "discard":
+            break;
         }
       }
     } else {

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -14,9 +14,15 @@ import type { HereDocNode, RedirectionNode, WordNode } from "../ast/types.js";
 import {
   encodeUtf8ToBytes,
   latin1FromBytes,
+  type OutputKind,
   readBytesFrom,
   utf8ByteLength,
 } from "../encoding.js";
+import {
+  chunksDescribe,
+  joinChunkTexts,
+  orderedOutput,
+} from "../output-chunks.js";
 import type { ExecResult, OutputChunk } from "../types.js";
 import {
   ControlFlowError,
@@ -118,9 +124,20 @@ type PreparedDupSource =
 
 export type PreparedDupSources = Map<number, PreparedDupSource>;
 
+/**
+ * The fd-table entry each output redirection's open produced, keyed by its
+ * position in the redirection list.
+ *
+ * Two redirections naming one path are two opens with two positions of their
+ * own, so identity here is what separates `> f 2>&1` -- one open, both fds --
+ * from `> f 2> f`, which clobbers.
+ */
+export type OpenedRedirectEntries = Map<number, FdEntry>;
+
 export type PreparedRedirections = {
   targets: ExpandedRedirectTargets;
   dupSources: PreparedDupSources;
+  openedEntries: OpenedRedirectEntries;
   standardRoutes: Map<number, FdEntry>;
   stdin: string | undefined;
   stdinSourceFd: number;
@@ -319,6 +336,7 @@ async function prepareRedirectionsWithState(
 ): Promise<PreparedRedirections> {
   const targets: ExpandedRedirectTargets = new Map();
   const dupSources: PreparedDupSources = new Map();
+  const openedEntries: OpenedRedirectEntries = new Map();
   const standardRoute = (fd: number, fallback: FdEntry): FdEntry =>
     ctx.state.closedStandardFds?.has(fd)
       ? { kind: "closed" }
@@ -342,6 +360,7 @@ async function prepareRedirectionsWithState(
   const base = (): PreparedRedirections => ({
     targets,
     dupSources,
+    openedEntries,
     standardRoutes,
     stdin,
     stdinSourceFd,
@@ -360,6 +379,7 @@ async function prepareRedirectionsWithState(
         redirections.slice(0, index),
         targets,
         dupSources,
+        openedEntries,
         standardRoutes,
       ),
     };
@@ -920,6 +940,7 @@ async function prepareRedirectionsWithState(
       );
       if (opened.error) return fail(opened.error, index);
       const entry = opened.entry as FdEntry;
+      openedEntries.set(index, entry);
       if (redir.operator === "&>" || redir.operator === "&>>") {
         persistStandard(1, entry);
         persistStandard(2, entry);
@@ -1033,16 +1054,26 @@ export async function routeControlFlowError(
       : error instanceof ExecutionLimitError
         ? ExecutionLimitError.EXIT_CODE
         : 0;
+  const carried = makeResult(error.stdout, error.stderr, exitCode);
+  if (error.outputChunks?.length) {
+    carried.internalOutputChunks = error.outputChunks;
+  }
   const routed = await applyRedirections(
     ctx,
-    makeResult(error.stdout, error.stderr, exitCode),
+    carried,
     redirections,
     prepared.targets,
     prepared.dupSources,
+    prepared.openedEntries,
     prepared.standardRoutes,
   );
   error.stdout = routed.stdout;
   error.stderr = routed.stderr;
+  error.outputChunks = orderedOutput(
+    routed.internalOutputChunks,
+    routed.stdout,
+    routed.stderr,
+  );
   error.internalOutputAccounting = routed.internalOutputAccounting ?? {
     stdout: utf8ByteLength(routed.stdout),
     stderr: utf8ByteLength(routed.stderr),
@@ -1078,6 +1109,7 @@ export async function withPreparedRedirections(
         redirections,
         prepared.targets,
         prepared.dupSources,
+        prepared.openedEntries,
         prepared.standardRoutes,
       );
     } finally {
@@ -1101,30 +1133,28 @@ export async function withPreparedRedirections(
  * appending it after all of stdout.
  *
  * Falls back to stdout-then-stderr whenever the recorded chunks no longer
- * reconstruct both pending strings exactly -- a single command records no
- * order, and the redirection list above may have rewritten a stream (an
- * ambiguous-redirect message, a target that failed to open). Reconstructing
- * rather than trusting the chunks keeps content authoritative: the merge can
- * reorder, never invent or drop.
+ * describe both pending strings -- a single command records no order, and the
+ * redirection list above may have rewritten a stream (an ambiguous-redirect
+ * message, a target that failed to open).
+ *
+ * Either way the pieces are joined by shape rather than concatenated, since
+ * the two streams reaching one descriptor need not agree on one: a
+ * byte-shaped stdout and a Unicode stderr are both written through the single
+ * encoding this returns.
  */
 function mergeInRecordedOrder(
   chunks: OutputChunk[] | undefined,
   pendingStdout: string,
   pendingStderr: string,
-): string {
-  if (!chunks?.length) {
-    return pendingStdout + pendingStderr;
+  stdoutKind: OutputKind,
+): { text: string; kind: OutputKind } {
+  if (!chunksDescribe(chunks, pendingStdout, pendingStderr)) {
+    return joinChunkTexts([
+      { text: pendingStdout, kind: stdoutKind },
+      { text: pendingStderr, kind: "text" },
+    ]);
   }
-  let recordedStdout = "";
-  let recordedStderr = "";
-  for (const chunk of chunks) {
-    if (chunk.stream === "stdout") recordedStdout += chunk.text;
-    else recordedStderr += chunk.text;
-  }
-  if (recordedStdout !== pendingStdout || recordedStderr !== pendingStderr) {
-    return pendingStdout + pendingStderr;
-  }
-  return chunks.map((chunk) => chunk.text).join("");
+  return joinChunkTexts(chunks);
 }
 
 export async function applyRedirections(
@@ -1133,6 +1163,7 @@ export async function applyRedirections(
   redirections: RedirectionNode[],
   targets: ExpandedRedirectTargets,
   dupSources: PreparedDupSources = new Map(),
+  openedEntries: OpenedRedirectEntries = new Map(),
   standardRoutes: Map<number, FdEntry> = new Map(),
   writeErrorCommand = "bash",
   omitShellPrefix = false,
@@ -1177,7 +1208,10 @@ export async function applyRedirections(
   type RedirectSink =
     | { kind: "live-stdout" }
     | { kind: "live-stderr" }
-    | { kind: "file"; path: string; append: boolean }
+    // `entry` is the fd-table entry this redirection's own open produced, so
+    // a dup that resolved back to it can be told apart from an independent
+    // open of the same path.
+    | { kind: "file"; path: string; append: boolean; entry?: FdEntry }
     | {
         kind: "descriptor";
         source: Extract<PreparedDupSource, { kind: "entry" }>;
@@ -1291,10 +1325,16 @@ export async function applyRedirections(
           break;
         }
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
+        const sink: RedirectSink = {
+          kind: "file",
+          path: filePath,
+          append: isAppend,
+          entry: openedEntries.get(i),
+        };
         if (fd === 1) {
-          fd1Sink = { kind: "file", path: filePath, append: isAppend };
+          fd1Sink = sink;
         } else {
-          fd2Sink = { kind: "file", path: filePath, append: isAppend };
+          fd2Sink = sink;
         }
         break;
       }
@@ -1323,19 +1363,35 @@ export async function applyRedirections(
 
       case "&>": {
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        fd1Sink = { kind: "file", path: filePath, append: false };
+        fd1Sink = {
+          kind: "file",
+          path: filePath,
+          append: false,
+          entry: openedEntries.get(i),
+        };
         fd2Sink = fd1Sink;
         break;
       }
 
       case "&>>": {
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        fd1Sink = { kind: "file", path: filePath, append: true };
+        fd1Sink = {
+          kind: "file",
+          path: filePath,
+          append: true,
+          entry: openedEntries.get(i),
+        };
         fd2Sink = fd1Sink;
         break;
       }
     }
   }
+
+  // The order of whatever is still on the caller's streams once delivery is
+  // done, and the shape stdout is left in. Both describe only what this
+  // function hands back, so an enclosing scope can go on merging along them.
+  let deliveredChunks: OutputChunk[] | undefined;
+  let mergedStdoutKind: OutputKind | undefined;
 
   // Deliver content still held in the streams to each fd's final sink.
   // "live-stdout" / "live-stderr" mean the caller's own streams as they were
@@ -1359,27 +1415,33 @@ export async function applyRedirections(
       exitCode = 1;
     }
     if (fd2Sink.kind === "invalid-output") pendingStderr = "";
+    // The entry a sink writes through, for the redirections in this list that
+    // produced one. An entry opened here is handed to the dup that names its
+    // fd, so both fds arrive holding the one object.
+    const entryBehind = (sink: RedirectSink): FdEntry | undefined =>
+      sink.kind === "descriptor"
+        ? sink.source.entry
+        : sink.kind === "file"
+          ? sink.entry
+          : undefined;
+    // The fds sharing the open a dup resolved to. An entry that came back out
+    // of the fd table was decoded on lookup, so two dups of one open arrive as
+    // two equal objects; the alias group is what still ties them together,
+    // being exactly the set of fds on that open.
+    const aliasesBehind = (sink: RedirectSink): number[] | undefined =>
+      sink.kind === "descriptor" ? sink.source.descriptors : undefined;
     // Whether both fds ended up on one open descriptor, which is what makes a
     // duplication carry the two streams in the order they were written.
     //
     // Sharing the sink object is one way to be that descriptor (`&> f` points
-    // both fds at one open). The others come from a sink rebuilt rather than
-    // shared: the live streams are the caller's own stdout and stderr, of which
-    // there is only ever one each, and `> f 2>&1` leaves fd 1 on the file it
-    // opened while fd 2 holds a dup snapshot of that open — the same fd-table
-    // entry, whose alias list names the fd that opened it. Two independent
-    // redirects to one path (`> f 2> f`) each open their own entry, so they
-    // match none of these and keep clobbering.
-    const dupOfOpenFile = (
-      sink: RedirectSink,
-      opener: 1 | 2,
-      opened: Extract<RedirectSink, { kind: "file" }>,
-    ): boolean =>
-      sink.kind === "descriptor" &&
-      sink.source.entry.kind === "output" &&
-      sink.source.entry.path === opened.path &&
-      sink.source.entry.append === opened.append &&
-      sink.source.descriptors.includes(opener);
+    // both fds at one open). The rest come from a sink rebuilt rather than
+    // shared: the live streams are the caller's own stdout and stderr, of
+    // which there is only ever one each; a dup of a file opened beside it
+    // (`> f 2>&1`) holds that open's entry; and two dups of a descriptor the
+    // caller already had (`exec 3> f` then `>&3 2>&3`) sit in one alias
+    // group. Two independent redirects to one path (`> f 2> f`) open an entry
+    // each and share no group, so they match none of these and keep
+    // clobbering.
     const fdsShareOneDescriptor = (): boolean => {
       if (fd1Sink === fd2Sink) return true;
       if (fd1Sink.kind === "live-stdout" && fd2Sink.kind === "live-stdout") {
@@ -1388,10 +1450,29 @@ export async function applyRedirections(
       if (fd1Sink.kind === "live-stderr" && fd2Sink.kind === "live-stderr") {
         return true;
       }
-      if (fd1Sink.kind === "file") return dupOfOpenFile(fd2Sink, 1, fd1Sink);
-      if (fd2Sink.kind === "file") return dupOfOpenFile(fd1Sink, 2, fd2Sink);
-      return false;
+      const fd1Entry = entryBehind(fd1Sink);
+      if (fd1Entry !== undefined && fd1Entry === entryBehind(fd2Sink)) {
+        return true;
+      }
+      const fd1Aliases = aliasesBehind(fd1Sink);
+      const fd2Aliases = aliasesBehind(fd2Sink);
+      return (
+        fd1Aliases !== undefined &&
+        fd2Aliases !== undefined &&
+        fd1Aliases.some((fd) => fd2Aliases.includes(fd))
+      );
     };
+    // Which of the caller's own streams each pending string ended up on, if
+    // either did. Only those two are still described by the result returned
+    // below, so only they can carry the recorded order to the next layer.
+    const liveStreamOf = (
+      sink: RedirectSink,
+    ): "stdout" | "stderr" | undefined =>
+      sink.kind === "live-stdout"
+        ? "stdout"
+        : sink.kind === "live-stderr"
+          ? "stderr"
+          : undefined;
     const deliverToFile = async (
       sink: { path: string; append: boolean },
       content: string,
@@ -1407,34 +1488,43 @@ export async function applyRedirections(
       // One descriptor carries both streams, so they arrive at it in the order
       // they were written.
       const combined = mergeInRecordedOrder(
-        result.outputChunks,
+        result.internalOutputChunks,
         pendingStdout,
         pendingStderr,
+        stdoutIsBytes ? "bytes" : "text",
       );
-      if (combined !== "") {
+      if (combined.text !== "") {
+        const encoding = combined.kind === "bytes" ? "binary" : "utf8";
         switch (fd1Sink.kind) {
           case "live-stdout":
-            stdout += combined;
+            stdout += combined.text;
+            mergedStdoutKind = combined.kind;
             break;
           case "live-stderr":
-            stderr += combined;
+            stderr += combined.text;
             break;
           case "file":
-            await deliverToFile(fd1Sink, combined, getStdoutEncoding(combined));
+            await deliverToFile(fd1Sink, combined.text, encoding);
             break;
           case "descriptor":
             await writeFdEntry(
               ctx,
               fd1Sink.source.entry,
               fd1Sink.source.descriptors,
-              combined,
-              getStdoutEncoding(combined),
+              combined.text,
+              encoding,
             );
             break;
           case "invalid-output":
             break;
           case "discard":
             break;
+        }
+        const landedOn = liveStreamOf(fd1Sink);
+        if (landedOn) {
+          deliveredChunks = [
+            { stream: landedOn, text: combined.text, kind: combined.kind },
+          ];
         }
       }
     } else {
@@ -1474,19 +1564,50 @@ export async function applyRedirections(
             break;
         }
       }
+      // Each stream went to a destination of its own, so what stayed with the
+      // caller keeps the order it was written in — re-tagged for the stream it
+      // landed on, since a swap (`1>&2 2>&1`) sends each to the other, and
+      // minus any piece routed away from the caller along with the content it
+      // describes. Nothing is recorded where nothing was: an order the
+      // upstream never observed must stay unobserved, or a single command's
+      // two strings would come out of here claiming to be stdout-then-stderr.
+      const stdoutTo = liveStreamOf(fd1Sink);
+      const stderrTo = liveStreamOf(fd2Sink);
+      const recorded = result.internalOutputChunks;
+      if (chunksDescribe(recorded, pendingStdout, pendingStderr)) {
+        deliveredChunks = recorded.flatMap((chunk) => {
+          const landedOn = chunk.stream === "stdout" ? stdoutTo : stderrTo;
+          return landedOn ? [{ ...chunk, stream: landedOn }] : [];
+        });
+      }
     }
   }
 
   const finalResult = makeResult(stdout, stderr, exitCode);
+  // Carry the write order across this layer, so a scope that redirects
+  // nothing (or redirects only one fd) does not flatten what it relays and
+  // leave an enclosing `2>&1` with two strings to guess at.
+  if (deliveredChunks?.length) {
+    finalResult.internalOutputChunks = deliveredChunks;
+  }
   // Preserve the upstream's stdout shape through the redirection layer so
   // the next stage (pipeline glue, output boundary) can tell bytes-shaped
   // output from text-shaped output. Both the new `stdoutKind` field and
-  // the legacy `stdoutEncoding` alias are forwarded.
-  if (result.stdoutKind) {
-    finalResult.stdoutKind = result.stdoutKind;
-  }
-  if (result.stdoutEncoding === "binary") {
-    finalResult.stdoutEncoding = "binary";
+  // the legacy `stdoutEncoding` alias are forwarded. A merge that put both
+  // streams on the caller's stdout decides the shape itself: joining a byte
+  // buffer with Unicode text settles on bytes for the pair.
+  if (mergedStdoutKind) {
+    finalResult.stdoutKind = mergedStdoutKind;
+    if (mergedStdoutKind === "bytes" && result.stdoutEncoding === "binary") {
+      finalResult.stdoutEncoding = "binary";
+    }
+  } else {
+    if (result.stdoutKind) {
+      finalResult.stdoutKind = result.stdoutKind;
+    }
+    if (result.stdoutEncoding === "binary") {
+      finalResult.stdoutEncoding = "binary";
+    }
   }
   if (result.internalPipeStatusOverride) {
     finalResult.internalPipeStatusOverride = result.internalPipeStatusOverride;

--- a/packages/just-bash/src/interpreter/subshell-group.ts
+++ b/packages/just-bash/src/interpreter/subshell-group.ts
@@ -136,75 +136,30 @@ async function executeSubshellBody(
     // SubshellExitError means break/continue was called when parent had loop context
     // This exits the subshell cleanly with exit code 0
     if (error instanceof SubshellExitError) {
-      output.append(
-        "stdout",
-        error.stdout,
-        error.internalOutputAccounting.stdout,
-      );
-      output.append(
-        "stderr",
-        error.stderr,
-        error.internalOutputAccounting.stderr,
-      );
+      output.appendError(error);
       return output.build(0);
     }
     // BreakError/ContinueError should NOT propagate out of subshell
     // They only affect loops within the subshell
     if (error instanceof BreakError || error instanceof ContinueError) {
-      output.append(
-        "stdout",
-        error.stdout,
-        error.internalOutputAccounting.stdout,
-      );
-      output.append(
-        "stderr",
-        error.stderr,
-        error.internalOutputAccounting.stderr,
-      );
+      output.appendError(error);
       return output.build(0);
     }
     // ExitError in subshell should NOT propagate - just return the exit code
     // (subshells are like separate processes)
     if (error instanceof ExitError) {
-      output.append(
-        "stdout",
-        error.stdout,
-        error.internalOutputAccounting.stdout,
-      );
-      output.append(
-        "stderr",
-        error.stderr,
-        error.internalOutputAccounting.stderr,
-      );
+      output.appendError(error);
       return output.build(error.exitCode);
     }
     // ReturnError in subshell (e.g., f() ( return 42; )) should also just exit
     // with the given code, since subshells are like separate processes
     if (error instanceof ReturnError) {
-      output.append(
-        "stdout",
-        error.stdout,
-        error.internalOutputAccounting.stdout,
-      );
-      output.append(
-        "stderr",
-        error.stderr,
-        error.internalOutputAccounting.stderr,
-      );
+      output.appendError(error);
       return output.build(error.exitCode);
     }
     if (error instanceof ErrexitError) {
       // Apply output redirections before propagating
-      output.append(
-        "stdout",
-        error.stdout,
-        error.internalOutputAccounting.stdout,
-      );
-      output.append(
-        "stderr",
-        error.stderr,
-        error.internalOutputAccounting.stderr,
-      );
+      output.appendError(error);
       return output.build(error.exitCode);
     }
     // Apply output redirections before returning
@@ -302,7 +257,7 @@ async function executeGroupBody(
       error instanceof ErrexitError ||
       error instanceof ExitError
     ) {
-      error.prependOutput(output.stdout, output.stderr);
+      error.prependOutput(output.stdout, output.stderr, output.chunks);
       throw error;
     }
     output.append("stderr", `${getErrorMessage(error)}\n`);

--- a/packages/just-bash/src/output-chunks.ts
+++ b/packages/just-bash/src/output-chunks.ts
@@ -1,0 +1,120 @@
+/**
+ * Ordered output sequences.
+ *
+ * An `ExecResult` keeps stdout and stderr as two strings, which is enough to
+ * deliver each to its own destination but says nothing about how the two
+ * interleaved. `OutputChunk[]` records that sequence alongside them, for the
+ * one case that needs it: a duplication (`2>&1`) puts both fds on a single
+ * descriptor, and what that descriptor carries is the two streams in the
+ * order they were written.
+ */
+
+import {
+  encodeUtf8ToBytes,
+  latin1FromBytes,
+  type OutputKind,
+} from "./encoding.js";
+import type { OutputChunk } from "./types.js";
+
+/**
+ * Whether a recorded sequence still accounts for exactly the two streams it is
+ * attached to, piece for piece.
+ *
+ * Every consumer checks this before following the sequence. A layer between
+ * the recording and the read can rewrite a stream -- a decode that reshapes
+ * stdout, a diagnostic appended on the way out, an earlier pipeline stage's
+ * stderr prepended -- and the recording then describes content the result no
+ * longer carries. Reconstructing rather than trusting keeps the two strings
+ * authoritative: the sequence can reorder, never invent or drop.
+ */
+export function chunksDescribe(
+  chunks: OutputChunk[] | undefined,
+  stdout: string,
+  stderr: string,
+): chunks is OutputChunk[] {
+  if (!chunks?.length) return false;
+  let recordedStdout = "";
+  let recordedStderr = "";
+  for (const chunk of chunks) {
+    if (chunk.stream === "stdout") recordedStdout += chunk.text;
+    else recordedStderr += chunk.text;
+  }
+  return recordedStdout === stdout && recordedStderr === stderr;
+}
+
+/**
+ * The sequence for two streams, or `undefined` where none was recorded.
+ *
+ * Output with nothing in it is trivially in order, which lets a caller join
+ * two sequences whenever both sides are known -- and drop to `undefined`, the
+ * stdout-then-stderr fallback, as soon as either is not. Chunks are never
+ * synthesized from the strings alone: their shape (`kind`) is not recoverable
+ * from the text, and guessing it wrong re-encodes bytes as if they were
+ * Unicode.
+ */
+export function orderedOutput(
+  chunks: OutputChunk[] | undefined,
+  stdout: string,
+  stderr: string,
+): OutputChunk[] | undefined {
+  if (stdout === "" && stderr === "") return [];
+  return chunksDescribe(chunks, stdout, stderr) ? chunks : undefined;
+}
+
+/**
+ * A sequence for output built here rather than relayed from a child -- a
+ * diagnostic, a shell message. Its shape is known to be JS text, which is
+ * what lets it be described where `orderedOutput` declines to guess.
+ */
+export function textChunks(stdout: string, stderr: string): OutputChunk[] {
+  const chunks: OutputChunk[] = [];
+  if (stdout) chunks.push({ stream: "stdout", text: stdout, kind: "text" });
+  if (stderr) chunks.push({ stream: "stderr", text: stderr, kind: "text" });
+  return chunks;
+}
+
+/**
+ * One descriptor's worth of text, built from pieces that may not share a
+ * shape.
+ *
+ * A byte-shaped piece is a latin1 buffer of bytes already chosen; a
+ * text-shaped one is JS Unicode whose bytes are chosen when it is written.
+ * Concatenating the two would leave a string that is neither, so a mixed run
+ * settles on bytes and encodes the Unicode pieces to UTF-8 first. Pieces that
+ * already agree are joined untouched.
+ */
+export function joinChunkTexts(pieces: { text: string; kind: OutputKind }[]): {
+  text: string;
+  kind: OutputKind;
+} {
+  let hasBytes = false;
+  let hasText = false;
+  for (const piece of pieces) {
+    if (piece.text === "") continue;
+    if (piece.kind === "bytes") hasBytes = true;
+    else hasText = true;
+  }
+  if (hasBytes && hasText) {
+    return { text: chunksToBytes(pieces), kind: "bytes" };
+  }
+  return {
+    text: pieces.map((piece) => piece.text).join(""),
+    kind: hasBytes ? "bytes" : "text",
+  };
+}
+
+/**
+ * The pieces as one byte buffer, each encoded by its own shape -- what a pipe
+ * carries, since the reading end sees bytes and nothing else.
+ */
+export function chunksToBytes(
+  pieces: { text: string; kind: OutputKind }[],
+): string {
+  return pieces
+    .map((piece) =>
+      piece.kind === "bytes"
+        ? piece.text
+        : latin1FromBytes(encodeUtf8ToBytes(piece.text)),
+    )
+    .join("");
+}

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -1,4 +1,4 @@
-import type { ByteString } from "./encoding.js";
+import type { ByteString, OutputKind } from "./encoding.js";
 import type { CommandExecutionBudget } from "./execution-scope.js";
 import type { IFileSystem } from "./fs/interface.js";
 import type { ExecutionLimits } from "./limits.js";
@@ -12,10 +12,23 @@ export interface FeatureCoverageWriter {
   hit(feature: string): void;
 }
 
-/** One stream's worth of output, tagged with which stream produced it. */
+/**
+ * One stream's worth of output, tagged with which stream produced it and what
+ * shape its text is in.
+ *
+ * The shape travels per piece rather than per result because a duplication
+ * puts pieces of both streams on one descriptor, where a byte-shaped stdout
+ * and a Unicode stderr need different encodings on the way out.
+ * @internal
+ */
 export interface OutputChunk {
   stream: "stdout" | "stderr";
   text: string;
+  /**
+   * Matches `ExecResult.stdoutKind`. A stderr piece is `"text"` unless a
+   * duplication put byte-shaped stdout on that stream.
+   */
+  kind: OutputKind;
 }
 
 export interface ExecResult {
@@ -61,11 +74,12 @@ export interface ExecResult {
    * only adds back the relative ordering that keeping two strings discards.
    *
    * Set for a result the interpreter assembled from more than one statement: a
-   * group, a subshell, a function body. Absent for a single command, whose two
-   * streams arrive already separated, so consumers fall back to
+   * group, a subshell, a loop, a function body. Absent for a single command,
+   * whose two streams arrive already separated, so consumers fall back to
    * stdout-then-stderr there.
+   * @internal
    */
-  outputChunks?: OutputChunk[];
+  internalOutputChunks?: OutputChunk[];
   /**
    * Bytes in the current result that have already been charged to the shared
    * execution output budget. Interpreter plumbing must preserve this when it

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -12,6 +12,12 @@ export interface FeatureCoverageWriter {
   hit(feature: string): void;
 }
 
+/** One stream's worth of output, tagged with which stream produced it. */
+export interface OutputChunk {
+  stream: "stdout" | "stderr";
+  text: string;
+}
+
 export interface ExecResult {
   stdout: string;
   stderr: string;
@@ -48,6 +54,18 @@ export interface ExecResult {
   internalProducerOmitsShellPrefix?: boolean;
   /** @internal Bytes consumed from a descriptor-backed stdin stream. */
   internalStdinConsumed?: number;
+  /**
+   * The stdout and stderr pieces of this result in the order they were
+   * produced, when the interpreter observed that order. `stdout` and `stderr`
+   * remain authoritative -- they are these pieces filtered by stream -- so this
+   * only adds back the relative ordering that keeping two strings discards.
+   *
+   * Set for a result the interpreter assembled from more than one statement: a
+   * group, a subshell, a function body. Absent for a single command, whose two
+   * streams arrive already separated, so consumers fall back to
+   * stdout-then-stderr there.
+   */
+  outputChunks?: OutputChunk[];
   /**
    * Bytes in the current result that have already been charged to the shared
    * execution output budget. Interpreter plumbing must preserve this when it


### PR DESCRIPTION
## Problem

A duplication operator points both fds at one descriptor, so what it carries is the two streams in the order they were written. Today stderr is appended after all of stdout instead:

```js
await new Bash().exec("{ echo O1; echo E1 1>&2; echo O2; echo E2 1>&2; } 2>&1");

// stdout, before: "O1\nO2\nE1\nE2\n"
// stdout, after:  "O1\nE1\nO2\nE2\n"   // what bash prints
```

Same for `> f 2>&1` into a file, and for `1>&2` onto stderr.

When the two fds reach one file from opposite directions, the same gap drops output rather than reordering it:

```bash
{ echo O1; echo E1 1>&2; echo O2; } 2> f 1>&2

# f, before: "E1\n"           # O1 and O2 are gone
# f, after:  "O1\nE1\nO2\n"   # what bash writes
```

stdout is delivered through the descriptor, then stderr is written to the file from position 0 and truncates it. That clobbering is correct for two independent opens, which is what the delivery path takes these for. There is only one open here.

This matters most when the output is being read by a model rather than a person. `2>&1` is the usual way to capture everything a script did, and an agent reading the result has only the text to reason from, so when every error migrates to the bottom, a diagnostic no longer sits next to the command that produced it. A failure in step one reads as a failure in the last step, and an agent that retries or repairs on that basis fixes the wrong thing. Ordering is the only signal it has for attributing a message to a command.

## Cause

Two things, and the second is why fixing the first alone changes nothing.

`ExecutionOutputAccumulator` appends each statement's output in the order it was produced, then splits it across `stdoutChunks` and `stderrChunks`. The sequence exists at append time and is discarded by that split, so the merge in `applyRedirections` had nothing to follow and concatenated the two strings.

The delivery site already called this out:

> stdout-then-stderr order, not the command's temporal write order: ExecResult accumulates the two streams separately, so interleaving is not recorded anywhere in the interpreter.

So this is filed against a known gap rather than a surprise. If it was left open deliberately, I'm happy to be told so and close it.

The merge then only runs where `applyRedirections` can tell both fds ended up on one descriptor, and it recognized that by sink object identity: a dup used to assign the source fd's sink object to the other fd. Pre-resolved redirections (#336) changed that. A dup now reads its source back from the fd table, so `2>&1` rebuilds an equivalent `live-stdout` sink instead of sharing fd 1's object, and `> f 2>&1` leaves fd 1 on a `file` sink while fd 2 holds a `descriptor` sink for the entry that same open produced. Identity sees two objects, takes the separate-streams path, and that path is also what clobbers `2> f 1>&2`.

## Fix

Record the sequence the accumulator already sees, carry it on `ExecResult` as `outputChunks`, and merge along it when one sink holds both fds. `stdout` and `stderr` stay authoritative: the chunks are those same strings, split by stream, and only add back the relative ordering.

Then recognize one descriptor by what makes it one, rather than by object identity alone:

- a shared sink object, since `&> f` still points both fds at a single open
- the live streams by kind, since the caller has exactly one stdout and one stderr
- a file by the fd-table entry its open produced, whose alias list names the fd that opened it

Two independent redirects to one path each open their own entry and match none of these, so they keep clobbering.

The merge falls back to stdout-then-stderr unless the recorded chunks reconstruct both pending strings exactly. A single command records no order, and the redirection list can rewrite a stream before delivery (an ambiguous-redirect message, a target that failed to open). So the merge can reorder, never invent or drop.

## Scope

Statement-level ordering only. A single command hands back two already-separated strings, so its own interleaving is still lost and `cmd 2>&1` merges that command stdout-first. There's a test pinning that as intended rather than implying it's fixed.

Two independent redirects naming one path (`> f 2> f`) are separate descriptors and keep clobbering, now keyed on the entry each open produced rather than on path equality.

Not addressed, and unchanged by this: a delivery writes its whole string from position 0 rather than at the descriptor's offset, so independent opens clobber wholesale where bash overwrites byte ranges. `> f 2> f` gives `E1` where bash gives `E1 O2`, and `exec 2> f` followed by `{ ...; } > f` gives `O1` where bash gives `E1`. Both behave identically before and after this change; they want offset-tracking sinks, which is a different piece of work.

## Tests

Eight cases in `redirections.dup-ordering.test.ts`. Five fail on `main`, checked by copying the file onto a clean worktree at `244f73c` and running it there, not inferred. The other three pin behaviour this must not change: separate streams when nothing duplicates them, the single-command fallback, and `> f 2> f` still clobbering.

Checked the dup matrix by hand against real bash as well (3.2.57, so the ordering semantics rather than anything version-specific). File contents, newlines shown as spaces:

```
                     bash         after        before
> f 2>&1             O1 E1 O2     O1 E1 O2     O1 O2 E1
2> f 1>&2            O1 E1 O2     O1 E1 O2     E1
&> f                 O1 E1 O2     O1 E1 O2     O1 O2 E1
>> f 2>&1            O1 E1 O2     O1 E1 O2     O1 O2 E1
2>&1 > f             O1 O2        O1 O2        O1 O2        (E1 to stdout, all three)
> f 2> f             E1 O2        E1           E1
exec 2> f; > f       E1           O1           O1
```

The last two are the offset gap noted above, matching `main` in both columns.

`test:run` on this branch: 570 files, 15249 passing, 97 skipped, nothing failing, plus 72 passing in `just-bash-executor`. Typecheck, Biome and knip clean, changeset included.

One thing worth naming: `src/syntax/loops.test.ts > should detect infinite for loop and error` failed once while I had two full suites running concurrently, and passes on its own and in the clean run above. It's a timing-based limit test and nothing here touches loop protection, but it does look load-sensitive.

---

Model: Claude Opus 5
