### PR TITLE
feat(parser,interpreter): support process substitution <(…) and >(…)

### DIFF
--- a/.changeset/tidy-pandas-substitute.md
+++ b/.changeset/tidy-pandas-substitute.md
@@ -1,0 +1,11 @@
+---
+"just-bash": minor
+---
+
+Support process substitution `<(cmd)` and `>(cmd)`.
+
+`<(cmd)` runs `cmd` and substitutes a readable `/dev/fd/N` path backed by an
+in-memory file; `>(cmd)` substitutes a writable path whose contents are fed to
+`cmd` once the outer command finishes. Descriptors are numbered from 63
+downwards like bash and released when the command that opened them completes.
+Previously any use raised `Parse error: Expected redirection target`.

--- a/packages/just-bash/src/ast/types.ts
+++ b/packages/just-bash/src/ast/types.ts
@@ -977,6 +977,13 @@ export const AST = {
     return { type: "ArithmeticExpansion", expression };
   },
 
+  processSubstitution(
+    body: ScriptNode,
+    direction: "input" | "output",
+  ): ProcessSubstitutionPart {
+    return { type: "ProcessSubstitution", body, direction };
+  },
+
   assignment(
     name: string,
     value: WordNode | null,

--- a/packages/just-bash/src/comparison-tests/fixtures/process-substitution.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/process-substitution.comparison.fixtures.json
@@ -1,0 +1,235 @@
+{
+  "01c325f4fd2df45d": {
+    "command": "cat <(cat <(echo deep))",
+    "files": {},
+    "stdout": "deep\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "058c28f8e9d915ea": {
+    "command": "x=1; cat <(x=2; echo $x); echo after=$x",
+    "files": {},
+    "stdout": "2\nafter=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "0efecfb8671f9a86": {
+    "command": "cat <(echo in) > >(sed 's/in/OUT/')",
+    "files": {},
+    "stdout": "OUT\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "15e473d07c753afb": {
+    "command": "printf 'a\\nb\\n' | tee >(grep -c b) > /dev/null",
+    "files": {},
+    "stdout": "1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "2702326abcba5d31": {
+    "command": "echo '<(echo hi)' \"<(echo hi)\"",
+    "files": {},
+    "stdout": "<(echo hi) <(echo hi)\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3e9af782dc7a5397": {
+    "command": "cat < <(printf 'a\\nb\\n')",
+    "files": {},
+    "stdout": "a\nb\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "429f9e9e2269b3c3": {
+    "command": "printf 'x\\n' | tee >(cat) >(cat) > /dev/null",
+    "files": {},
+    "stdout": "x\nx\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "437b3e98f8700886": {
+    "command": "cat <(echo hi) | tr a-z A-Z",
+    "files": {},
+    "stdout": "HI\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "46a63be8029de200": {
+    "command": "comm -12 <(sort -u x.txt) <(sort -u y.txt)",
+    "files": {
+      "x.txt": "b\na\nb\n",
+      "y.txt": "c\nb\n"
+    },
+    "stdout": "b\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4cf2c6c0d221a282": {
+    "command": "paste <(printf 'a\\nb\\n') <(printf '1\\n2\\n')",
+    "files": {},
+    "stdout": "a\t1\nb\t2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "520c1a8824b37972": {
+    "command": "cat <(echo one) <(echo two) <(echo three)",
+    "files": {},
+    "stdout": "one\ntwo\nthree\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "60f0f73c5f361df0": {
+    "command": "echo hi > >(tr a-z A-Z)",
+    "files": {},
+    "stdout": "HI\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "65895a2e77a67686": {
+    "command": "wc -c < <(printf 'abc') | tr -d ' '",
+    "files": {},
+    "stdout": "3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "6be1bfc2d1a3991f": {
+    "command": "cat <(echo hi)",
+    "files": {},
+    "stdout": "hi\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "99a7207c139319bc": {
+    "command": "v=hello; cat <(echo $v)",
+    "files": {},
+    "stdout": "hello\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "acc9bbbbbf618f16": {
+    "command": "while read -r l; do echo \"got $l\"; done < <(printf '1\\n2\\n')",
+    "files": {},
+    "stdout": "got 1\ngot 2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "adc3dbb2ce7f58b1": {
+    "command": "diff <(sort a.txt) <(sort b.txt) > /dev/null; echo rc=$?",
+    "files": {
+      "a.txt": "b\na\n",
+      "b.txt": "a\nb\n"
+    },
+    "stdout": "rc=0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b308d68722b9f342": {
+    "command": "grep -q zzz <(echo hi); echo rc=$?",
+    "files": {},
+    "stdout": "rc=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b7173da4021b8a5c": {
+    "command": "echo hi > >(false); echo rc=$?",
+    "files": {},
+    "stdout": "rc=0\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c39dc04d62db3b56": {
+    "command": "for (( i=0; i<(2); i++ )); do echo $i; done",
+    "files": {},
+    "stdout": "0\n1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "c4203e60e96a23d3": {
+    "command": "echo ignored | grep -c . <(printf 'a\\nb\\n')",
+    "files": {},
+    "stdout": "2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "d19e9297fa888368": {
+    "command": "echo <(true)",
+    "files": {},
+    "stdout": "/dev/fd/63\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d4ecc99e492f5734": {
+    "command": "diff <(echo a) <(echo b) > /dev/null; echo rc=$?",
+    "files": {},
+    "stdout": "rc=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "df36ad323dff959b": {
+    "command": "echo <(true) <(true) <(true)",
+    "files": {},
+    "stdout": "/dev/fd/63 /dev/fd/62 /dev/fd/61\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e6c3386822d3348a": {
+    "command": "echo a<(true)",
+    "files": {},
+    "stdout": "a/dev/fd/63\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ec694650a83f0843": {
+    "command": "(( 3 > (1) )) && echo yes",
+    "files": {},
+    "stdout": "yes\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "eea422fbeef2eec8": {
+    "command": "cat <(echo a; exit 3); echo rc=$?",
+    "files": {},
+    "stdout": "a\nrc=0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f0530d91d94cfb55": {
+    "command": "echo 2>(true)",
+    "files": {},
+    "stdout": "2/dev/fd/63\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f2b739f20b173244": {
+    "command": "cat <(false); echo rc=$?",
+    "files": {},
+    "stdout": "rc=0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f2fc4c2ce711d7d5": {
+    "command": "cat <(echo a; echo b)",
+    "files": {},
+    "stdout": "a\nb\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ffb7e565962bcbd1": {
+    "command": "cat < (echo hi)",
+    "files": {},
+    "stdout": "",
+    "stderr": "/bin/bash: -c: line 0: syntax error near unexpected token `('\n/bin/bash: -c: line 0: `cat < (echo hi)'\n",
+    "exitCode": 2,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/process-substitution.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/process-substitution.comparison.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Process substitution comparison tests.
+ *
+ * Cases deliberately avoid anything bash makes non-deterministic or
+ * platform-specific:
+ * - `>(cmd)` writers run asynchronously in bash, so their output can interleave
+ *   with the shell's in any order; only their *effect* is compared here.
+ * - `wc` pads its counts differently across platforms, so counts go through
+ *   `tr -d ' '` or `grep -c`.
+ * - `diff`'s report format differs between implementations, so only its exit
+ *   status is compared.
+ */
+describe("Process Substitution - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  it("feeds a command from <(cmd)", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(echo hi)");
+  });
+
+  it("substitutes a /dev/fd path", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo <(true)");
+  });
+
+  it("numbers multiple substitutions downwards", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo <(true) <(true) <(true)");
+  });
+
+  it("passes several substitutions to one command", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "cat <(echo one) <(echo two) <(echo three)",
+    );
+  });
+
+  it("supports the comm idiom", async () => {
+    const env = await setupFiles(testDir, {
+      "x.txt": "b\na\nb\n",
+      "y.txt": "c\nb\n",
+    });
+    await compareOutputs(
+      env,
+      testDir,
+      "comm -12 <(sort -u x.txt) <(sort -u y.txt)",
+    );
+  });
+
+  it("supports the diff idiom for equal inputs", async () => {
+    const env = await setupFiles(testDir, {
+      "a.txt": "b\na\n",
+      "b.txt": "a\nb\n",
+    });
+    await compareOutputs(
+      env,
+      testDir,
+      "diff <(sort a.txt) <(sort b.txt) > /dev/null; echo rc=$?",
+    );
+  });
+
+  it("supports the diff idiom for differing inputs", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "diff <(echo a) <(echo b) > /dev/null; echo rc=$?",
+    );
+  });
+
+  it("supports the paste idiom", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "paste <(printf 'a\\nb\\n') <(printf '1\\n2\\n')",
+    );
+  });
+
+  it("reads a substitution through an input redirection", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat < <(printf 'a\\nb\\n')");
+  });
+
+  it("feeds a while-read loop", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "while read -r l; do echo \"got $l\"; done < <(printf '1\\n2\\n')",
+    );
+  });
+
+  it("works inside a pipeline", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(echo hi) | tr a-z A-Z");
+  });
+
+  it("works in a non-first pipeline stage", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "echo ignored | grep -c . <(printf 'a\\nb\\n')",
+    );
+  });
+
+  it("nests", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(cat <(echo deep))");
+  });
+
+  it("runs a multi-command body", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(echo a; echo b)");
+  });
+
+  it("preserves a body's missing trailing newline", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "wc -c < <(printf 'abc') | tr -d ' '");
+  });
+
+  it("does not let a failing body change the outer status", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(false); echo rc=$?");
+  });
+
+  it("keeps the outer command's own status", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "grep -q zzz <(echo hi); echo rc=$?");
+  });
+
+  it("contains exit inside the body", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(echo a; exit 3); echo rc=$?");
+  });
+
+  it("runs the body in a subshell", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "x=1; cat <(x=2; echo $x); echo after=$x",
+    );
+  });
+
+  it("sees the caller's variables", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "v=hello; cat <(echo $v)");
+  });
+
+  it("concatenates with an adjacent literal", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo a<(true)");
+  });
+
+  it("does not read a leading digit as a file descriptor", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo 2>(true)");
+  });
+
+  it("stays literal inside quotes", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo '<(echo hi)' \"<(echo hi)\"");
+  });
+
+  it("leaves > alone inside arithmetic", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "(( 3 > (1) )) && echo yes");
+  });
+
+  it("leaves < alone in a C-style for header", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "for (( i=0; i<(2); i++ )); do echo $i; done",
+    );
+  });
+
+  it("keeps a spaced < as a redirection", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat < (echo hi)", {
+      compareStderr: false,
+    });
+  });
+
+  it("pipes what a command wrote into >(cmd)", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo hi > >(tr a-z A-Z)");
+  });
+
+  it("supports the tee idiom", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "printf 'a\\nb\\n' | tee >(grep -c b) > /dev/null",
+    );
+  });
+
+  it("drives several writers from one command", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      "printf 'x\\n' | tee >(cat) >(cat) > /dev/null",
+    );
+  });
+
+  it("combines an input and an output substitution", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "cat <(echo in) > >(sed 's/in/OUT/')");
+  });
+
+  it("does not let a failing writer change the outer status", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "echo hi > >(false); echo rc=$?");
+  });
+});

--- a/packages/just-bash/src/fs/init.ts
+++ b/packages/just-bash/src/fs/init.ts
@@ -55,6 +55,9 @@ function initCommonDirectories(
  */
 function initDevFiles(fs: SyncInitFs): void {
   fs.mkdirSync("/dev", { recursive: true });
+  // Backing files for process substitution (`<(cmd)` / `>(cmd)`) are created
+  // here, mirroring the /dev/fd path bash substitutes on Linux.
+  fs.mkdirSync("/dev/fd", { recursive: true });
   fs.writeFileSync("/dev/null", "");
   fs.writeFileSync("/dev/zero", new Uint8Array(0));
   fs.writeFileSync("/dev/stdin", "");

--- a/packages/just-bash/src/interpreter/expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion.ts
@@ -92,6 +92,7 @@ import {
 } from "./helpers/ifs.js";
 import { isNameref, resolveNameref } from "./helpers/nameref.js";
 import { getLiteralValue, isQuotedPart } from "./helpers/word-parts.js";
+import { openProcessSubstitution } from "./process-substitution.js";
 import type { InterpreterContext } from "./types.js";
 
 // Re-export extracted functions for use elsewhere
@@ -642,7 +643,15 @@ export async function expandRedirectTarget(
 
   // Skip glob expansion if noglob is set (set -f) or if the word was quoted
   // Check these BEFORE building glob pattern to avoid double-expanding side-effectful expressions
-  if (hasQuoted || ctx.state.options.noglob) {
+  // A process substitution is side-effectful in the same way: it has already
+  // opened a descriptor above, and re-expanding the word to build a glob
+  // pattern would open a second one. The substituted /dev/fd path never
+  // contains glob metacharacters, so there is nothing to match anyway.
+  if (
+    hasQuoted ||
+    ctx.state.options.noglob ||
+    wordParts.some((p) => p.type === "ProcessSubstitution")
+  ) {
     return { target: value };
   }
 
@@ -868,6 +877,9 @@ async function expandPart(
         throw error;
       }
     }
+
+    case "ProcessSubstitution":
+      return openProcessSubstitution(ctx, part);
 
     case "ArithmeticExpansion": {
       // If original text is available and contains $var patterns (not ${...}),

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -28,6 +28,7 @@ import {
   encodeUtf8ToBytes,
   latin1FromBytes,
   readBytesFrom,
+  stdoutAsBytes,
 } from "../encoding.js";
 import { ExecutionOutputAccumulator } from "../execution-output.js";
 import type { ExecutionScope } from "../execution-scope.js";
@@ -98,6 +99,10 @@ import {
 } from "./helpers/word-matching.js";
 import { traceSimpleCommand } from "./helpers/xtrace.js";
 import { executePipeline as executePipelineHelper } from "./pipeline-execution.js";
+import {
+  markProcessSubstitutions,
+  releaseProcessSubstitutions,
+} from "./process-substitution.js";
 import {
   applyRedirections,
   preOpenOutputRedirects,
@@ -528,7 +533,41 @@ export class Interpreter {
     );
   }
 
+  /**
+   * Execute a command, tearing down any process substitutions its own word
+   * expansion opened. Descriptor numbers are handed out from 63 downwards and
+   * released here, so they are reused per command exactly like bash and no
+   * backing file outlives the command that created it.
+   */
   private async executeCommand(
+    node: CommandNode,
+    stdin: string,
+  ): Promise<ExecResult> {
+    const procSubMark = markProcessSubstitutions(this.ctx);
+    let result: ExecResult;
+    try {
+      result = await this.executeCommandInner(node, stdin);
+    } catch (error) {
+      await releaseProcessSubstitutions(this.ctx, procSubMark).catch(
+        () => undefined,
+      );
+      throw error;
+    }
+    const writer = await releaseProcessSubstitutions(this.ctx, procSubMark);
+    if (!writer.stdout && !writer.stderr) return result;
+    // A `>(cmd)` writer shares the shell's stdout and stderr in bash; append
+    // what it produced once the outer command has finished writing to it.
+    return {
+      ...result,
+      stdout: writer.stdout
+        ? latin1FromBytes(stdoutAsBytes(result)) + writer.stdout
+        : result.stdout,
+      stdoutKind: writer.stdout ? "bytes" : result.stdoutKind,
+      stderr: result.stderr + writer.stderr,
+    };
+  }
+
+  private async executeCommandInner(
     node: CommandNode,
     stdin: string,
   ): Promise<ExecResult> {

--- a/packages/just-bash/src/interpreter/process-substitution.output.test.ts
+++ b/packages/just-bash/src/interpreter/process-substitution.output.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+describe("process substitution - output >(cmd)", () => {
+  it("feeds what the outer command wrote into the body", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi > >(tr a-z A-Z)");
+    expect(result.stdout).toBe("HI\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("substitutes a writable /dev/fd path", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi >(cat)");
+    expect(result.stdout).toBe("hi /dev/fd/63\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports the tee idiom", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'a\\nb\\n' | tee >(wc -l) > /dev/null",
+    );
+    expect(result.stdout).toBe("2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("drives several writers from one command", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'x\\n' | tee >(cat) >(cat) > /dev/null",
+    );
+    expect(result.stdout).toBe("x\nx\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("combines with an input substitution", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo in) > >(sed 's/in/OUT/')");
+    expect(result.stdout).toBe("OUT\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("runs the body with empty stdin when nothing was written", async () => {
+    const env = new Bash();
+    const result = await env.exec("true > >(wc -c)");
+    expect(result.stdout).toBe("0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not let a failing body change the outer status", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi > >(false); echo rc=$?");
+    expect(result.stdout).toBe("rc=0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("sends the body's stderr to the shell's stderr", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi > >(cat >&2)");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("hi\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("discards variable assignments made in the body", async () => {
+    const env = new Bash();
+    const result = await env.exec("x=1; echo hi > >(read x); echo after=$x");
+    expect(result.stdout).toBe("after=1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("removes the backing file once the command finishes", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo hi > >(cat); ls /dev/fd | wc -l");
+    expect(result.stdout).toBe("hi\n0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("bounds a non-terminating body with the command limit", async () => {
+    const env = new Bash({ executionLimits: { maxCommandCount: 50 } });
+    const result = await env.exec("echo hi > >(while true; do echo x; done)");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "bash: too many commands executed (>50), increase executionLimits.maxCommandCount\n",
+    );
+    expect(result.exitCode).toBe(126);
+  });
+});

--- a/packages/just-bash/src/interpreter/process-substitution.readonly.test.ts
+++ b/packages/just-bash/src/interpreter/process-substitution.readonly.test.ts
@@ -1,0 +1,170 @@
+import * as path from "node:path";
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { OverlayFs } from "../fs/overlay-fs/index.js";
+
+/**
+ * Process substitution on a read-only filesystem — the mode the `just-bash`
+ * CLI uses by default.
+ *
+ * Real bash runs `<(cmd)` and `>(cmd)` fine on a read-only mount: they are
+ * pipes, not file writes. Both directions need writes to land somewhere —
+ * `<(cmd)` to materialise the body's output, and `>(cmd)` for the *outer*
+ * command to write into — so the interpreter routes `/dev/fd` to a private
+ * in-memory filesystem while leaving the supplied one read-only.
+ */
+const ROOT = path.join(import.meta.dirname, "..", "comparison-tests");
+
+function readOnlyBash(): Bash {
+  const fs = new OverlayFs({ root: ROOT, readOnly: true });
+  return new Bash({ fs, cwd: fs.getMountPoint() });
+}
+
+describe("process substitution - read-only filesystem", () => {
+  it("still refuses ordinary writes", async () => {
+    const env = readOnlyBash();
+    await expect(env.exec("echo nope > out.txt")).rejects.toThrow(
+      "EROFS: read-only file system, write '/home/user/project/out.txt'",
+    );
+  });
+
+  it("reads from <(cmd)", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("cat <(echo hi)");
+    expect(result.stdout).toBe("hi\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports the comm idiom", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec(
+      "comm -12 <(printf 'a\\nb\\n') <(printf 'b\\nc\\n')",
+    );
+    expect(result.stdout).toBe("b\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports the diff idiom", async () => {
+    const env = readOnlyBash();
+    // No `> /dev/null` here: writing to /dev/null is itself refused by a
+    // read-only OverlayFs, independently of process substitution.
+    const result = await env.exec("diff <(echo a) <(echo a); echo rc=$?");
+    expect(result.stdout).toBe("rc=0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("writes to >(cmd) through a redirection", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("echo hi > >(tr a-z A-Z)");
+    expect(result.stdout).toBe("HI\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("writes to >(cmd) through a command argument", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("printf 'a\\nb\\n' | tee >(grep -c b)");
+    expect(result.stdout).toBe("a\nb\n1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("feeds a while-read loop", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec(
+      "while read -r l; do echo \"got $l\"; done < <(printf '1\\n2\\n')",
+    );
+    expect(result.stdout).toBe("got 1\ngot 2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("leaves no backing file behind", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("cat <(echo x); ls /dev/fd | wc -l");
+    expect(result.stdout).toBe("x\n0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps the rest of /dev visible", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("cat <(echo x); ls /dev");
+    expect(result.stdout).toBe("x\nfd\nnull\nstderr\nstdin\nstdout\nzero\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still reads the underlying filesystem", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("cat <(ls README.md)");
+    expect(result.stdout).toBe("README.md\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+/**
+ * The `/dev/fd` mount exists to back descriptors, not to hand scripts a
+ * writable scratch directory a read-only sandbox is supposed to deny them.
+ * Only descriptors that are live right now accept writes.
+ */
+describe("process substitution - read-only /dev/fd is not scratch space", () => {
+  it("refuses a write to an unallocated descriptor", async () => {
+    const env = readOnlyBash();
+    await expect(
+      env.exec("cat <(true); echo data > /dev/fd/99"),
+    ).rejects.toThrow("EROFS: read-only file system, write '/dev/fd/99'");
+  });
+
+  it("refuses an append to an unallocated descriptor", async () => {
+    const env = readOnlyBash();
+    await expect(
+      env.exec("cat <(true); echo data >> /dev/fd/99"),
+    ).rejects.toThrow("EROFS: read-only file system, append '/dev/fd/99'");
+  });
+
+  it("refuses a write even with a descriptor still live", async () => {
+    const env = readOnlyBash();
+    await expect(
+      env.exec("cat <(true) <(echo data > /dev/fd/99)"),
+    ).rejects.toThrow("EROFS: read-only file system, write '/dev/fd/99'");
+  });
+
+  it("refuses creating a directory under /dev/fd", async () => {
+    const env = readOnlyBash();
+    const result = await env.exec("cat <(true); mkdir /dev/fd/sub");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mkdir: cannot create directory '/dev/fd/sub': " +
+        "EROFS: read-only file system, mkdir '/dev/fd/sub'\n",
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("behaves the same whether or not a substitution ran first", async () => {
+    const before = readOnlyBash();
+    await expect(before.exec("echo data > /dev/fd/99")).rejects.toThrow(
+      "EROFS: read-only file system, write '/dev/fd/99'",
+    );
+    const after = readOnlyBash();
+    await expect(
+      after.exec("cat <(true); echo data > /dev/fd/99"),
+    ).rejects.toThrow("EROFS: read-only file system, write '/dev/fd/99'");
+  });
+
+  it("leaves a writable filesystem's /dev/fd alone", async () => {
+    // No mount is installed when the supplied filesystem accepts writes, so
+    // /dev/fd stays an ordinary writable directory, exactly as before.
+    const env = new Bash();
+    const result = await env.exec(
+      "cat <(true); echo data > /dev/fd/99; cat /dev/fd/99",
+    );
+    expect(result.stdout).toBe("data\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/interpreter/process-substitution.test.ts
+++ b/packages/just-bash/src/interpreter/process-substitution.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+describe("process substitution - input <(cmd)", () => {
+  it("substitutes a readable path for the body's stdout", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo hi)");
+    expect(result.stdout).toBe("hi\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("substitutes a /dev/fd path counting down from 63", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo <(true) <(true) <(true)");
+    expect(result.stdout).toBe("/dev/fd/63 /dev/fd/62 /dev/fd/61\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("passes several substitutions to one command in order", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo one) <(echo two) <(echo three)");
+    expect(result.stdout).toBe("one\ntwo\nthree\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports the comm idiom", async () => {
+    const env = new Bash({
+      files: { "/x.txt": "b\na\nb\n", "/y.txt": "c\nb\n" },
+    });
+    const result = await env.exec(
+      "comm -12 <(sort -u /x.txt) <(sort -u /y.txt)",
+    );
+    expect(result.stdout).toBe("b\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports the diff idiom", async () => {
+    const env = new Bash({
+      files: { "/a.txt": "b\na\n", "/b.txt": "a\nb\n" },
+    });
+    const result = await env.exec(
+      "diff <(sort /a.txt) <(sort /b.txt) > /dev/null; echo rc=$?",
+    );
+    expect(result.stdout).toBe("rc=0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports a difference through diff's exit status", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "diff <(echo a) <(echo b) > /dev/null; echo rc=$?",
+    );
+    expect(result.stdout).toBe("rc=1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("works as the source of an input redirection", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat < <(printf 'a\\nb\\n')");
+    expect(result.stdout).toBe("a\nb\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("feeds a while-read loop", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "while read -r l; do echo \"got $l\"; done < <(printf '1\\n2\\n')",
+    );
+    expect(result.stdout).toBe("got 1\ngot 2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("works inside a pipeline", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo hi) | tr a-z A-Z");
+    expect(result.stdout).toBe("HI\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("works in a non-first pipeline stage", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "echo ignored | grep -c . <(printf 'a\\nb\\n')",
+    );
+    expect(result.stdout).toBe("2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("nests", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(cat <(echo deep))");
+    expect(result.stdout).toBe("deep\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves the body's exact bytes, including a missing newline", async () => {
+    const env = new Bash();
+    const result = await env.exec("wc -c < <(printf 'abc')");
+    expect(result.stdout).toBe("3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("concatenates with an adjacent literal", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo a<(true)");
+    expect(result.stdout).toBe("a/dev/fd/63\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("stays literal inside quotes", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo '<(echo hi)' \"<(echo hi)\"");
+    expect(result.stdout).toBe("<(echo hi) <(echo hi)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("process substitution - exit status", () => {
+  it("does not let a failing body change the outer status", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(false); echo rc=$?");
+    expect(result.stdout).toBe("rc=0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps the outer command's own status", async () => {
+    const env = new Bash();
+    const result = await env.exec("grep -q zzz <(echo hi); echo rc=$?");
+    expect(result.stdout).toBe("rc=1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("contains `exit` inside the body", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo a; exit 3); echo rc=$?");
+    expect(result.stdout).toBe("a\nrc=0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not abort the script under set -e", async () => {
+    const env = new Bash();
+    const result = await env.exec("set -e; cat <(false); echo after");
+    expect(result.stdout).toBe("after\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("sends the body's stderr to the shell's stderr", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo oops >&2; echo ok)");
+    expect(result.stdout).toBe("ok\n");
+    expect(result.stderr).toBe("oops\n");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("process substitution - subshell semantics", () => {
+  it("discards variable assignments made in the body", async () => {
+    const env = new Bash();
+    const result = await env.exec("x=1; cat <(x=2; echo $x); echo after=$x");
+    expect(result.stdout).toBe("2\nafter=1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("discards directory changes made in the body", async () => {
+    const env = new Bash();
+    const result = await env.exec("cd /tmp; cat <(cd /; pwd); pwd");
+    expect(result.stdout).toBe("/\n/tmp\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("sees the caller's variables", async () => {
+    const env = new Bash();
+    const result = await env.exec("v=hello; cat <(echo $v)");
+    expect(result.stdout).toBe("hello\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("process substitution - cleanup", () => {
+  it("removes the backing file once the command finishes", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <(echo hi); cat /dev/fd/63; echo rc=$?");
+    expect(result.stdout).toBe("hi\nrc=1\n");
+    expect(result.stderr).toBe("cat: /dev/fd/63: No such file or directory\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not accumulate backing files across commands", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "for i in 1 2 3; do cat <(echo $i) > /dev/null; done; ls /dev/fd | wc -l",
+    );
+    expect(result.stdout).toBe("0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reuses descriptor numbers across commands", async () => {
+    const env = new Bash();
+    const result = await env.exec("echo <(true); echo <(true)");
+    expect(result.stdout).toBe("/dev/fd/63\n/dev/fd/63\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("cleans up when the outer command fails", async () => {
+    const env = new Bash();
+    const result = await env.exec("nosuchcmd <(echo hi); ls /dev/fd | wc -l");
+    expect(result.stdout).toBe("0\n");
+    expect(result.stderr).toBe("bash: nosuchcmd: command not found\n");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("process substitution - limits", () => {
+  it("bounds a non-terminating body with the command limit", async () => {
+    const env = new Bash({ executionLimits: { maxCommandCount: 50 } });
+    const result = await env.exec("cat <(while true; do echo x; done)");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "bash: too many commands executed (>50), increase executionLimits.maxCommandCount\n",
+    );
+    expect(result.exitCode).toBe(126);
+  });
+
+  it("bounds body output with the string length limit", async () => {
+    const env = new Bash({ executionLimits: { maxStringLength: 8 } });
+    const result = await env.exec("cat <(echo aaa; echo bbb; echo ccc)");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "bash: process substitution: string length limit exceeded (8 bytes)\n",
+    );
+    expect(result.exitCode).toBe(126);
+  });
+
+  it("bounds nesting depth", async () => {
+    const env = new Bash({ executionLimits: { maxSubstitutionDepth: 2 } });
+    const result = await env.exec("cat <(cat <(cat <(echo deep)))");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "bash: Process substitution nesting limit exceeded (2)\n",
+    );
+    expect(result.exitCode).toBe(126);
+  });
+});

--- a/packages/just-bash/src/interpreter/process-substitution.ts
+++ b/packages/just-bash/src/interpreter/process-substitution.ts
@@ -1,0 +1,431 @@
+/**
+ * Process Substitution
+ *
+ * Implements bash's `<(cmd)` and `>(cmd)`.
+ *
+ * Real bash runs `cmd` asynchronously connected to a pipe and substitutes the
+ * pipe's path (`/dev/fd/N`, or a FIFO on systems without `/dev/fd`). There are
+ * no processes or pipes here, so the construct is modelled with the same
+ * building blocks the rest of the interpreter uses for fds: a backing file in
+ * the VFS under `/dev/fd/`, whose contents are produced (or consumed) by
+ * running the body as a subshell.
+ *
+ * - `<(cmd)` runs `cmd` eagerly during word expansion, writes its stdout to
+ *   the backing file, and substitutes that path. Because the body is fully
+ *   buffered, a body that never terminates on its own (e.g. `yes`) is bounded
+ *   by the ordinary execution limits rather than by the reader closing the
+ *   pipe.
+ * - `>(cmd)` substitutes an empty writable backing file. Once the command that
+ *   consumed the path has finished, whatever was written to the file is fed to
+ *   `cmd` as stdin and `cmd`'s output is appended to the result — the closest
+ *   deterministic analogue of bash's asynchronous writer.
+ *
+ * Backing files live only for the duration of the command whose expansion
+ * created them: {@link markProcessSubstitutions} / {@link releaseProcessSubstitutions}
+ * bracket every command execution, so fd numbers are reused (63, 62, … just
+ * like bash) and nothing accumulates in the VFS across commands.
+ */
+
+import type { ProcessSubstitutionPart, ScriptNode } from "../ast/types.js";
+import { latin1FromBytes, readBytesFrom, stdoutAsBytes } from "../encoding.js";
+import { InMemoryFs } from "../fs/in-memory-fs/index.js";
+import type {
+  BufferEncoding,
+  FileContent,
+  MkdirOptions,
+  RmOptions,
+  WriteFileOptions,
+} from "../fs/interface.js";
+import { MountableFs } from "../fs/mountable-fs/index.js";
+import type { ExecResult } from "../types.js";
+import { ExecutionLimitError, ExitError } from "./errors.js";
+import { cloneArrays } from "./helpers/array.js";
+import type { InterpreterContext } from "./types.js";
+
+/**
+ * Directory holding the synthetic descriptor files. Matches the Linux path
+ * bash substitutes, so scripts that echo the substituted word (or test it with
+ * `[ -r ... ]`) see what they would see on a real system.
+ */
+const PROC_SUB_DIR = "/dev/fd";
+
+/**
+ * First descriptor number handed out, counting down. bash uses 63 for the
+ * first process substitution of a command, 62 for the second, and so on.
+ */
+const FIRST_FD = 63;
+
+/**
+ * Lowest descriptor number handed out. bash's high fds stop well above the
+ * shell's own 0-9 range; capping here bounds how many bodies a single command
+ * can buffer at once.
+ */
+const LOWEST_FD = 10;
+
+/** Maximum number of process substitutions live at the same time. */
+const MAX_LIVE = FIRST_FD - LOWEST_FD + 1;
+
+/**
+ * The filesystem mounted at `/dev/fd` for sandboxes that refuse writes.
+ *
+ * Mounting a plain `InMemoryFs` would hand a script exactly the scratch space
+ * the read-only contract denies it: after any process substitution,
+ * `echo data > /dev/fd/anything` would start succeeding. Nothing reaches the
+ * host either way, but it is a policy widening a script can observe and use.
+ *
+ * So the hole is narrowed to what the feature actually needs. Only the
+ * descriptors the interpreter currently has allocated are writable; every
+ * other path under `/dev/fd` gets the same `EROFS` the base filesystem would
+ * have produced. Reads are untouched — they are already allowed on the
+ * read-only base — and directory-shaped mutations are refused outright,
+ * because process substitution never performs them.
+ */
+class ProcessSubstitutionFs extends InMemoryFs {
+  private readonly isLiveDescriptor: (relativePath: string) => boolean;
+
+  constructor(isLiveDescriptor: (relativePath: string) => boolean) {
+    super();
+    this.isLiveDescriptor = isLiveDescriptor;
+  }
+
+  /** Refuse anything that is not a live descriptor's backing file. */
+  private assertLiveDescriptor(path: string, operation: string): void {
+    if (this.isLiveDescriptor(path)) return;
+    this.refuse(path, operation);
+  }
+
+  private refuse(path: string, operation: string): never {
+    throw new Error(
+      `EROFS: read-only file system, ${operation} '${PROC_SUB_DIR}${path}'`,
+    );
+  }
+
+  override async writeFile(
+    path: string,
+    content: FileContent,
+    options?: WriteFileOptions | BufferEncoding,
+  ): Promise<void> {
+    this.assertLiveDescriptor(path, "write");
+    return super.writeFile(path, content, options);
+  }
+
+  override async appendFile(
+    path: string,
+    content: FileContent,
+    options?: WriteFileOptions | BufferEncoding,
+  ): Promise<void> {
+    this.assertLiveDescriptor(path, "append");
+    return super.appendFile(path, content, options);
+  }
+
+  override async rm(path: string, options?: RmOptions): Promise<void> {
+    this.assertLiveDescriptor(path, "rm");
+    return super.rm(path, options);
+  }
+
+  override async mkdir(path: string, _options?: MkdirOptions): Promise<void> {
+    this.refuse(path, "mkdir");
+  }
+
+  override async cp(_src: string, dest: string): Promise<void> {
+    this.refuse(dest, "cp");
+  }
+
+  override async mv(_src: string, dest: string): Promise<void> {
+    this.refuse(dest, "mv");
+  }
+
+  override async symlink(_target: string, linkPath: string): Promise<void> {
+    this.refuse(linkPath, "symlink");
+  }
+
+  override async link(_existingPath: string, newPath: string): Promise<void> {
+    this.refuse(newPath, "link");
+  }
+
+  override async chmod(path: string, _mode: number): Promise<void> {
+    this.refuse(path, "chmod");
+  }
+
+  override async utimes(
+    path: string,
+    _atime: Date,
+    _mtime: Date,
+  ): Promise<void> {
+    this.refuse(path, "utimes");
+  }
+}
+
+/**
+ * Give `/dev/fd` a private, always-writable filesystem for the rest of this
+ * execution.
+ *
+ * A read-only sandbox (`OverlayFs({ readOnly: true })` — the `just-bash` CLI's
+ * default) rejects every write. That forbids the *script* from modifying the
+ * filesystem it was handed, but a process substitution is a pipe, not a file
+ * write: real bash runs `cat <(cmd)` and `tee >(cmd)` fine on a read-only
+ * mount. Both directions need writes to succeed — `<(cmd)` to materialise the
+ * body's output, and `>(cmd)` for the *outer* command (`tee`, a `>` redirect,
+ * any command handed the path) to write into it.
+ *
+ * Rather than special-case each writer, the whole `/dev/fd` subtree is routed
+ * to a throwaway `InMemoryFs`. Everything else still goes to the filesystem the
+ * caller supplied, unchanged and still read-only. The mount lives for one
+ * execution and never reaches the host filesystem, so nothing the sandbox
+ * exposes changes — and because the mount is genuinely writable, descriptors
+ * are removed on release instead of leaving stale entries behind.
+ *
+ * A fresh `MountableFs` wraps the caller's filesystem; the caller's own object
+ * is never mutated, even if it happens to be a `MountableFs` itself. The
+ * mounted filesystem only accepts writes to descriptors that are live right
+ * now, so the read-only contract still holds for every other path.
+ */
+function mountBackingFs(ctx: InterpreterContext): void {
+  const backing = new ProcessSubstitutionFs((relativePath) =>
+    liveEntries(ctx).some(
+      (entry) => entry.path === `${PROC_SUB_DIR}${relativePath}`,
+    ),
+  );
+  ctx.fs = new MountableFs({
+    base: ctx.fs,
+    mounts: [{ mountPoint: PROC_SUB_DIR, filesystem: backing }],
+  });
+  ctx.state.processSubstitutionFsMounted = true;
+}
+
+/**
+ * Materialise a descriptor's backing file, mounting the private `/dev/fd`
+ * filesystem first if the supplied one refuses the write.
+ */
+async function writeBackingFile(
+  ctx: InterpreterContext,
+  path: string,
+  bytes: string,
+): Promise<void> {
+  try {
+    await ctx.fs.writeFile(path, bytes, "binary");
+    return;
+  } catch (error) {
+    // Already on the private mount: the failure is real, not a policy refusal.
+    if (ctx.state.processSubstitutionFsMounted) throw error;
+    mountBackingFs(ctx);
+  }
+  await ctx.fs.writeFile(path, bytes, "binary");
+}
+
+/** Drop a descriptor's backing file. */
+async function dropBackingFile(
+  ctx: InterpreterContext,
+  path: string,
+): Promise<void> {
+  try {
+    await ctx.fs.rm(path, { force: true });
+  } catch {
+    // Nothing to drop: an outer command may have removed the path itself.
+  }
+}
+
+/** A process substitution whose backing file is still live. */
+export interface ProcessSubstitutionEntry {
+  /** Synthetic descriptor number (63, 62, …). */
+  fd: number;
+  /** Backing file path handed to the outer command. */
+  path: string;
+  /** `<(...)` or `>(...)`. */
+  direction: "input" | "output";
+  /** Body to run with the written bytes as stdin (output substitutions only). */
+  body: ScriptNode;
+}
+
+function liveEntries(ctx: InterpreterContext): ProcessSubstitutionEntry[] {
+  const existing = ctx.state.processSubstitutions;
+  if (existing) return existing;
+  const created: ProcessSubstitutionEntry[] = [];
+  ctx.state.processSubstitutions = created;
+  return created;
+}
+
+/**
+ * Run a process substitution body with subshell semantics: variable, array and
+ * cwd changes are discarded and `$?` is left untouched (bash reaps the body
+ * asynchronously, so it never becomes the shell's last exit status). The
+ * caller decides where the body's stderr goes.
+ */
+async function runBody(
+  ctx: InterpreterContext,
+  body: ScriptNode,
+  stdin: string | undefined,
+): Promise<ExecResult> {
+  const currentDepth = ctx.substitutionDepth ?? 0;
+  const maxDepth = ctx.limits.maxSubstitutionDepth;
+  if (currentDepth >= maxDepth) {
+    throw new ExecutionLimitError(
+      `Process substitution nesting limit exceeded (${maxDepth})`,
+      "substitution_depth",
+    );
+  }
+
+  const savedDepth = ctx.substitutionDepth;
+  const savedEnv = new Map(ctx.state.env);
+  const savedArrays = cloneArrays(ctx.state.arrays);
+  const savedCwd = ctx.state.cwd;
+  const savedBashPid = ctx.state.bashPid;
+  const savedSuppressVerbose = ctx.state.suppressVerbose;
+  const savedGroupStdin = ctx.state.groupStdin;
+  const savedExitCode = ctx.state.lastExitCode;
+  const savedExitCodeVar = ctx.state.env.get("?");
+
+  ctx.substitutionDepth = currentDepth + 1;
+  ctx.state.bashPid = ctx.state.nextVirtualPid++;
+  ctx.state.suppressVerbose = true;
+  if (stdin !== undefined) ctx.state.groupStdin = stdin;
+
+  let result: ExecResult;
+  try {
+    result = await ctx.executeScript(body);
+  } catch (error) {
+    // Safety limits always propagate.
+    if (error instanceof ExecutionLimitError) throw error;
+    // `exit` inside the body terminates only the body, exactly like a
+    // subshell; whatever it printed before exiting still reaches the pipe.
+    if (error instanceof ExitError) {
+      return {
+        stdout: error.stdout,
+        stderr: error.stderr,
+        exitCode: error.exitCode,
+      };
+    }
+    throw error;
+  } finally {
+    ctx.substitutionDepth = savedDepth;
+    ctx.state.env = savedEnv;
+    ctx.state.arrays = savedArrays;
+    ctx.state.cwd = savedCwd;
+    ctx.state.bashPid = savedBashPid;
+    ctx.state.suppressVerbose = savedSuppressVerbose;
+    ctx.state.groupStdin = savedGroupStdin;
+    // The body's status is never the shell's `$?` (bash forks it away).
+    ctx.state.lastExitCode = savedExitCode;
+    if (savedExitCodeVar !== undefined) {
+      ctx.state.env.set("?", savedExitCodeVar);
+    } else {
+      ctx.state.env.delete("?");
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Expand a process substitution to the path the outer command should use.
+ */
+export async function openProcessSubstitution(
+  ctx: InterpreterContext,
+  part: ProcessSubstitutionPart,
+): Promise<string> {
+  const entries = liveEntries(ctx);
+  if (entries.length >= MAX_LIVE) {
+    throw new ExecutionLimitError(
+      `Process substitution limit exceeded (${MAX_LIVE} concurrent)`,
+      "file_descriptors",
+    );
+  }
+
+  let bytes = "";
+  if (part.direction === "input") {
+    const result = await runBody(ctx, part.body, undefined);
+    // The body runs during expansion, so its stderr belongs to the shell at
+    // expansion time - later redirections on the outer command must not
+    // capture it (same rule as command substitution).
+    if (result.stderr) {
+      ctx.state.expansionStderr =
+        (ctx.state.expansionStderr || "") + result.stderr;
+    }
+    bytes = latin1FromBytes(stdoutAsBytes(result));
+    if (bytes.length > ctx.limits.maxStringLength) {
+      throw new ExecutionLimitError(
+        `process substitution: string length limit exceeded (${ctx.limits.maxStringLength} bytes)`,
+        "string_length",
+      );
+    }
+  }
+
+  // The descriptor is numbered only after the body has run, so a nested
+  // substitution inside it gets - and releases - this same number first, just
+  // as bash reuses a descriptor once its writer is reaped. Registering the
+  // entry before the write is what makes the backing path writable on the
+  // guarded /dev/fd mount; a failed write must not leave it registered.
+  const fd = FIRST_FD - entries.length;
+  const path = `${PROC_SUB_DIR}/${fd}`;
+  entries.push({ fd, path, direction: part.direction, body: part.body });
+  try {
+    await writeBackingFile(ctx, path, bytes);
+  } catch (error) {
+    entries.pop();
+    throw error;
+  }
+  return path;
+}
+
+/**
+ * Remember how many process substitutions were live before a command ran.
+ */
+export function markProcessSubstitutions(ctx: InterpreterContext): number {
+  return ctx.state.processSubstitutions?.length ?? 0;
+}
+
+/** Output produced by `>(cmd)` writers drained at the end of a command. */
+export interface ProcessSubstitutionWriterOutput {
+  stdout: string;
+  stderr: string;
+}
+
+/** Nothing was drained. */
+const NO_WRITER_OUTPUT: ProcessSubstitutionWriterOutput = {
+  stdout: "",
+  stderr: "",
+};
+
+/**
+ * Tear down every process substitution opened since `mark`, newest first.
+ *
+ * Input substitutions just drop their backing file. Output substitutions first
+ * feed everything the outer command wrote into their body; the body's output is
+ * returned so the caller can append it to the command's own, the way bash's
+ * asynchronous writer shares the shell's stdout and stderr.
+ */
+export async function releaseProcessSubstitutions(
+  ctx: InterpreterContext,
+  mark: number,
+): Promise<ProcessSubstitutionWriterOutput> {
+  const entries = ctx.state.processSubstitutions;
+  if (!entries || entries.length <= mark) return NO_WRITER_OUTPUT;
+
+  let stdout = "";
+  let stderr = "";
+  while (entries.length > mark) {
+    const entry = entries[entries.length - 1];
+
+    // Read and drop while the entry is still registered: on the guarded
+    // /dev/fd mount only live descriptors may be removed.
+    let written = "";
+    if (entry.direction === "output") {
+      try {
+        written = latin1FromBytes(await readBytesFrom(ctx.fs, entry.path));
+      } catch {
+        // Backing file already gone - nothing was written.
+      }
+    }
+    await dropBackingFile(ctx, entry.path);
+    entries.pop();
+
+    // Run the writer only after the descriptor is gone, so a body that throws
+    // (an execution limit, say) cannot leave the entry or its file behind.
+    if (entry.direction === "output") {
+      const result = await runBody(ctx, entry.body, written);
+      stdout += latin1FromBytes(stdoutAsBytes(result));
+      stderr += result.stderr;
+    }
+  }
+  return { stdout, stderr };
+}

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -19,6 +19,7 @@ import type {
   FeatureCoverageWriter,
   TraceCallback,
 } from "../types.js";
+import type { ProcessSubstitutionEntry } from "./process-substitution.js";
 
 export type InterpreterExecOptions = Omit<CommandExecOptions, "cwd"> & {
   cwd?: string;
@@ -319,6 +320,17 @@ export interface IOState {
   fileDescriptors?: Map<number, string>;
   /** Next available file descriptor for {varname}>file allocation (starts at 10) */
   nextFd?: number;
+  /**
+   * Process substitutions (`<(cmd)` / `>(cmd)`) whose backing files are still
+   * live, oldest first. Used as a stack: each command execution releases the
+   * entries its own expansion pushed.
+   */
+  processSubstitutions?: ProcessSubstitutionEntry[];
+  /**
+   * True once `/dev/fd` has been routed to a private in-memory filesystem
+   * because the supplied one refused to back a descriptor (read-only sandbox).
+   */
+  processSubstitutionFsMounted?: boolean;
 }
 
 // ============================================================================

--- a/packages/just-bash/src/parser/expansion-parser.ts
+++ b/packages/just-bash/src/parser/expansion-parser.ts
@@ -997,6 +997,19 @@ export function parseWordParts(
       continue;
     }
 
+    // Handle process substitution: <(cmd) and >(cmd).
+    // The lexer only folds `<(` / `>(` into a word token when the paren is
+    // immediately adjacent, so reaching here means bash would treat it as a
+    // process substitution too (`< (cmd)` stays a redirection + syntax error).
+    // Heredoc bodies are literal, so they never contain one.
+    if ((char === "<" || char === ">") && value[i + 1] === "(" && !hereDoc) {
+      flushLiteral();
+      const { part, endIndex } = p.parseProcessSubstitution(value, i);
+      parts.push(part);
+      i = endIndex;
+      continue;
+    }
+
     // Handle tilde expansion
     if (char === "~") {
       const prevChar = i > 0 ? value[i - 1] : "";

--- a/packages/just-bash/src/parser/lexer.ts
+++ b/packages/just-bash/src/parser/lexer.ts
@@ -441,6 +441,20 @@ export class Lexer {
       this.registerHeredocFromLookahead(false);
       return this.makeToken(TokenType.DLESS, "<<", pos, startLine, startColumn);
     }
+    // Process substitution: `<(cmd)` / `>(cmd)`. The `(` must be immediately
+    // adjacent — `< (cmd)` stays an input redirection (and a syntax error in
+    // bash). This is a word-level construct, not a redirection operator, so
+    // read it as a word (which also folds in any adjacent prefix/suffix, e.g.
+    // `2>(cat)` is the single word `2` + the substitution). Inside `(( ))`,
+    // `>` is a comparison operator, so the rewrite is suppressed there.
+    if (
+      (c0 === "<" || c0 === ">") &&
+      c1 === "(" &&
+      this.dparenDepth === 0 &&
+      this.scanProcessSubstitution(pos) !== null
+    ) {
+      return this.readWord(pos, startLine, startColumn);
+    }
     // Special handling for (( and )) to track nested parentheses in arithmetic contexts
     // This is needed for C-style for loops: for (( n=0; n<(3-(1)); n++ ))
     if (c0 === "(" && c1 === "(") {
@@ -902,6 +916,13 @@ export class Lexer {
         // Extglob pattern - need slow path to handle it properly
         // Fall through to slow path below
       } else if (
+        (c === "<" || c === ">") &&
+        input[pos + 1] === "(" &&
+        this.dparenDepth === 0
+      ) {
+        // Process substitution glued to the word (`a<(cmd)`) - slow path
+        // concatenates it into the same word, matching bash.
+      } else if (
         // If we hit end or a simple delimiter, we can use the fast path result
         pos >= len ||
         c === " " ||
@@ -1081,6 +1102,29 @@ export class Lexer {
           pos++;
           col++;
           continue;
+        }
+
+        // Process substitution `<(cmd)` / `>(cmd)` is part of the word, so it
+        // must be consumed whole before `<`/`>` are treated as boundaries.
+        if (
+          (char === "<" || char === ">") &&
+          input[pos + 1] === "(" &&
+          this.dparenDepth === 0
+        ) {
+          const procSub = this.scanProcessSubstitution(pos);
+          if (procSub !== null) {
+            value += procSub.content;
+            for (let k = pos; k < procSub.end; k++) {
+              if (input[k] === "\n") {
+                ln++;
+                col = 0;
+              } else {
+                col++;
+              }
+            }
+            pos = procSub.end;
+            continue;
+          }
         }
 
         if (
@@ -2329,6 +2373,62 @@ export class Lexer {
     }
 
     return null;
+  }
+
+  /**
+   * Scan a process substitution `<(...)` / `>(...)` starting at the `<` or `>`.
+   *
+   * Tracks quoting and nesting so parens inside strings or nested
+   * substitutions do not close the construct early. Newlines are allowed
+   * (the body is an ordinary command list). Returns null when the parens are
+   * unbalanced, so the caller can fall back to plain redirection lexing and
+   * let the parser report the syntax error.
+   */
+  private scanProcessSubstitution(
+    startPos: number,
+  ): { content: string; end: number } | null {
+    const input = this.input;
+    const len = input.length;
+    let pos = startPos + 2; // Skip the `<(` / `>(`
+    let depth = 1;
+    let inSingleQuote = false;
+    let inDoubleQuote = false;
+
+    while (pos < len && depth > 0) {
+      const c = input[pos];
+
+      if (inSingleQuote) {
+        if (c === "'") inSingleQuote = false;
+        pos++;
+        continue;
+      }
+
+      if (c === "\\" && pos + 1 < len) {
+        pos += 2;
+        continue;
+      }
+
+      if (inDoubleQuote) {
+        if (c === '"') inDoubleQuote = false;
+        pos++;
+        continue;
+      }
+
+      if (c === "'") {
+        inSingleQuote = true;
+      } else if (c === '"') {
+        inDoubleQuote = true;
+      } else if (c === "(") {
+        depth++;
+      } else if (c === ")") {
+        depth--;
+      }
+      pos++;
+    }
+
+    if (depth !== 0) return null;
+
+    return { content: input.slice(startPos, pos), end: pos };
   }
 
   /**

--- a/packages/just-bash/src/parser/parser-substitution.ts
+++ b/packages/just-bash/src/parser/parser-substitution.ts
@@ -8,6 +8,7 @@
 import {
   AST,
   type CommandSubstitutionPart,
+  type ProcessSubstitutionPart,
   type ScriptNode,
 } from "../ast/types.js";
 
@@ -253,23 +254,23 @@ function skipHeredocBodies(
 }
 
 /**
- * Parse a command substitution starting at the given position.
- * Handles $(...) syntax with proper depth tracking for nested substitutions.
+ * Find the index of the `)` that closes a parenthesised substitution body.
+ *
+ * Shared by `$(...)` command substitution and `<(...)` / `>(...)` process
+ * substitution: both open with a two-character prefix followed by an ordinary
+ * command list, so the boundary scan (quote tracking, nested parens, heredoc
+ * bodies, `case` patterns) is identical.
  *
  * @param value The string containing the substitution
- * @param start Position of the `$` in `$(`
- * @param createParser Factory function to create a new parser instance
+ * @param cmdStart Index of the first character after the opening `X(`
  * @param error Error reporting function
- * @returns The parsed command substitution part and the ending index
+ * @returns Index of the closing `)` in `value`
  */
-export function parseCommandSubstitutionFromString(
+function findSubstitutionBodyEnd(
   value: string,
-  start: number,
-  createParser: ParserFactory,
+  cmdStart: number,
   error: ErrorFn,
-): { part: CommandSubstitutionPart; endIndex: number } {
-  // Skip $(
-  const cmdStart = start + 2;
+): number {
   let depth = 1;
   let i = cmdStart;
 
@@ -398,10 +399,33 @@ export function parseCommandSubstitutionFromString(
     if (depth > 0) i++;
   }
 
-  // Check for unclosed command substitution
+  // Check for unclosed substitution
   if (depth > 0) {
     error("unexpected EOF while looking for matching `)'");
   }
+
+  return i;
+}
+
+/**
+ * Parse a command substitution starting at the given position.
+ * Handles $(...) syntax with proper depth tracking for nested substitutions.
+ *
+ * @param value The string containing the substitution
+ * @param start Position of the `$` in `$(`
+ * @param createParser Factory function to create a new parser instance
+ * @param error Error reporting function
+ * @returns The parsed command substitution part and the ending index
+ */
+export function parseCommandSubstitutionFromString(
+  value: string,
+  start: number,
+  createParser: ParserFactory,
+  error: ErrorFn,
+): { part: CommandSubstitutionPart; endIndex: number } {
+  // Skip $(
+  const cmdStart = start + 2;
+  const i = findSubstitutionBodyEnd(value, cmdStart, error);
 
   const cmdStr = value.slice(cmdStart, i);
   // Use a new Parser instance to avoid overwriting the caller's parser's tokens
@@ -410,6 +434,38 @@ export function parseCommandSubstitutionFromString(
 
   return {
     part: AST.commandSubstitution(body, false),
+    endIndex: i + 1,
+  };
+}
+
+/**
+ * Parse a process substitution starting at the given position.
+ * Handles `<(...)` (input) and `>(...)` (output) syntax.
+ *
+ * @param value The string containing the substitution
+ * @param start Position of the `<` or `>` in `<(` / `>(`
+ * @param createParser Factory function to create a new parser instance
+ * @param error Error reporting function
+ * @returns The parsed process substitution part and the ending index
+ */
+export function parseProcessSubstitutionFromString(
+  value: string,
+  start: number,
+  createParser: ParserFactory,
+  error: ErrorFn,
+): { part: ProcessSubstitutionPart; endIndex: number } {
+  const direction = value[start] === "<" ? "input" : "output";
+  // Skip `<(` / `>(`
+  const cmdStart = start + 2;
+  const i = findSubstitutionBodyEnd(value, cmdStart, error);
+
+  const cmdStr = value.slice(cmdStart, i);
+  // Use a new Parser instance to avoid overwriting the caller's parser's tokens
+  const nestedParser = createParser();
+  const body = nestedParser.parse(cmdStr);
+
+  return {
+    part: AST.processSubstitution(body, direction),
     endIndex: i + 1,
   };
 }

--- a/packages/just-bash/src/parser/parser.ts
+++ b/packages/just-bash/src/parser/parser.ts
@@ -24,6 +24,7 @@ import {
   type ConditionalCommandNode,
   type FunctionDefNode,
   type PipelineNode,
+  type ProcessSubstitutionPart,
   type RedirectionNode,
   type ScriptNode,
   type StatementNode,
@@ -40,6 +41,7 @@ import {
   isDollarDparenSubshell as isDollarDparenSubshellHelper,
   parseBacktickSubstitutionFromString,
   parseCommandSubstitutionFromString,
+  parseProcessSubstitutionFromString,
 } from "./parser-substitution.js";
 import {
   MAX_INPUT_SIZE,
@@ -825,6 +827,18 @@ export class Parser {
     start: number,
   ): { part: CommandSubstitutionPart; endIndex: number } {
     return parseCommandSubstitutionFromString(
+      value,
+      start,
+      () => new Parser(this.parseBudget),
+      (msg) => this.error(msg),
+    );
+  }
+
+  parseProcessSubstitution(
+    value: string,
+    start: number,
+  ): { part: ProcessSubstitutionPart; endIndex: number } {
+    return parseProcessSubstitutionFromString(
       value,
       start,
       () => new Parser(this.parseBudget),

--- a/packages/just-bash/src/parser/process-substitution.test.ts
+++ b/packages/just-bash/src/parser/process-substitution.test.ts
@@ -1,0 +1,188 @@
+import { describe, expect, it } from "vitest";
+import type {
+  ProcessSubstitutionPart,
+  SimpleCommandNode,
+  WordPart,
+} from "../ast/types.js";
+import { serialize } from "../transform/serialize.js";
+import { Lexer, TokenType } from "./lexer.js";
+import { Parser } from "./parser.js";
+
+/** Parse a script and return the parts of the first command's args. */
+function argParts(script: string): WordPart[][] {
+  const ast = new Parser().parse(script);
+  const command = ast.statements[0].pipelines[0]
+    .commands[0] as SimpleCommandNode;
+  return command.args.map((arg) => arg.parts);
+}
+
+function firstArgPart(script: string): WordPart {
+  return argParts(script)[0][0];
+}
+
+function asProcSub(part: WordPart): ProcessSubstitutionPart {
+  expect(part.type).toBe("ProcessSubstitution");
+  return part as ProcessSubstitutionPart;
+}
+
+describe("process substitution - lexer", () => {
+  it("lexes <(cmd) as a single word token, not a redirection", () => {
+    const tokens = new Lexer("cat <(echo hi)").tokenize();
+    expect(tokens.map((t) => [t.type, t.value])).toEqual([
+      [TokenType.NAME, "cat"],
+      [TokenType.WORD, "<(echo hi)"],
+      [TokenType.EOF, ""],
+    ]);
+  });
+
+  it("lexes >(cmd) as a single word token", () => {
+    const tokens = new Lexer("tee >(cat)").tokenize();
+    expect(tokens.map((t) => [t.type, t.value])).toEqual([
+      [TokenType.NAME, "tee"],
+      [TokenType.WORD, ">(cat)"],
+      [TokenType.EOF, ""],
+    ]);
+  });
+
+  it("keeps `< (` as a redirection operator followed by a paren", () => {
+    const tokens = new Lexer("cat < (echo hi)").tokenize();
+    expect(tokens.map((t) => t.type)).toEqual([
+      TokenType.NAME,
+      TokenType.LESS,
+      TokenType.LPAREN,
+      TokenType.NAME,
+      TokenType.NAME,
+      TokenType.RPAREN,
+      TokenType.EOF,
+    ]);
+  });
+
+  it("keeps `<<` here-documents and `<<<` here-strings intact", () => {
+    expect(new Lexer("cat <<<(x)").tokenize()[1].type).toBe(TokenType.TLESS);
+    expect(new Lexer("cat <<EOF\n(x)\nEOF\n").tokenize()[1].type).toBe(
+      TokenType.DLESS,
+    );
+  });
+
+  it("glues a process substitution onto an adjacent word", () => {
+    const tokens = new Lexer("echo a<(echo hi)").tokenize();
+    expect(tokens.map((t) => [t.type, t.value])).toEqual([
+      [TokenType.NAME, "echo"],
+      [TokenType.WORD, "a<(echo hi)"],
+      [TokenType.EOF, ""],
+    ]);
+  });
+
+  it("does not treat a leading digit as a file descriptor", () => {
+    const tokens = new Lexer("echo 2>(cat)").tokenize();
+    expect(tokens.map((t) => [t.type, t.value])).toEqual([
+      [TokenType.NAME, "echo"],
+      [TokenType.WORD, "2>(cat)"],
+      [TokenType.EOF, ""],
+    ]);
+  });
+
+  it("leaves `>` alone inside arithmetic contexts", () => {
+    const tokens = new Lexer("(( 3 > (1) ))").tokenize();
+    expect(tokens.map((t) => t.type)).toEqual([
+      TokenType.DPAREN_START,
+      TokenType.NUMBER,
+      TokenType.GREAT,
+      TokenType.LPAREN,
+      TokenType.NUMBER,
+      TokenType.RPAREN,
+      TokenType.DPAREN_END,
+      TokenType.EOF,
+    ]);
+  });
+
+  it("falls back to a redirection when the parens are unbalanced", () => {
+    const tokens = new Lexer("cat <(echo hi").tokenize();
+    expect(tokens[1].type).toBe(TokenType.LESS);
+  });
+
+  it("tracks parens through quotes and nesting", () => {
+    expect(new Lexer("cat <(echo 'a)b')").tokenize()[1].value).toBe(
+      "<(echo 'a)b')",
+    );
+    expect(new Lexer('cat <(echo ")")').tokenize()[1].value).toBe(
+      'cat <(echo ")")'.slice(4),
+    );
+    expect(new Lexer("cat <(cat <(echo x))").tokenize()[1].value).toBe(
+      "<(cat <(echo x))",
+    );
+  });
+});
+
+describe("process substitution - parser", () => {
+  it("builds an input ProcessSubstitution part", () => {
+    const part = asProcSub(firstArgPart("cat <(echo hi)"));
+    expect(part.direction).toBe("input");
+    expect(serialize(part.body)).toBe("echo hi");
+  });
+
+  it("builds an output ProcessSubstitution part", () => {
+    const part = asProcSub(firstArgPart("tee >(wc -l)"));
+    expect(part.direction).toBe("output");
+    expect(serialize(part.body)).toBe("wc -l");
+  });
+
+  it("parses several substitutions in one command", () => {
+    const parts = argParts("diff <(sort a) <(sort b)");
+    expect(parts).toHaveLength(2);
+    expect(serialize(asProcSub(parts[0][0]).body)).toBe("sort a");
+    expect(serialize(asProcSub(parts[1][0]).body)).toBe("sort b");
+  });
+
+  it("parses a multi-command body", () => {
+    const part = asProcSub(firstArgPart("cat <(echo a; echo b)"));
+    expect(serialize(part.body)).toBe("echo a\necho b");
+  });
+
+  it("parses a nested process substitution", () => {
+    const outer = asProcSub(firstArgPart("cat <(cat <(echo deep))"));
+    expect(serialize(outer.body)).toBe("cat <(echo deep)");
+  });
+
+  it("concatenates a literal prefix with the substitution", () => {
+    const parts = argParts("echo a<(echo hi)")[0];
+    expect(parts).toHaveLength(2);
+    expect(parts[0]).toEqual({ type: "Literal", value: "a" });
+    expect(asProcSub(parts[1]).direction).toBe("input");
+  });
+
+  it("keeps quoted text literal", () => {
+    expect(argParts('echo "<(echo hi)"')[0]).toEqual([
+      {
+        type: "DoubleQuoted",
+        parts: [{ type: "Literal", value: "<(echo hi)" }],
+      },
+    ]);
+    expect(argParts("echo '<(echo hi)'")[0]).toEqual([
+      { type: "SingleQuoted", value: "<(echo hi)" },
+    ]);
+  });
+
+  it("parses a substitution used as a redirection source", () => {
+    const ast = new Parser().parse("cat < <(echo hi)");
+    const command = ast.statements[0].pipelines[0]
+      .commands[0] as SimpleCommandNode;
+    expect(command.redirections).toHaveLength(1);
+    expect(command.redirections[0].operator).toBe("<");
+    const target = command.redirections[0].target;
+    expect(target.type).toBe("Word");
+    if (target.type !== "Word") throw new Error("expected a word target");
+    expect(asProcSub(target.parts[0]).direction).toBe("input");
+  });
+
+  it("round-trips through the serializer", () => {
+    const script = "cat <(echo hi) >(cat)";
+    expect(serialize(new Parser().parse(script))).toBe(script);
+  });
+
+  it("reports a parse error for an unterminated substitution", () => {
+    expect(() => new Parser().parse("cat <(echo hi")).toThrow(
+      "Expected redirection target",
+    );
+  });
+});

--- a/packages/just-bash/src/spec-tests/bash/KNOWN_LIMITATIONS.md
+++ b/packages/just-bash/src/spec-tests/bash/KNOWN_LIMITATIONS.md
@@ -384,7 +384,6 @@ The following test files are entirely skipped in `spec.test.ts`:
 - `builtin-trap-bash.test.sh`
 - `builtin-trap-err.test.sh`
 - `builtin-times.test.sh`
-- `process-sub.test.sh`
 
 ### Shell Features Not Implemented
 - `alias.test.sh` - alias expansion

--- a/packages/just-bash/src/spec-tests/bash/spec.test.ts
+++ b/packages/just-bash/src/spec-tests/bash/spec.test.ts
@@ -37,7 +37,7 @@ const SKIP_FILES = new Set([
   "builtin-trap-bash.test.sh",
   "builtin-trap-err.test.sh",
   "builtin-times.test.sh",
-  "process-sub.test.sh",
+  // "process-sub.test.sh", // Unskipped - all 9 cases pass with <(…) / >(…) support
 
   // Shell-specific features not implemented
   // "builtin-dirs.test.sh", // Unskipped - tests added with SKIP markers


### PR DESCRIPTION
## Summary

Process substitution — `<(cmd)` and `>(cmd)` — was not parsed at all. Every use
died at the lexer: `<` was read as an input redirection, and the parser then hit
`(` where a filename belonged.

```
$ cat <(echo hi)
bash: syntax error: Parse error at 1:5: Expected redirection target
```

That takes out the whole `diff`/`comm`/`join`/`paste`/`tee` family of one-liners
agents reach for when a tool only accepts file arguments, forcing a temp-file
dance instead.

Both directions now work. `cat <(echo hi)` prints `hi`; `comm -12 <(sort -u x)
<(sort -u y)`, `while read l; do …; done < <(cmd)`, `printf … | tee >(wc -l)`
and multiple substitutions per command all behave like bash.
`diff <(sort a) <(sort b)` feeds both substitutions correctly and its **exit
status** matches bash; the report text itself still differs because this
repo's `diff` uses its own output format, which is unchanged by this PR and
already diverges on `main`.

Closes #320

## Details

### Parser

`<(` / `>(` is a **word-level** construct, not a redirection operator followed by
a paren, so the fix lives in the lexer's word reader rather than in the
redirection rule.

- `Lexer.nextToken` routes `<(` / `>(` to `readWord` when the `(` is
  *immediately* adjacent. `< (cmd)` keeps its old meaning (redirection + syntax
  error, same as bash). `<<`, `<<-` and `<<<` are matched earlier and unaffected.
- The rewrite is suppressed while `dparenDepth > 0`, so `(( 3 > (1) ))` and
  `for (( i=0; i<(2); i++ ))` still lex `>`/`<` as comparison operators.
- `readWord` consumes the substitution into the *current* word in both its fast
  and slow paths, so it concatenates like bash: `echo a<(true)` → `a/dev/fd/63`,
  and `echo 2>(cat)` → `2/dev/fd/63` (the leading digit is **not** an fd).
- `Lexer.scanProcessSubstitution` finds the closing paren with quote and nesting
  tracking. When the parens are unbalanced it returns `null` and lexing falls
  back to a plain `<` redirection, so `cat <(echo hi` is still a parse error
  rather than an infinite loop.
- `parseWordParts` turns the folded text into a `ProcessSubstitution` part. The
  AST node already existed (`ast/types.ts`) and the serializer and
  command-collector already handled it — only the producer was missing.
- `parseCommandSubstitutionFromString`'s boundary scanner (quotes, nested
  parens, heredoc bodies, `case` patterns) was extracted as
  `findSubstitutionBodyEnd` and is now shared with the new
  `parseProcessSubstitutionFromString`. `$(…)` behaviour is unchanged.

### Interpreter

There are no processes or pipes here, so a substitution is modelled with the
primitive the interpreter already uses for fds: a backing file in the VFS under
`/dev/fd/` (`fs/init.ts` now creates the directory alongside `/dev/null` and
friends). Everything that reads a path — `cat`, `sort`, `comm`, `diff`,
`[ -r … ]`, `wc -c`, `< file` redirects — then works with no per-command
plumbing.

- `<(cmd)` runs the body during word expansion, writes its stdout to
  `/dev/fd/N` and substitutes that path.
- `>(cmd)` substitutes an empty writable path; when the outer command finishes,
  whatever it wrote is fed to the body as stdin and the body's stdout/stderr are
  appended to the result.
- Descriptors count down from 63 (`63`, `62`, `61`, …) exactly like bash, and
  `Interpreter.executeCommand` brackets every command with
  `markProcessSubstitutions` / `releaseProcessSubstitutions`. Numbers are
  therefore reused per command and no backing file survives the command that
  opened it — including when the command throws.
- `expandRedirectTarget` expands a redirect target twice — once for the value,
  once to build a glob pattern. It now skips the second pass only when the word
  contains a `ProcessSubstitution` part (a narrower condition than the existing
  `hasQuoted` / `noglob` skips beside it, and one that cannot change any other
  word's globbing). Without it, `echo hi > >(cat)` expanded the word twice and
  opened two descriptors.

Bash edge cases matched (verified against real bash, see Tests):

| case | behaviour |
|---|---|
| `cat <(false); echo $?` | `0` — a failing body never becomes `$?`, and `set -e` does not trip |
| `grep -q zzz <(echo hi); echo $?` | `1` — the outer command's own status is kept |
| `cat <(echo a; exit 3)` | `a` — `exit` ends only the body; earlier output still reaches the pipe |
| `x=1; cat <(x=2; echo $x)` | body is a subshell: variable, array and cwd changes are discarded |
| `cat <(echo oops >&2)` | body stderr goes to the shell's stderr at expansion time, unaffected by the outer command's redirections |
| `cat <(printf abc)` | exact bytes, no trailing-newline stripping (unlike `$(…)`) |
| `echo '<(echo hi)' "<(echo hi)"` | literal inside quotes |
| `cat <(cat <(echo deep))` | nests |

### Limits

`<(…)` fully buffers its body, so it follows the same limit discipline as
command substitution: output is checked against `maxStringLength`
(`process substitution: string length limit exceeded`), nesting against
`maxSubstitutionDepth`, and a non-terminating body (`cat <(while true; do …; done)`)
is stopped by `maxCommandCount` rather than hanging. At most 54 descriptors
(63 down to 10) can be live at once.

### Read-only filesystems

`OverlayFs({ readOnly: true })` — the `just-bash` CLI's default — rejects every
write with `EROFS`. Real bash runs process substitution fine on a read-only
mount because it is a pipe, not a file write, and **both** directions need a
write to land somewhere: `<(cmd)` to materialise the body's output, and
`>(cmd)` for the *outer* command (a `>` redirect, `tee`, any command handed the
path) to write into it.

Rather than special-case each writer, the first refused backing-file write
mounts a private filesystem at `/dev/fd` via the existing `MountableFs`,
wrapping — never mutating — the filesystem the caller supplied. Everything
outside `/dev/fd` still goes to that filesystem and stays read-only; the mount
lives for one execution and never reaches the host. Because the mount is
genuinely writable, descriptors are `rm`ed on release, so read-only mode leaves
no stale `/dev/fd/N` entries either, and `ls /dev` still shows the rest of the
device files.

The mount is **not** a general scratch directory. A plain `InMemoryFs` there
would let a script do `echo data > /dev/fd/anything` after any substitution —
nothing would reach the host, but it is a policy widening the script can
observe. `ProcessSubstitutionFs` subclasses `InMemoryFs` and gates the mutating
methods on the interpreter's live-descriptor set: only backing paths that are
allocated *right now* accept `writeFile`/`appendFile`/`rm`, directory-shaped
mutations are refused outright, and everything else raises the same `EROFS` the
base filesystem would have. A read-only sandbox therefore behaves identically
whether or not a substitution ran first. Writable filesystems never get the
mount at all, so their `/dev/fd` is unchanged from `main`.

```
$ node ./dist/cli/just-bash.js -c 'cat <(echo hi)' --root . --json
{"stdout":"hi\n","stderr":"","exitCode":0}
$ node ./dist/cli/just-bash.js -c 'echo hi > >(tr a-z A-Z)' --root . --json
{"stdout":"HI\n","stderr":"","exitCode":0}
$ node ./dist/cli/just-bash.js -c 'printf "a\nb\n" | tee >(grep -c b)' --root . --json
{"stdout":"a\nb\n1\n","stderr":"","exitCode":0}
$ node ./dist/cli/just-bash.js -c 'echo test > /tmp/nope.txt' --root . --json
{"stdout":"","stderr":"EROFS: read-only file system, write '<path>'","exitCode":1}
$ node ./dist/cli/just-bash.js -c 'cat <(true); echo data > /dev/fd/99' --root . --json
{"stdout":"","stderr":"EROFS: read-only file system, write '/dev/fd/99'","exitCode":1}
```

### Known behaviour differences

- **`>(…)` ordering is deterministic here, asynchronous in bash.** bash forks
  the writer, so `echo hi > >(cat); echo rc=$?` can print `hi` before or after
  `rc=0`. This implementation drains the writer when the outer command
  completes, which always yields `hi` then `rc=0`. Comparison tests avoid
  ordering-sensitive cases.
- **`[ -f <(cmd) ]` is true here, false in bash**, where `/dev/fd/N` is a pipe.
  `-r` matches. Modelling the backing store as a regular file is what makes
  every path-reading command work unchanged.
- **A stale descriptor reports `No such file or directory`**, where bash says
  `Bad file descriptor` (bash keeps the `/dev/fd` entry after closing the fd).
  Both fail with status 1.
- **A `>(cmd)` body does not inherit redirections that precede it on the same
  command.** bash processes redirections left to right and spawns the writer
  with the earlier ones already in effect; this implementation drains the
  writer after the command completes and merges its output into the command's
  result, so earlier redirections no longer apply to it. Verified against
  `/bin/bash 3.2.57`:

  | script | bash | just-bash |
  |---|---|---|
  | `echo hi > o > >(echo writer)` | `o` contains `writer` | `writer` goes to the shell's stdout; `o` is empty |
  | `echo hi 2> e > >(echo err >&2)` | `e` contains `err` | `err` goes to the shell's stderr; `e` is empty |

  Both require a `>(…)` in a **redirection target** that is preceded by another
  redirection on the same command. The common shapes are unaffected, because a
  substitution in an *argument* is set up during word expansion — before any
  redirection is applied — in bash too: `printf … | tee >(grep -c b) > /dev/null`
  prints the count in both shells (it is a recorded comparison fixture), and
  `echo hi > >(cat) 2> e` writes `hi` to stdout with `e` empty in both. Fixing
  this properly means routing the drained writer through the redirect state as
  of the substitution's position in the redirection list, which would thread a
  redirection index through `applyRedirections` and the generic command
  wrapper — too broad for this PR, and this area is what #286 hardened.
- **Descriptors live longer here, so some scripts succeed that bash rejects.**
  Descriptors are released when the command that opened them completes, which
  for a compound command means the whole construct. bash closes each writer as
  soon as it is reaped, so
  `for f in <(echo a) <(echo b); do cat $f; done` prints `a` then
  `cat: /dev/fd/62: Bad file descriptor` (status 1) in bash, but prints `a` and
  `b` (status 0) here. Same family as the stale-descriptor difference above:
  this implementation is more permissive, never less.

## Tests

Added, all collocated and asserting full stdout/stderr strings:

| file | tests |
|---|---|
| `packages/just-bash/src/parser/process-substitution.test.ts` | 19 — token shapes for `<(`/`>(`, `< (`, `<<`/`<<<`, glued words, `2>(`, `(( ))` suppression, unbalanced fallback, quote/nesting scanning; AST direction/body, multiple + nested substitutions, redirection targets, quoting, serializer round-trip, parse error |
| `packages/just-bash/src/interpreter/process-substitution.test.ts` | 29 — `<(…)` execution, fd numbering, `comm`/`diff`/redirect/`while read`/pipeline idioms, nesting, byte fidelity, exit-status rules, subshell isolation, cleanup, limits |
| `packages/just-bash/src/interpreter/process-substitution.output.test.ts` | 11 — `>(…)` writers, `tee` idiom, several writers, mixed `<(…)`/`>(…)`, empty input, status/stderr rules, cleanup, limits |
| `packages/just-bash/src/interpreter/process-substitution.readonly.test.ts` | 16 — `<(…)` and `>(…)` on `OverlayFs({ readOnly: true })`, the CLI's default mode: both writer paths (`>` redirect and `tee` argument), `comm`/`diff`/`while read`, no stale descriptors, `/dev` still intact, underlying files still readable, ordinary writes still refused; plus 6 asserting `/dev/fd` is not scratch space (write/append/mkdir to an unallocated descriptor all `EROFS`, identical behaviour with and without a preceding substitution, writable mode unchanged) |
| `packages/just-bash/src/comparison-tests/process-substitution.comparison.test.ts` | 31 — recorded against real bash |

Fixtures: `packages/just-bash/src/comparison-tests/fixtures/process-substitution.comparison.fixtures.json`,
recorded with `RECORD_FIXTURES=1` against **GNU bash 3.2.57(1)-release
(arm64-apple-darwin25)**, the system `/bin/bash` on macOS. 10 of the 31 entries
are marked `"locked": true` because their recorded output depends on the host
bash rather than on the feature: anything printing a `/dev/fd/N` number, every
`>(…)` case (bash's writer flushes asynchronously), and the `cat < (echo hi)`
syntax-error wording. The rest are portable and re-recordable.

`src/spec-tests/bash/cases/process-sub.test.sh` was **unskipped** — all 9 of its
cases now pass (3 passed / 6 failed on `upstream/main`). It has been removed from
the skip list in `spec.test.ts` and from the Process/Job Control section of
`KNOWN_LIMITATIONS.md`.

### Verification

Run from `packages/just-bash` unless noted:

| command | result |
|---|---|
| `pnpm typecheck` | clean |
| `pnpm lint` (repo root) | clean — workflows, biome (1043 files), banned patterns |
| `pnpm lint:banned` | ✓ No banned patterns detected |
| `pnpm knip` | clean (2 pre-existing configuration hints only) |
| `pnpm test:comparison` | **598 passed / 598** (36 files) |
| `pnpm test:run src/spec-tests` | **3834 passed, 1 skipped** (was 3825 before unskipping `process-sub.test.sh`) |
| `pnpm test:unit` | **13889 passed, 97 skipped, 6 failed (13992)** |
| `pnpm test:run --exclude src/spec-tests` | 10552 passed, 96 skipped, 6 failed |
| new test files only | **59 passed / 59** |

The 6 unit failures are pre-existing and unrelated: they are the CPython/WASM
and worker tests in `src/cli/just-bash.bundle.test.ts`,
`src/security/attacks/code-exec-exploit-regression.test.ts`,
`src/security/attacks/defense-in-depth-independence.test.ts`,
`src/security/sandbox/python-sqlite-information-disclosure.test.ts` and
`src/security/sandbox/worker-protocol-runtime-desync.test.ts`. The identical 6
failures were measured on a clean `upstream/main` checkout in this worktree
(`git stash` + same command), caused by unmaterialized git-LFS blobs locally.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
