### PR TITLE
fix(python): forward redirected stdin to CPython

### DIFF
--- a/packages/just-bash/src/commands/python3/python3.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.test.ts
@@ -75,6 +75,29 @@ describe("python3", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("should make a redirected file available to Python at runtime", async () => {
+      const env = new Bash({
+        python: true,
+        files: { "/input.txt": "hello from stdin\nsecond line\n" },
+      });
+      const result = await env.exec(
+        'python3 -c "import sys; sys.stdout.write(sys.stdin.read().upper())" < /input.txt',
+      );
+      expect(result.stdout).toBe("HELLO FROM STDIN\nSECOND LINE\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect Python stdout to a file", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(
+        'python3 -c "print(123)" > /output.txt && cat /output.txt',
+      );
+      expect(result.stdout).toBe("123\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
     it("should read Python code from stdin when invoked as `python3 -`", async () => {
       const env = new Bash({ python: true });
       const result = await env.exec('echo "print(456)" | python3 -');

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -12,7 +12,7 @@
 
 import { fileURLToPath } from "node:url";
 import { Worker } from "node:worker_threads";
-import { decodeBytesToUtf8 } from "../../encoding.js";
+import { decodeBytesToUtf8, latin1FromBytes } from "../../encoding.js";
 import type { IFileSystem } from "../../fs/interface.js";
 import {
   sanitizeErrorMessage,
@@ -473,6 +473,7 @@ function processNextExecution(queueState: QueueState): void {
  */
 async function executePython(
   pythonCode: string,
+  stdin: string,
   ctx: RuntimeCommandContext,
   scriptPath?: string,
   scriptArgs: string[] = [],
@@ -508,6 +509,7 @@ async function executePython(
     protocolToken: controller.protocolToken,
     sharedBuffer,
     pythonCode,
+    stdin,
     cwd: ctx.cwd,
     // Convert Map to null-prototype object for worker transfer
     // (Maps can't be postMessage'd, and null-prototype prevents prototype pollution)
@@ -651,6 +653,7 @@ export const python3Command: RuntimeCommand = {
 
     let pythonCode: string;
     let scriptPath: string | undefined;
+    let stdin = latin1FromBytes(ctx.stdin);
 
     if (parsed.code !== null) {
       pythonCode = parsed.code;
@@ -673,6 +676,7 @@ export const python3Command: RuntimeCommand = {
       // behavior in non-interactive contexts where no program is provided.
       // Decode bytes — Python source can hold unicode string literals.
       pythonCode = decodeBytesToUtf8(ctx.stdin);
+      stdin = "";
       scriptPath = "-";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
@@ -698,6 +702,7 @@ export const python3Command: RuntimeCommand = {
       }
     } else if (decodeBytesToUtf8(ctx.stdin).trim()) {
       pythonCode = decodeBytesToUtf8(ctx.stdin);
+      stdin = "";
       scriptPath = "<stdin>";
     } else {
       return {
@@ -708,7 +713,7 @@ export const python3Command: RuntimeCommand = {
       };
     }
 
-    return executePython(pythonCode, ctx, scriptPath, parsed.scriptArgs);
+    return executePython(pythonCode, stdin, ctx, scriptPath, parsed.scriptArgs);
   },
 };
 

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -28,6 +28,7 @@ export interface WorkerInput {
   protocolToken: string;
   sharedBuffer: SharedArrayBuffer;
   pythonCode: string;
+  stdin: string;
   cwd: string;
   env: Record<string, string>;
   args: string[];
@@ -277,6 +278,7 @@ interface EmscriptenFS {
     dev?: number,
   ) => EmscriptenNode;
   ErrnoError: new (errno: number) => Error;
+  init: (input?: () => number | null) => void;
   mkdir: (path: string) => void;
   unmount: (path: string) => void;
   mount: (
@@ -1303,10 +1305,17 @@ async function runPython(input: WorkerInput): Promise<WorkerOutput> {
 
   let Module: EmscriptenModule;
   try {
+    let stdinOffset = 0;
+    const readStdin = wrapWasmCallback("python3-worker", "stdin", () =>
+      stdinOffset < input.stdin.length
+        ? input.stdin.charCodeAt(stdinOffset++)
+        : null,
+    );
     const onPreRun = wrapWasmCallback(
       "python3-worker",
       "preRun",
       (mod: EmscriptenModule) => {
+        mod.FS.init(readStdin);
         // Write stdlib zip into MEMFS (no real FS access from WASM).
         // Python's zipimport can import directly from zip files.
         mod.FS.mkdirTree("/lib");


### PR DESCRIPTION
## Summary
- forward shell stdin bytes into the CPython worker through Emscripten's stdin callback
- keep stdin empty when it has already been consumed as Python source
- cover Python file-to-stdin and stdout-to-file redirection behavior

## Test plan
- [x] `pnpm vitest run --config vitest.wasm.config.ts src/commands/python3`
- [x] `pnpm exec biome check packages/just-bash/src/commands/python3/python3.ts packages/just-bash/src/commands/python3/worker.ts packages/just-bash/src/commands/python3/python3.test.ts`
- [x] `pnpm lint:banned`
- [x] Verify the stdin regression test fails against the unchanged base implementation
- [x] Verify commit signature through GitHub (`verified: true`, `reason: valid`)

🤖 Generated with [Pochi](https://getpochi.com) | [Task](https://app.getpochi.com/share/p-d98fbb7e630b45008ba273687f21f767)