### PR TITLE
feat(grep): support -f/--file to read patterns from file

### DIFF
--- a/.changeset/witty-moons-shave.md
+++ b/.changeset/witty-moons-shave.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add `grep -f FILE` / `--file=FILE` to read patterns from a file (one per line). Patterns from `-f` OR-combine with `-e` patterns and with each other, `-f -` reads patterns from stdin, empty pattern lines match every line, and an empty pattern file selects nothing (exit 1). Newline-separated `PATTERNS` operands are now split into individual patterns, and `-x` groups alternatives correctly (`^(?:a|b)$`).

--- a/packages/just-bash/src/commands/grep/grep.patterns-from-file-combos.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.patterns-from-file-combos.test.ts
@@ -1,0 +1,221 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * `grep -f FILE` composed with the other selection flags. The `-F -x -f` and
+ * `-v -f` combinations are the set-intersection / set-difference idioms called
+ * out in issue #322. Expectations verified against GNU grep 3.12.
+ */
+const setFiles = {
+  "/list.txt": "apple\nbanana\ncherry\n",
+  "/keep.txt": "banana\ndate\napple\n",
+};
+
+const searchFiles = {
+  "/pat.txt": "apple\nbanana\n",
+  "/p1.txt": "apple\n",
+  "/hay.txt": "apple pie\ncherry\nbanana split\n",
+  "/hay2.txt": "x\ny\n",
+};
+
+describe("grep -f set operations", () => {
+  it("intersects two line sets with -F -x -f", async () => {
+    const env = new Bash({ files: setFiles });
+    const result = await env.exec("grep -F -x -f /keep.txt /list.txt");
+    expect(result.stdout).toBe("apple\nbanana\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("subtracts one line set from another with -F -x -v -f", async () => {
+    const env = new Bash({ files: setFiles });
+    const result = await env.exec("grep -F -x -v -f /keep.txt /list.txt");
+    expect(result.stdout).toBe("cherry\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("counts the intersection with -F -x -c -f", async () => {
+    const env = new Bash({ files: setFiles });
+    const result = await env.exec("grep -F -x -c -f /keep.txt /list.txt");
+    expect(result.stdout).toBe("2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("anchors every alternative with -x, not just the first", async () => {
+    const env = new Bash({
+      files: {
+        "/pat.txt": "foo\nbar\n",
+        "/data.txt": "foo\nbar\nfoobar\nfoo suffix\nprefix bar\n",
+      },
+    });
+    const result = await env.exec("grep -x -f /pat.txt /data.txt");
+    expect(result.stdout).toBe("foo\nbar\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("inverts the union of all file patterns with -v", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -v -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("cherry\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -f with matching modifiers", () => {
+  it("applies -i to every pattern", async () => {
+    const env = new Bash({
+      files: { "/p1.txt": "apple\n", "/caps.txt": "APPLE PIE\nApple\nnope\n" },
+    });
+    const result = await env.exec("grep -i -f /p1.txt /caps.txt");
+    expect(result.stdout).toBe("APPLE PIE\nApple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("applies -w to every pattern", async () => {
+    const env = new Bash({
+      files: {
+        "/p1.txt": "apple\n",
+        "/words.txt": "apple\npineapple\napple pie\n",
+      },
+    });
+    const result = await env.exec("grep -w -f /p1.txt /words.txt");
+    expect(result.stdout).toBe("apple\napple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps every -F pattern literal", async () => {
+    const env = new Bash({
+      files: {
+        "/meta.txt": "a.b\nx*y\n",
+        "/metahay.txt": "a.b\naxb\nx*y\nxy\n",
+      },
+    });
+    const result = await env.exec("grep -F -f /meta.txt /metahay.txt");
+    expect(result.stdout).toBe("a.b\nx*y\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("treats every pattern as a BRE by default", async () => {
+    const env = new Bash({
+      files: {
+        "/meta.txt": "a.b\nx*y\n",
+        "/metahay.txt": "a.b\naxb\nx*y\nxy\n",
+      },
+    });
+    const result = await env.exec("grep -f /meta.txt /metahay.txt");
+    expect(result.stdout).toBe("a.b\naxb\nx*y\nxy\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("supports BRE alternation inside a single file pattern", async () => {
+    const env = new Bash({
+      files: { ...setFiles, "/bre.txt": "apple\\|cherry\n" },
+    });
+    const result = await env.exec("grep -f /bre.txt /list.txt");
+    expect(result.stdout).toBe("apple\ncherry\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("treats every pattern as an ERE with -E", async () => {
+    const env = new Bash({
+      files: { ...setFiles, "/ere.txt": "^a.+e$\nch.rry\n" },
+    });
+    const result = await env.exec("grep -E -f /ere.txt /list.txt");
+    expect(result.stdout).toBe("apple\ncherry\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -f with output modifiers", () => {
+  it("prints only the matched text with -o", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -o -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple\nbanana\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("counts matching lines with -c", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -c -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("lists only matching file names with -l", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -l -f /pat.txt /hay.txt /hay2.txt");
+    expect(result.stdout).toBe("/hay.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("prefixes file names when several files are searched", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -f /p1.txt /hay.txt /hay2.txt");
+    expect(result.stdout).toBe("/hay.txt:apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("suppresses the file name prefix with -h", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -h -f /p1.txt /hay.txt /hay2.txt");
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("stops after -m matches", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -m1 -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("prints trailing context with -A", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -A1 -f /p1.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("searches recursively with -r", async () => {
+    const env = new Bash({
+      files: { "/p1.txt": "apple\n", "/sub/f1.txt": "apple tree\nnope\n" },
+    });
+    const result = await env.exec("grep -r -f /p1.txt /sub");
+    expect(result.stdout).toBe("/sub/f1.txt:apple tree\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("stays quiet with -q", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -q -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports no match with -q and exit 1", async () => {
+    const env = new Bash({ files: searchFiles });
+    const result = await env.exec("grep -q -f /p1.txt /hay2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.patterns-from-file-validation.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.patterns-from-file-validation.test.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Multi-pattern validation for `grep -f`. Alternatives are concatenated
+ * textually, so a malformed pattern must be rejected rather than allowed to
+ * absorb its neighbour. Expectations verified against GNU grep 3.12 (which
+ * reports its own wording, e.g. "Trailing backslash"; just-bash keeps its
+ * existing `invalid regular expression` phrasing).
+ */
+describe("grep -f invalid patterns", () => {
+  const hay = { "/hay.txt": "apple pie\ncherry\nbanana split\n" };
+
+  it("rejects a trailing backslash instead of swallowing the next pattern", async () => {
+    const env = new Bash({
+      files: { ...hay, "/bad.txt": "a\\\nbanana\n" },
+    });
+    const result = await env.exec("grep -f /bad.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: invalid regular expression: a\\\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("rejects a trailing backslash under -v too", async () => {
+    const env = new Bash({
+      files: { ...hay, "/bad.txt": "a\\\nbanana\n" },
+    });
+    const result = await env.exec("grep -v -f /bad.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: invalid regular expression: a\\\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("rejects an unmatched bracket expression", async () => {
+    const env = new Bash({
+      files: { ...hay, "/bad.txt": "[a\nb]c\n" },
+    });
+    const result = await env.exec("grep -f /bad.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: invalid regular expression: [a\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("rejects an unmatched group with -E", async () => {
+    const env = new Bash({
+      files: { ...hay, "/bad.txt": "(a\nb)c\n" },
+    });
+    const result = await env.exec("grep -E -f /bad.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: invalid regular expression: (a\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("accepts a backslash in -F patterns, which are literal", async () => {
+    const env = new Bash({
+      files: { ...hay, "/bad.txt": "a\\\nbanana\n" },
+    });
+    const result = await env.exec("grep -F -f /bad.txt /hay.txt");
+    expect(result.stdout).toBe("banana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -P with multiple patterns", () => {
+  const files = {
+    "/hay.txt": "apple pie\ncherry\nbanana split\n",
+    "/two.txt": "apple\nbanana\n",
+    "/one.txt": "apple\n",
+  };
+
+  it("refuses more than one pattern from a file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -P -f /two.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: the -P option only supports a single pattern\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("refuses a -e pattern combined with a -f pattern", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -P -e cherry -f /one.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: the -P option only supports a single pattern\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("refuses a newline-separated PATTERNS operand", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -P \"$(printf 'a\\nb')\" /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: the -P option only supports a single pattern\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("folds duplicate patterns before counting", async () => {
+    const env = new Bash({ files: { ...files, "/dup.txt": "apple\napple\n" } });
+    const result = await env.exec("grep -P -f /dup.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts a single pattern from a file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -P -f /one.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts a single empty pattern from a file", async () => {
+    const env = new Bash({ files: { ...files, "/blank.txt": "\n" } });
+    const result = await env.exec("grep -P -f /blank.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("short-circuits an empty pattern file before the -P check", async () => {
+    const env = new Bash({ files: { ...files, "/empty.txt": "" } });
+    const result = await env.exec("grep -P -f /empty.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("grep -f argument handling", () => {
+  const hay = { "/hay.txt": "apple pie\n" };
+
+  it("reports an empty -f value as an empty file name", async () => {
+    const env = new Bash({ files: hay });
+    const result = await env.exec("grep -f '' /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: : No such file or directory\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reports an empty --file= value as an empty file name", async () => {
+    const env = new Bash({ files: hay });
+    const result = await env.exec("grep --file= /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: : No such file or directory\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("uses the long-option wording when --file has no argument", async () => {
+    const env = new Bash({ files: hay });
+    const result = await env.exec("grep --file");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: option '--file' requires an argument\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("uses the short-option wording when -f has no argument", async () => {
+    const env = new Bash({ files: hay });
+    const result = await env.exec("grep -f");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: option requires an argument -- 'f'\n");
+    expect(result.exitCode).toBe(2);
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.patterns-from-file.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.patterns-from-file.test.ts
@@ -1,0 +1,272 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * `grep -f FILE` / `--file=FILE` — patterns read from a file, one per line.
+ * Expectations verified against GNU grep 3.12.
+ */
+describe("grep -f (patterns from file)", () => {
+  const files = {
+    "/pat.txt": "apple\nbanana\n",
+    "/hay.txt": "apple pie\ncherry\nbanana split\n",
+  };
+
+  it("reads newline-separated patterns from a file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("matches the exact repro from issue #322", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      [
+        "printf 'apple\\nbanana\\n' > /tmp/pat.txt",
+        "printf 'apple pie\\ncherry\\nbanana split\\n' > /tmp/hay.txt",
+        "grep -f /tmp/pat.txt /tmp/hay.txt",
+      ].join("; "),
+    );
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts --file=FILE", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep --file=/pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts --file FILE as two arguments", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep --file /pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts the value attached to the flag (-fFILE)", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f/pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts -f bundled with other short flags", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -nf /pat.txt /hay.txt");
+    expect(result.stdout).toBe("1:apple pie\n3:banana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("unions -f patterns with -e patterns", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /pat.txt -e cherry /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("unions -f patterns with -e patterns regardless of order", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -e cherry -f /pat.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("unions patterns across repeated -f flags", async () => {
+    const env = new Bash({
+      files: {
+        ...files,
+        "/p1.txt": "apple\n",
+        "/p2.txt": "banana\n",
+      },
+    });
+    const result = await env.exec("grep -f /p1.txt -f /p2.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("treats a missing trailing newline as a pattern terminator", async () => {
+    const env = new Bash({
+      files: { ...files, "/notrail.txt": "apple\nbanana" },
+    });
+    const result = await env.exec("grep -f /notrail.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reads patterns from stdin with -f -", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("printf 'app\\nban\\n' | grep -f - /hay.txt");
+    expect(result.stdout).toBe("apple pie\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("lets only the first of repeated -f - read stdin", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple\\n' | grep -f - -f - /hay.txt",
+    );
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps repeated -f - to a single pattern under -P", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple\\n' | grep -P -f - -f - /hay.txt",
+    );
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("leaves no stdin to search when -f - consumed it", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -f -");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
+describe("grep -f empty patterns", () => {
+  const files = {
+    "/hay.txt": "apple pie\ncherry\nbanana split\n",
+    "/empty.txt": "",
+    "/blank.txt": "\n",
+    "/mixed.txt": "foo\n\nbar\n",
+  };
+
+  it("matches every line when the pattern file is a single blank line", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /blank.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("matches every line when a blank line is mixed with real patterns", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /mixed.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("anchors the empty pattern with -x so only blank lines match", async () => {
+    const env = new Bash({
+      files: { ...files, "/withblank.txt": "a\n\nb\n" },
+    });
+    const result = await env.exec("grep -F -x -f /blank.txt /withblank.txt");
+    expect(result.stdout).toBe("\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("matches nothing when the pattern file is empty", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /empty.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("matches nothing for grep -f /dev/null", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /dev/null /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("suppresses the -c count entirely for an empty pattern file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -c -f /empty.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("does not even open input files for an empty pattern file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /empty.txt /nonexistent.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("selects every line with -v and an empty pattern file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -v -f /empty.txt /hay.txt");
+    expect(result.stdout).toBe("apple pie\ncherry\nbanana split\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("counts every line with -c -v and an empty pattern file", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -c -v -f /empty.txt /hay.txt");
+    expect(result.stdout).toBe("3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still finds a match when an empty pattern file is combined with -e", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("grep -f /empty.txt -e apple /hay.txt");
+    expect(result.stdout).toBe("apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -f errors", () => {
+  it("reports a missing pattern file and exits 2", async () => {
+    const env = new Bash({ files: { "/hay.txt": "apple pie\n" } });
+    const result = await env.exec("grep -f /missing.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: /missing.txt: No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reports the failing file when only one of several -f is missing", async () => {
+    const env = new Bash({
+      files: { "/hay.txt": "apple pie\n", "/pat.txt": "apple\n" },
+    });
+    const result = await env.exec("grep -f /pat.txt -f /nope.txt /hay.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: /nope.txt: No such file or directory\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reports a directory pattern file and exits 2", async () => {
+    const env = new Bash({ files: { "/dir/keep.txt": "x\n" } });
+    const result = await env.exec("grep -f /dir /dir/keep.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: /dir: Is a directory\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("reports a missing -f argument and exits 2", async () => {
+    const env = new Bash({ files: { "/hay.txt": "apple pie\n" } });
+    const result = await env.exec("grep -f");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("grep: option requires an argument -- 'f'\n");
+    expect(result.exitCode).toBe(2);
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -9,7 +9,11 @@ import type {
 } from "../../types.js";
 import { matchGlob } from "../../utils/glob.js";
 import { showHelp, unknownOption } from "../help.js";
-import { buildRegex, searchContent } from "../search-engine/index.js";
+import {
+  buildRegex,
+  type RegexMode,
+  searchContent,
+} from "../search-engine/index.js";
 
 /** File entry with optional type info from glob expansion */
 interface FileEntry {
@@ -49,6 +53,71 @@ function addTraversalResult(budget: GrepTraversalBudget): void {
   budget.results++;
 }
 
+/**
+ * A regex that can never match anything, used when the pattern list is empty
+ * (e.g. `grep -f /dev/null`). `[^\s\S]` is the empty character class: no
+ * codepoint is both non-whitespace and non-non-whitespace. Wrapping it for
+ * -w (`\b(?:...)\b`) or -x (`^(?:...)$`) keeps it unmatchable.
+ */
+const NEVER_MATCHES = "[^\\s\\S]";
+
+/**
+ * Split a `-e`/positional PATTERNS operand into individual patterns.
+ *
+ * GNU grep documents PATTERNS as "one or more patterns separated by newline
+ * characters", so a trailing newline yields a trailing empty pattern (which
+ * matches every line). Verified against GNU grep 3.12:
+ *   grep -e $'cherry\n' FILE   # prints every line
+ */
+function splitPatternOperand(value: string): string[] {
+  return value.split("\n");
+}
+
+/**
+ * Split the contents of a `-f FILE` pattern file into individual patterns.
+ *
+ * Unlike `-e`, the final newline of a pattern file is a terminator rather than
+ * a separator, so it does not produce a trailing empty pattern. An empty file
+ * contributes no patterns at all. Interior empty lines are kept: an empty
+ * pattern matches every line. Verified against GNU grep 3.12.
+ */
+function splitPatternFile(content: string): string[] {
+  if (content === "") return [];
+  const lines = content.split("\n");
+  if (lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+/**
+ * OR-combine several patterns into one regex source.
+ *
+ * A single pattern is returned untouched so the common case keeps its original
+ * mode (and the literal pre-filter fast path). Multiple fixed strings are
+ * escaped and lifted into an extended regex, since POSIX BRE/ERE have no way to
+ * express "any of these literals" without escaping first.
+ */
+function combinePatterns(
+  patterns: string[],
+  mode: RegexMode,
+): { pattern: string; mode: RegexMode } {
+  if (patterns.length === 1) {
+    return { pattern: patterns[0], mode };
+  }
+  if (mode === "fixed") {
+    return {
+      pattern: patterns
+        .map((p) => `(?:${p.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")})`)
+        .join("|"),
+      mode: "extended",
+    };
+  }
+  if (mode === "basic") {
+    // BRE spells alternation `\|`; escapeRegexForBasicGrep turns it into `|`.
+    return { pattern: patterns.join("\\|"), mode };
+  }
+  return { pattern: patterns.map((p) => `(?:${p})`).join("|"), mode };
+}
+
 const grepHelp = {
   name: "grep",
   summary: "print lines that match patterns",
@@ -74,6 +143,7 @@ const grepHelp = {
     "-B NUM                   print NUM lines of leading context",
     "-C NUM                   print NUM lines of context",
     "-e PATTERN               use PATTERN for matching",
+    "-f FILE, --file=FILE     obtain patterns from FILE, one per line",
     "    --include=GLOB       search only files matching GLOB",
     "    --exclude=GLOB       skip files matching GLOB",
     "    --exclude-dir=DIR    skip directories matching DIR",
@@ -110,7 +180,9 @@ export const grepCommand: RuntimeCommand = {
     const excludePatterns: string[] = [];
     const excludeDirPatterns: string[] = [];
     let pattern: string | null = null;
-    const files: string[] = [];
+    /** Paths given to -f/--file, in argument order. "-" means stdin. */
+    const patternFiles: string[] = [];
+    const operands: string[] = [];
     let parseOptions = true;
 
     // Parse arguments
@@ -129,6 +201,12 @@ export const grepCommand: RuntimeCommand = {
       if (parseOptions && arg.startsWith("-") && arg !== "-") {
         if (arg === "-e" && i + 1 < args.length) {
           pattern = args[++i];
+          continue;
+        }
+
+        // Handle --file=FILE (can be specified multiple times)
+        if (arg.startsWith("--file=")) {
+          patternFiles.push(arg.slice("--file=".length));
           continue;
         }
 
@@ -197,7 +275,28 @@ export const grepCommand: RuntimeCommand = {
 
         const flags = arg.startsWith("--") ? [arg] : arg.slice(1).split("");
 
-        for (const flag of flags) {
+        for (let f = 0; f < flags.length; f++) {
+          const flag = flags[f];
+          if (flag === "f" || flag === "--file") {
+            // `-fFILE` and `-vxfFILE` attach the value to the same argument;
+            // `-f FILE`, `-vxf FILE` and `--file FILE` take the next one.
+            const attached = flag === "f" ? flags.slice(f + 1).join("") : "";
+            if (attached.length > 0) {
+              patternFiles.push(attached);
+            } else if (i + 1 < args.length) {
+              patternFiles.push(args[++i]);
+            } else {
+              return {
+                stdout: "",
+                stderr:
+                  flag === "f"
+                    ? "grep: option requires an argument -- 'f'\n"
+                    : "grep: option '--file' requires an argument\n",
+                exitCode: 2,
+              };
+            }
+            break;
+          }
           if (flag === "i" || flag === "--ignore-case") ignoreCase = true;
           else if (flag === "n" || flag === "--line-number")
             showLineNumbers = true;
@@ -228,36 +327,135 @@ export const grepCommand: RuntimeCommand = {
             return unknownOption("grep", `-${flag}`);
           }
         }
-      } else if (pattern === null) {
-        pattern = arg;
       } else {
-        files.push(arg);
+        operands.push(arg);
       }
     }
 
-    if (pattern === null) {
-      return {
-        stdout: "",
-        stderr: "grep: missing pattern\n",
-        exitCode: 2,
-      };
+    // The first operand is the pattern only when no -e/-f pattern was given.
+    if (pattern === null && patternFiles.length === 0) {
+      pattern = operands.shift() ?? null;
+      if (pattern === null) {
+        return {
+          stdout: "",
+          stderr: "grep: missing pattern\n",
+          exitCode: 2,
+        };
+      }
+    }
+    const files = operands;
+
+    // Collect patterns: -e/positional first, then each -f file in order.
+    // All of them OR-combine, exactly like GNU grep.
+    const patterns: string[] =
+      pattern === null ? [] : splitPatternOperand(pattern);
+    /** True once `-f -` has drained stdin, so it can't also be searched. */
+    let stdinUsedForPatterns = false;
+    for (const patternFile of patternFiles) {
+      let content: string;
+      if (patternFile === "") {
+        // `-f ""` / `--file=` never names a file; GNU reports the empty name
+        // rather than resolving it relative to the working directory.
+        return {
+          stdout: "",
+          stderr: "grep: : No such file or directory\n",
+          exitCode: 2,
+        };
+      }
+      if (patternFile === "-") {
+        // stdin is a stream: the first `-f -` drains it, any later one reads
+        // EOF and contributes nothing.
+        content = stdinUsedForPatterns ? "" : decodeBytesToUtf8(ctx.stdin);
+        stdinUsedForPatterns = true;
+      } else {
+        try {
+          const path = ctx.fs.resolvePath(ctx.cwd, patternFile);
+          const stat = await ctx.fs.stat(path);
+          if (stat.isDirectory) {
+            return {
+              stdout: "",
+              stderr: `grep: ${patternFile}: Is a directory\n`,
+              exitCode: 2,
+            };
+          }
+          content = await ctx.fs.readFile(path);
+        } catch (error) {
+          rethrowFatalExecutionError(error);
+          return {
+            stdout: "",
+            stderr: `grep: ${patternFile}: No such file or directory\n`,
+            exitCode: 2,
+          };
+        }
+      }
+      const filePatterns = splitPatternFile(content);
+      if (patterns.length + filePatterns.length > ctx.limits.maxArrayElements) {
+        throw new ExecutionLimitError(
+          `grep: array element limit exceeded (${ctx.limits.maxArrayElements})`,
+          "array_elements",
+        );
+      }
+      patterns.push(...filePatterns);
+    }
+
+    // An empty pattern list (e.g. `grep -f /dev/null`) selects no lines at all.
+    // GNU grep short-circuits: no output, no per-file counts, no "no such file"
+    // diagnostics, exit 1. With -v every line is selected instead, and -L still
+    // has to visit the files, so both keep the normal path with a regex that
+    // can never match.
+    if (patterns.length === 0 && !invertMatch && !filesWithoutMatch) {
+      return { stdout: "", stderr: "", exitCode: 1 };
     }
 
     // Build regex using shared search-engine
-    const regexMode = fixedStrings
+    const regexMode: RegexMode = fixedStrings
       ? "fixed"
       : extendedRegex
         ? "extended"
         : perlRegex
           ? "perl"
           : "basic";
+    // GNU's PCRE backend cannot express an alternation of independent
+    // patterns, so it refuses more than one under -P. Duplicates are folded
+    // first, matching GNU: `-P -e apple -e apple` is accepted.
+    if (regexMode === "perl" && new Set(patterns).size > 1) {
+      return {
+        stdout: "",
+        stderr: "grep: the -P option only supports a single pattern\n",
+        exitCode: 2,
+      };
+    }
+
+    // Alternatives are concatenated textually, so a malformed pattern could
+    // otherwise swallow the separator and silently absorb its neighbour
+    // (`a\` + `banana` becoming the literal `a|banana`). Compile each pattern
+    // on its own first so a syntax error is reported instead. Fixed strings
+    // are escaped before joining and can never be malformed.
+    if (patterns.length > 1 && regexMode !== "fixed") {
+      for (const p of patterns) {
+        try {
+          buildRegex(p, { mode: regexMode });
+        } catch {
+          return {
+            stdout: "",
+            stderr: `grep: invalid regular expression: ${p}\n`,
+            exitCode: 2,
+          };
+        }
+      }
+    }
+
+    const combined =
+      patterns.length === 0
+        ? { pattern: NEVER_MATCHES, mode: "extended" as RegexMode }
+        : combinePatterns(patterns, regexMode);
 
     let regex: UserRegex;
     let kResetGroup: number | undefined;
     let preFilter: import("../search-engine/regex.js").PreFilter | undefined;
     try {
-      const regexResult = buildRegex(pattern, {
-        mode: regexMode,
+      const regexResult = buildRegex(combined.pattern, {
+        mode: combined.mode,
         ignoreCase,
         wholeWord,
         lineRegexp,
@@ -268,7 +466,7 @@ export const grepCommand: RuntimeCommand = {
     } catch {
       return {
         stdout: "",
-        stderr: `grep: invalid regular expression: ${pattern}\n`,
+        stderr: `grep: invalid regular expression: ${patterns.join("\n")}\n`,
         exitCode: 2,
       };
     }
@@ -277,7 +475,8 @@ export const grepCommand: RuntimeCommand = {
     // stdin. grep runs regex over text — decode bytes to UTF-8 so multibyte
     // codepoints match `.` / character classes correctly.
     if (files.length === 0 && ctx.stdin !== undefined) {
-      const result = searchContent(decodeBytesToUtf8(ctx.stdin), regex, {
+      const input = stdinUsedForPatterns ? "" : decodeBytesToUtf8(ctx.stdin);
+      const result = searchContent(input, regex, {
         invertMatch,
         showLineNumbers,
         countOnly,
@@ -870,6 +1069,7 @@ export const flagsForFuzzing: CommandFuzzInfo = {
     { flag: "-B", type: "value", valueHint: "number" },
     { flag: "-C", type: "value", valueHint: "number" },
     { flag: "-e", type: "value", valueHint: "pattern" },
+    { flag: "-f", type: "value", valueHint: "path" },
   ],
   stdinType: "text",
   needsArgs: true,

--- a/packages/just-bash/src/commands/search-engine/regex.ts
+++ b/packages/just-bash/src/commands/search-engine/regex.ts
@@ -216,7 +216,10 @@ export function buildRegex(
     regexPattern = `\\b(?:${regexPattern})\\b`;
   }
   if (options.lineRegexp) {
-    regexPattern = `^${regexPattern}$`;
+    // Wrap in a non-capturing group so alternation binds inside the anchors:
+    // a|b must become ^(?:a|b)$, not ^a|b$ (which anchors only the outer
+    // alternatives). Matters for multi-pattern grep (-e/-f) with -x.
+    regexPattern = `^(?:${regexPattern})$`;
   }
 
   // Build flags:

--- a/packages/just-bash/src/comparison-tests/fixtures/grep-patterns-from-file.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/grep-patterns-from-file.comparison.fixtures.json
@@ -1,0 +1,298 @@
+{
+  "02ab7b8a04b9d1cc": {
+    "command": "grep -f pat.txt -e cherry hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "apple pie\ncherry\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "083a6b8c5a151939": {
+    "command": "grep -f meta.txt metahay.txt",
+    "files": {
+      "meta.txt": "a.b\nx*y\n",
+      "metahay.txt": "a.b\naxb\nx*y\nxy\n"
+    },
+    "stdout": "a.b\naxb\nx*y\nxy\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "1af9140fefba5844": {
+    "command": "grep -r -f p1.txt sub",
+    "files": {
+      "p1.txt": "apple\n",
+      "sub/f1.txt": "apple tree\nnope\n"
+    },
+    "stdout": "sub/f1.txt:apple tree\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "30333687b2079d2f": {
+    "command": "grep -F -f meta.txt metahay.txt",
+    "files": {
+      "meta.txt": "a.b\nx*y\n",
+      "metahay.txt": "a.b\naxb\nx*y\nxy\n"
+    },
+    "stdout": "a.b\nx*y\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "31c875d8a7151e99": {
+    "command": "grep -o -f pat.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "apple\nbanana\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "3735a32e68779137": {
+    "command": "grep -f notrail.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "notrail.txt": "apple\nbanana"
+    },
+    "stdout": "apple pie\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "387fabc29d0f152d": {
+    "command": "grep -F -x -c -f keep.txt list.txt",
+    "files": {
+      "list.txt": "apple\nbanana\ncherry\n",
+      "keep.txt": "banana\ndate\napple\n"
+    },
+    "stdout": "2\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "4ba957bc991cf9b4": {
+    "command": "grep -f sub hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "sub/f1.txt": "x\n"
+    },
+    "stdout": "",
+    "stderr": "grep: sub: Is a directory\n",
+    "exitCode": 2,
+    "locked": true
+  },
+  "716efe6511b3bf4a": {
+    "command": "grep -c -f empty.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "81de23591d36efdc": {
+    "command": "grep -i -f p1.txt caps.txt",
+    "files": {
+      "p1.txt": "apple\n",
+      "caps.txt": "APPLE PIE\nApple\nnope\n"
+    },
+    "stdout": "APPLE PIE\nApple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "90056beab043627f": {
+    "command": "grep -v -f empty.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "empty.txt": ""
+    },
+    "stdout": "apple pie\ncherry\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "90f3bff5ab88721e": {
+    "command": "grep --file=pat.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "apple pie\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "9e04005fae32344c": {
+    "command": "grep -f mixed.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "mixed.txt": "foo\n\nbar\n"
+    },
+    "stdout": "apple pie\ncherry\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b372b1c75e1a8b15": {
+    "command": "grep -F -x -v -f keep.txt list.txt",
+    "files": {
+      "list.txt": "apple\nbanana\ncherry\n",
+      "keep.txt": "banana\ndate\napple\n"
+    },
+    "stdout": "cherry\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b9f787fdd0d38b43": {
+    "command": "grep -n -f pat.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "1:apple pie\n3:banana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c18843025d4e14f8": {
+    "command": "grep -f blank.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "blank.txt": "\n"
+    },
+    "stdout": "apple pie\ncherry\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c1ec7e1966c89bff": {
+    "command": "grep -f p1.txt -f p2.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "p1.txt": "apple\n",
+      "p2.txt": "banana\n"
+    },
+    "stdout": "apple pie\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d30a75ceaa8276f2": {
+    "command": "grep -f /dev/null hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "d8448ec6e4604615": {
+    "command": "grep -f missing.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "",
+    "stderr": "grep: missing.txt: No such file or directory\n",
+    "exitCode": 2,
+    "locked": true
+  },
+  "e1ec2a2e0083b764": {
+    "command": "grep -E -f ere.txt list.txt",
+    "files": {
+      "list.txt": "apple\nbanana\ncherry\n",
+      "keep.txt": "banana\ndate\napple\n",
+      "ere.txt": "^a.+e$\nch.rry\n"
+    },
+    "stdout": "apple\ncherry\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "eaf9b761b9e7820f": {
+    "command": "grep -f pat.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "apple pie\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f0c6b6610cd45ef7": {
+    "command": "grep -f empty.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "f55c6321fc7176ab": {
+    "command": "grep -F -x -f keep.txt list.txt",
+    "files": {
+      "list.txt": "apple\nbanana\ncherry\n",
+      "keep.txt": "banana\ndate\napple\n"
+    },
+    "stdout": "apple\nbanana\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f69efafbc45e0b0b": {
+    "command": "printf 'app\\nban\\n' | grep -f - hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "apple pie\nbanana split\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f88dd7befbf52987": {
+    "command": "grep -v -f pat.txt hay.txt",
+    "files": {
+      "pat.txt": "apple\nbanana\n",
+      "hay.txt": "apple pie\ncherry\nbanana split\n"
+    },
+    "stdout": "cherry\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "fde4d326ea986149": {
+    "command": "grep -w -f p1.txt words.txt",
+    "files": {
+      "p1.txt": "apple\n",
+      "words.txt": "apple\npineapple\napple pie\n"
+    },
+    "stdout": "apple\napple pie\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/grep-patterns-from-file.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/grep-patterns-from-file.comparison.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * `grep -f FILE` comparison tests.
+ *
+ * Fixtures are recorded against GNU grep 3.12, not the BSD grep that ships with
+ * macOS, and are therefore locked. To re-record:
+ *
+ *   PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
+ *     RECORD_FIXTURES=force pnpm test:run \
+ *     src/comparison-tests/grep-patterns-from-file.comparison.test.ts
+ */
+describe("grep -f - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const patternFiles = {
+    "pat.txt": "apple\nbanana\n",
+    "hay.txt": "apple pie\ncherry\nbanana split\n",
+  };
+
+  const setFiles = {
+    "list.txt": "apple\nbanana\ncherry\n",
+    "keep.txt": "banana\ndate\napple\n",
+  };
+
+  describe("reading patterns", () => {
+    it("should read patterns from a file", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -f pat.txt hay.txt");
+    });
+
+    it("should accept --file=FILE", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep --file=pat.txt hay.txt");
+    });
+
+    it("should union -f patterns with -e patterns", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -f pat.txt -e cherry hay.txt");
+    });
+
+    it("should union patterns across repeated -f", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "p1.txt": "apple\n",
+        "p2.txt": "banana\n",
+      });
+      await compareOutputs(env, testDir, "grep -f p1.txt -f p2.txt hay.txt");
+    });
+
+    it("should handle a pattern file without a trailing newline", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "notrail.txt": "apple\nbanana",
+      });
+      await compareOutputs(env, testDir, "grep -f notrail.txt hay.txt");
+    });
+
+    it("should read patterns from stdin with -f -", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'app\\nban\\n' | grep -f - hay.txt",
+      );
+    });
+  });
+
+  describe("empty patterns", () => {
+    it("should match every line for a blank pattern line", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "blank.txt": "\n",
+      });
+      await compareOutputs(env, testDir, "grep -f blank.txt hay.txt");
+    });
+
+    it("should match every line when a blank line is mixed in", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "mixed.txt": "foo\n\nbar\n",
+      });
+      await compareOutputs(env, testDir, "grep -f mixed.txt hay.txt");
+    });
+
+    it("should match nothing for an empty pattern file", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "empty.txt": "",
+      });
+      await compareOutputs(env, testDir, "grep -f empty.txt hay.txt");
+    });
+
+    it("should match nothing for grep -f /dev/null", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -f /dev/null hay.txt");
+    });
+
+    it("should print no count for an empty pattern file", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "empty.txt": "",
+      });
+      await compareOutputs(env, testDir, "grep -c -f empty.txt hay.txt");
+    });
+
+    it("should select every line with -v and an empty pattern file", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "empty.txt": "",
+      });
+      await compareOutputs(env, testDir, "grep -v -f empty.txt hay.txt");
+    });
+  });
+
+  describe("set operations", () => {
+    it("should intersect line sets with -F -x -f", async () => {
+      const env = await setupFiles(testDir, setFiles);
+      await compareOutputs(env, testDir, "grep -F -x -f keep.txt list.txt");
+    });
+
+    it("should subtract line sets with -F -x -v -f", async () => {
+      const env = await setupFiles(testDir, setFiles);
+      await compareOutputs(env, testDir, "grep -F -x -v -f keep.txt list.txt");
+    });
+
+    it("should count the intersection with -F -x -c -f", async () => {
+      const env = await setupFiles(testDir, setFiles);
+      await compareOutputs(env, testDir, "grep -F -x -c -f keep.txt list.txt");
+    });
+
+    it("should invert the union with -v -f", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -v -f pat.txt hay.txt");
+    });
+  });
+
+  describe("modifiers", () => {
+    it("should apply -i to file patterns", async () => {
+      const env = await setupFiles(testDir, {
+        "p1.txt": "apple\n",
+        "caps.txt": "APPLE PIE\nApple\nnope\n",
+      });
+      await compareOutputs(env, testDir, "grep -i -f p1.txt caps.txt");
+    });
+
+    it("should apply -w to file patterns", async () => {
+      const env = await setupFiles(testDir, {
+        "p1.txt": "apple\n",
+        "words.txt": "apple\npineapple\napple pie\n",
+      });
+      await compareOutputs(env, testDir, "grep -w -f p1.txt words.txt");
+    });
+
+    it("should keep -F patterns literal", async () => {
+      const env = await setupFiles(testDir, {
+        "meta.txt": "a.b\nx*y\n",
+        "metahay.txt": "a.b\naxb\nx*y\nxy\n",
+      });
+      await compareOutputs(env, testDir, "grep -F -f meta.txt metahay.txt");
+    });
+
+    it("should treat file patterns as BREs by default", async () => {
+      const env = await setupFiles(testDir, {
+        "meta.txt": "a.b\nx*y\n",
+        "metahay.txt": "a.b\naxb\nx*y\nxy\n",
+      });
+      await compareOutputs(env, testDir, "grep -f meta.txt metahay.txt");
+    });
+
+    it("should treat file patterns as EREs with -E", async () => {
+      const env = await setupFiles(testDir, {
+        ...setFiles,
+        "ere.txt": "^a.+e$\nch.rry\n",
+      });
+      await compareOutputs(env, testDir, "grep -E -f ere.txt list.txt");
+    });
+
+    it("should print line numbers with -n", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -n -f pat.txt hay.txt");
+    });
+
+    it("should print only matches with -o", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -o -f pat.txt hay.txt");
+    });
+
+    it("should search recursively with -r", async () => {
+      const env = await setupFiles(testDir, {
+        "p1.txt": "apple\n",
+        "sub/f1.txt": "apple tree\nnope\n",
+      });
+      await compareOutputs(env, testDir, "grep -r -f p1.txt sub");
+    });
+  });
+
+  describe("errors", () => {
+    it("should report a missing pattern file", async () => {
+      const env = await setupFiles(testDir, patternFiles);
+      await compareOutputs(env, testDir, "grep -f missing.txt hay.txt");
+    });
+
+    it("should report a directory pattern file", async () => {
+      const env = await setupFiles(testDir, {
+        ...patternFiles,
+        "sub/f1.txt": "x\n",
+      });
+      await compareOutputs(env, testDir, "grep -f sub hay.txt");
+    });
+  });
+});

--- a/packages/just-bash/src/spec-tests/grep/skips.ts
+++ b/packages/just-bash/src/spec-tests/grep/skips.ts
@@ -148,12 +148,6 @@ const SKIP_TESTS: Map<string, string> = new Map<string, string>([
     "multiple -e patterns not supported",
   ],
 
-  // -f option (read patterns from file)
-  [
-    "busybox-grep.tests:grep can read regexps from stdin",
-    "-f option not supported",
-  ],
-
   // -L option (print files without matches)
   ["busybox-grep.tests:grep -L exitcode 0", "-L option not implemented"],
 
@@ -161,20 +155,6 @@ const SKIP_TESTS: Map<string, string> = new Map<string, string>([
   [
     "busybox-grep.tests:grep -o does not loop forever",
     "-o option not implemented",
-  ],
-
-  // -v with -f on empty file
-  ["busybox-grep.tests:grep -v -f EMPTY_FILE", "-f option not supported"],
-  ["busybox-grep.tests:grep -vxf EMPTY_FILE", "-f option not supported"],
-
-  // Newline-delimited patterns via command substitution
-  [
-    "busybox-grep.tests:grep PATTERN can be a newline-delimited list",
-    "newline-delimited patterns not supported",
-  ],
-  [
-    "busybox-grep.tests:grep -e PATTERN can be a newline-delimited list",
-    "newline-delimited patterns not supported",
   ],
 
   // Recursive grep with symlinks (requires mkdir/symlink setup)


### PR DESCRIPTION
## Summary

Adds GNU-compatible `grep -f FILE` / `--file=FILE` — patterns read from a file, one per line — so `grep -F -x -f`, `grep -v -f` and friends work as set operations over lines.

Closes #322.

This **builds on #184** by @ericjypark, which is still open and still applies cleanly to `main` — the problem is correctness, not staleness. Behaviours where #184 diverges from GNU grep 3.12:

1. **`-x` produces wrong results.** #184 joins the alternatives into `(?:a)|(?:b)` and hands that to `buildRegex`, whose `lineRegexp` wrapper produced `^(?:a)|(?:b)$` — "starts with a" OR "ends with b", not "the whole line is a or b". `-F -x -f` is the primary use case in #322, so this matters.
2. **`-fFILE` and `-vxfFILE` read the wrong file.** The cluster loop's `f` case always takes `args[++i]`, so `grep -fpat.txt hay.txt` reads patterns from `hay.txt` and is then left with no input file. (`-f FILE` and `-vxf FILE` do work.)
3. **Only one `-f` is kept** (`patternFile` is a single slot, so `-f a -f b` silently drops `a`), and `-f` does not combine with `-e` — whichever is written last wins.
4. **Empty pattern files are wrong in both directions.** #184 returns `exit 1` immediately whenever the file is empty, so `grep -v -f EMPTY` prints nothing where GNU prints every line, and `grep -c -f EMPTY` is only accidentally right.
5. **A malformed pattern can absorb its neighbour.** Joining alternatives textually means a pattern file of `a\` + `banana` compiles as the single literal `a|banana` instead of erroring; under `-v` that turns a blocklist into a pass-everything filter.
6. **`-f -`** (patterns from stdin) is unsupported, and would double-read stdin if it were.
7. **`-P` accepts multiple patterns**, which GNU refuses outright.

### What changed vs #184

- **Fixed `-x`**: `buildRegex` now wraps as `^(?:PATTERN)$`, mirroring what the `-w` wrapper already does. Split into its own commit.
- **All `-f` spellings**: `-f FILE`, `-fFILE`, `-vxf FILE`, `-vxfFILE`, `--file=FILE`, `--file FILE`, and `-f -`.
- **Repeated `-f` unions**, and unions with `-e` in either order.
- **Empty pattern list handled like GNU** rather than as an early error (details below).
- **Each pattern is compiled standalone before joining** (basic/extended only — `-F` patterns are escaped and can never be malformed), so a syntax error is reported instead of silently swallowing the next pattern.
- **`-P` with more than one distinct pattern is refused**: `grep: the -P option only supports a single pattern`, exit 2.
- **`-f -` models stream consumption**: only the first `-f -` reads stdin; a repeated `-f -` sees EOF and contributes nothing, so `printf 'a\n' | grep -P -f - -f - FILE` stays a single-pattern search instead of duplicating it.
- **Pattern-file errors are GNU's**: `grep: FILE: No such file or directory` / `Is a directory`, exit 2, raised before any input file is searched — #184 has no directory case and always reports "No such file or directory".
- BRE alternatives are joined with `\|` instead of being lifted to ERE, so a BRE pattern file stays a BRE (#184's `-f` silently switched the whole pattern to extended regex, changing what `+`, `?`, `{n}` and `(` mean).
- **Non-option operands are files when `-f` is present** — `grep -f pat.txt hay.txt` must not treat `hay.txt` as the pattern.
- Pattern count from files is bounded by `maxArrayElements`, per the repo's runaway-compute rule.
- Tests rewritten and expanded (see below); every expectation re-derived from GNU grep 3.12 rather than assumed.

Credit to @ericjypark for the original implementation and tests (#184). The `-e`/`-i`/`--file=`/blank-line/empty-file test scenarios there are all preserved here, with the expected values corrected where they diverged from GNU.

## Details

**GNU edge cases matched** (each verified against GNU grep 3.12, `ggrep` from Homebrew):

| case | GNU behaviour |
| --- | --- |
| blank line in pattern file | empty pattern, matches every line |
| blank line + `-x` | anchors to `^$`, matches only blank lines |
| trailing newline in pattern file | terminator, does **not** add an empty pattern |
| trailing newline in a `-e` operand | separator, **does** add an empty pattern |
| empty pattern file / `-f /dev/null` | selects nothing, exit 1 |
| `-c -f EMPTY` | prints **nothing** (not `0`), exit 1 |
| `-f EMPTY missing_file` | no diagnostic at all, exit 1 — GNU never opens the inputs |
| `-v -f EMPTY` | selects every line, exit 0 |
| `-c -v -f EMPTY` | per-file counts as usual |
| missing pattern file | `grep: FILE: No such file or directory`, exit 2 |
| directory pattern file | `grep: FILE: Is a directory`, exit 2 |
| `-f a -f missing` | reports only `missing`, exit 2, nothing searched |
| `-f` with no argument | `grep: option requires an argument -- 'f'`, exit 2 |
| `--file` with no argument | `grep: option '--file' requires an argument`, exit 2 |
| `-f ""` / `--file=` | `grep: : No such file or directory`, exit 2 (never resolved against the cwd) |
| `-f -` | patterns from stdin; stdin is then drained, so `printf x \| grep -f -` exits 1 |
| repeated `-f -` | only the first reads stdin; later ones hit EOF and add no patterns |
| malformed pattern among several | rejected, exit 2 — never joined into the alternation |
| `-P` with more than one *distinct* pattern | `grep: the -P option only supports a single pattern`, exit 2 (duplicates are folded first, so `-P -f dup.pat` is accepted) |

The empty-pattern-list short-circuit is the subtle one: GNU exits 1 without visiting the inputs when the list is empty and `-v` is absent, but `-v` and `-L` still need the normal path. Implemented as an early return for the former and an unmatchable regex (`[^\s\S]`) for the latter, so `-x`/`-w` wrapping keeps it unmatchable.

**Malformed patterns.** Alternatives are concatenated textually, so a pattern that is invalid on its own can otherwise swallow the separator and merge with its neighbour — `a\` + `banana` becoming the literal `a|banana`, `[a` + `b]c` matching `ac`. Each pattern is therefore compiled standalone first (skipped for `-F`, whose patterns are escaped) and a failure is reported as `grep: invalid regular expression: PATTERN`, exit 2. GNU words these differently (`grep: FILE:1: Trailing backslash`); this keeps just-bash's existing phrasing. Residual gap: `a\{1` still compiles here, because incomplete BRE braces are treated as literals — a pre-existing engine difference already recorded in the grep spec-test skip patterns, so `a\{1` + `banana` matches where GNU errors.

**Composition with `-e` / relationship to #314.** GNU treats `PATTERNS` (positional, `-e`, or `-f`) as a newline-separated list, and unions everything. This PR builds that union and adds a `combinePatterns()` helper that OR-combines while preserving each mode's semantics (`\|` for BRE, `(?:...)|(?:...)` for ERE, escape-then-lift for `-F`). It deliberately **does not** change `-e`'s "last one wins" behaviour — that is #297, owned by #314.

The two PRs are complementary in intent but **do overlap in code**: #314 adds a near-identical `combinePatterns()` at the same insertion point, makes the same `^(?:...)$` anchor fix, and edits the same spec-test skip list. `git merge-tree` reports conflicts in all three files (`grep.ts`, `search-engine/regex.ts`, `spec-tests/grep/skips.ts`) — roughly 70% of the non-test diff is shared. Whichever lands second should rebase; the resolution is mechanical (keep one `combinePatterns`, keep one anchor fix, take the union of the skip-list removals) since the two implementations agree on semantics.

Newline-separated `PATTERNS` operands are split here as well, because `-f` is defined in terms of that same rule and the common `grep -F "$(cat file)"` workaround depends on it.

**Spec tests unskipped** (5, all now passing):

- `grep can read regexps from stdin` (`-f -`)
- `grep -v -f EMPTY_FILE`
- `grep -vxf EMPTY_FILE`
- `grep PATTERN can be a newline-delimited list`
- `grep -e PATTERN can be a newline-delimited list`

## Tests

New files:

- `packages/just-bash/src/commands/grep/grep.patterns-from-file.test.ts` — 28 tests: reading forms, `-f`+`-e` union, repeated `-f`, no trailing newline, `-f -`, stdin drain, repeated `-f -` (plain and under `-P`), blank/mixed/empty pattern files, `-f /dev/null`, `-c`/`-v` on an empty list, the four error cases, and the exact repro from #322.
- `packages/just-bash/src/commands/grep/grep.patterns-from-file-combos.test.ts` — 21 tests: `-F -x -f`, `-F -x -v -f`, `-F -x -c -f`, `-x` alternative anchoring, `-v -f`, `-i`, `-w`, `-F` literals, BRE/ERE modes, `-o`, `-c`, `-l`, `-h`, `-m`, `-A`, `-r`, `-q`.
- `packages/just-bash/src/commands/grep/grep.patterns-from-file-validation.test.ts` — 16 tests: malformed patterns (trailing backslash, unmatched `[`, unmatched `(` under `-E`, and the same backslash accepted under `-F`), the `-P` single-pattern restriction and what it still allows (single pattern, single empty pattern, duplicates, empty file), and the four argument-shape cases (`-f ""`, `--file=`, `--file` and `-f` with no argument).
- `packages/just-bash/src/comparison-tests/grep-patterns-from-file.comparison.test.ts` + `fixtures/grep-patterns-from-file.comparison.fixtures.json` — 26 fixtures.

All assertions are full-string `stdout`/`stderr` plus exit code.

**Fixture recording.** macOS ships BSD grep 2.6.0-FreeBSD, so the fixtures were recorded against **GNU grep 3.12** (Homebrew `grep` formula) by putting its `gnubin` first on `PATH`, and every entry is marked `"locked": true` so a re-record on a BSD box can't silently replace GNU behaviour with BSD behaviour. The re-record command is documented at the top of the test file:

```
PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
  RECORD_FIXTURES=force pnpm test:run \
  src/comparison-tests/grep-patterns-from-file.comparison.test.ts
```

**Verification results:**

- `pnpm typecheck` — clean
- `pnpm lint:fix` — clean (no fixes applied)
- `pnpm lint:banned` — clean
- `pnpm knip` — clean (only the two pre-existing configuration hints)
- `pnpm test:comparison` — 593 passed, 36 files (26 of them new)
- `pnpm test:run src/commands/grep src/commands/rg src/commands/search-engine src/spec-tests/grep` — 1195 passed, 90 skipped, 35 files
- `pnpm test:run` (full) — 14378 passed, 97 skipped; the 6 failures are pre-existing on `main` in this environment (python3/CPython-WASM and bundled-binary tests that need `pnpm build` and the vendored WASM), confirmed by re-running them on a clean tree

**Known gap (pre-existing, not touched here):** `grep -L`'s exit code is inverted relative to GNU — GNU exits 1 when `-L` prints names and 0 when it prints none, since the status reflects whether a line was selected. `-L` is already listed as unimplemented in the spec-test skips, so no `-L` assertion is included.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
