### PR TITLE
fix(interpreter): pipelines no longer drain the shared stdin to EOF

### DIFF
--- a/.changeset/olive-pumas-listen.md
+++ b/.changeset/olive-pumas-listen.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Stop pipelines from draining the enclosing shell's stdin, so `while read …; do … | …; done < file` runs once per line again.

--- a/packages/just-bash/src/comparison-tests/fixtures/pipeline-stdin.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/pipeline-stdin.comparison.fixtures.json
@@ -1,0 +1,269 @@
+{
+  "067bfd45d4b8689f": {
+    "command": "{ echo piped | read v; echo \"v=[$v]\"; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\n"
+    },
+    "stdout": "v=[]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "0bdbc43af02c15df": {
+    "command": "n=0; while read a; do n=$((n+1)); echo a | cat | cat >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1f0bd0d9d6f88e08": {
+    "command": "{ echo start | cat >/dev/null; while read l; do echo \"L:$l\"; done; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\n"
+    },
+    "stdout": "L:L1\nL:L2\nL:L3\nL:L4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "247b15d3ec600ec1": {
+    "command": "n=0; while read a; do n=$((n+1)); echo x | echo y >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "252eac5ac03b4310": {
+    "command": "{ echo A | cat; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "A\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3367cedd2220bae9": {
+    "command": "n=0; while read a; do n=$((n+1)); (echo x | cat) >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "357b2448ab3a26ea": {
+    "command": "{ read a; false | true | false; echo \"${PIPESTATUS[*]}\"; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "1 0 1\nb=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3805b8825aa4aa95": {
+    "command": "n=0; while read a; do n=$((n+1)); printf 'x\\ny\\n' | sed 1q >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3ee15c0daacbb7c2": {
+    "command": "{ cat | tr a-z A-Z; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "L1\nL2\nL3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "4c24906786b6c22a": {
+    "command": "n=0; while read a; do n=$((n+1)); echo hi | head -1 >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "527a291347cbfe0c": {
+    "command": "{ true | cat; echo \"---\"; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "---\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5305a9b560761fe3": {
+    "command": "while read o; do while read i; do echo \"$o$i\"; echo x | cat >/dev/null; done < inner.txt; done < outer.txt",
+    "files": {
+      "outer.txt": "A\nB\n",
+      "inner.txt": "1\n2\n"
+    },
+    "stdout": "A1\nA2\nB1\nB2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "61802d57a1027706": {
+    "command": "f() { echo x | cat >/dev/null; }; n=0; while read a; do n=$((n+1)); f; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "640c900ad55dae76": {
+    "command": "{ read a; true | true; read b; echo \"a=[$a] b=[$b]\"; } <<EOT\nL1\nL2\nEOT\n",
+    "files": {},
+    "stdout": "a=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "6723871c6848c7a5": {
+    "command": "n=0; while read a; do n=$((n+1)); { echo x | cat; } >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "7849e9a46d0b9783": {
+    "command": "n=0; while read a; do n=$((n+1)); { echo x; } >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "7cbc3e72faddada6": {
+    "command": "n=0; while read a; do n=$((n+1)); eval 'echo x | cat' >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "8a186d05bd45d915": {
+    "command": "{ read a; (exit 3) | true; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "a=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "987819a6133437f4": {
+    "command": "n=0; while read a; do n=$((n+1)); ! echo a | grep -q zzz; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "aa0d5baa225de03c": {
+    "command": "{ echo abc | grep zzz | head -1; echo \"---\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "---\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b672a71408ce1733": {
+    "command": "while read a; do echo \"got:$a\"; echo z | cat >/dev/null; done < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "got:L1\ngot:L2\ngot:L3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "bd4e4acb30172b2a": {
+    "command": "n=0; while read a; do n=$((n+1)); echo abc | tr a-z A-Z >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "beb3877d77781923": {
+    "command": "n=0; while read a; do n=$((n+1)); :; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ca8f2263542e394f": {
+    "command": "n=0; while echo y | grep -q y && read a; do n=$((n+1)); done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "iterations: 3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "e62a982bec2718ee": {
+    "command": "n=0; while read a; do n=$((n+1)); case x in x) echo q | cat;; esac >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "e67133f20adda947": {
+    "command": "{ read a; echo \"a=[$a]\"; true | true; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "a=[L1]\nb=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "e9e20f01dcb7a424": {
+    "command": "n=0; while read a; do n=$((n+1)); true | true; done <<< $'L1\\nL2\\nL3'; echo \"iterations: $n\"",
+    "files": {},
+    "stdout": "iterations: 3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ed0c2dc6faa76ac4": {
+    "command": "n=0; while read a; do n=$((n+1)); true | true; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f1a73290817552a7": {
+    "command": "{ read x | cat; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\n"
+    },
+    "stdout": "b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f88e82bcef99cf53": {
+    "command": "n=0; while read a; do n=$((n+1)); for i in 1 2; do echo x | cat; done >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/pipeline-stdin.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/pipeline-stdin.comparison.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * A pipeline inherits the enclosing shell's stdin for its first stage only,
+ * and never consumes it on the pipeline's behalf. Recorded against real bash
+ * for https://github.com/vercel-labs/just-bash/issues/323.
+ */
+
+const FIVE_LINES = "L1\nL2\nL3\nL4\nL5\n";
+const THREE_LINES = "L1\nL2\nL3\n";
+
+describe("Pipeline stdin - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  describe("issue #323 repros", () => {
+    it("keeps the shared position across a pipeline between two reads", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ read a; echo "a=[$a]"; true | true; read b; echo "b=[$b]"; } < loop.txt',
+      );
+    });
+
+    it("runs the loop body once per line when it contains a pipeline", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": FIVE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        'n=0; while read a; do n=$((n+1)); echo hi | head -1 >/dev/null; done < loop.txt; echo "iterations: $n"',
+      );
+    });
+  });
+
+  describe("loop body scope table", () => {
+    const bodies: Array<[label: string, body: string]> = [
+      ["empty body", ":"],
+      ["command group", "{ echo x; } >/dev/null"],
+      ["true | true", "true | true"],
+      ["echo x | echo y", "echo x | echo y >/dev/null"],
+      ["echo abc | tr a-z A-Z", "echo abc | tr a-z A-Z >/dev/null"],
+      ["echo hi | head -1", "echo hi | head -1 >/dev/null"],
+      ["printf | sed 1q", "printf 'x\\ny\\n' | sed 1q >/dev/null"],
+      ["three-stage pipeline", "echo a | cat | cat >/dev/null"],
+      ["negated pipeline", "! echo a | grep -q zzz"],
+      ["pipeline in a command group", "{ echo x | cat; } >/dev/null"],
+      ["pipeline in a subshell", "(echo x | cat) >/dev/null"],
+      [
+        "pipeline in a for loop",
+        "for i in 1 2; do echo x | cat; done >/dev/null",
+      ],
+      ["pipeline in a case arm", "case x in x) echo q | cat;; esac >/dev/null"],
+      ["pipeline in eval", "eval 'echo x | cat' >/dev/null"],
+    ];
+
+    for (const [label, body] of bodies) {
+      it(`${label} iterates once per line`, async () => {
+        const env = await setupFiles(testDir, { "loop.txt": FIVE_LINES });
+        await compareOutputs(
+          env,
+          testDir,
+          `n=0; while read a; do n=$((n+1)); ${body}; done < loop.txt; echo "iterations: $n"`,
+        );
+      });
+    }
+
+    it("pipeline in a function called from the loop body", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": FIVE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        'f() { echo x | cat >/dev/null; }; n=0; while read a; do n=$((n+1)); f; done < loop.txt; echo "iterations: $n"',
+      );
+    });
+
+    it("reads every line, not just the first", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        'while read a; do echo "got:$a"; echo z | cat >/dev/null; done < loop.txt',
+      );
+    });
+  });
+
+  describe("other stdin sources", () => {
+    it("here-string backing the loop survives a pipeline", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        "n=0; while read a; do n=$((n+1)); true | true; done <<< $'L1\\nL2\\nL3'; echo \"iterations: $n\"",
+      );
+    });
+
+    it("group here-doc stdin survives a pipeline", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        '{ read a; true | true; read b; echo "a=[$a] b=[$b]"; } <<EOT\nL1\nL2\nEOT\n',
+      );
+    });
+  });
+
+  describe("stage wiring", () => {
+    it("first stage reads the shell's stdin", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(env, testDir, "{ cat | tr a-z A-Z; } < loop.txt");
+    });
+
+    it("a read in the first stage advances the shared position", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ read x | cat; read b; echo "b=[$b]"; } < loop.txt',
+      );
+    });
+
+    it("a later stage takes the pipe, not the shell's stdin", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(env, testDir, "{ echo A | cat; } < loop.txt");
+    });
+
+    it("a later stage fed empty output does not fall back to the shell's stdin", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ true | cat; echo "---"; read b; echo "b=[$b]"; } < loop.txt',
+      );
+    });
+
+    it("a non-matching grep does not leak the shell's stdin to the next stage", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ echo abc | grep zzz | head -1; echo "---"; } < loop.txt',
+      );
+    });
+
+    it("a read in a non-first stage leaves the shell's stdin alone", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": "L1\nL2\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ echo piped | read v; echo "v=[$v]"; read b; echo "b=[$b]"; } < loop.txt',
+      );
+    });
+
+    it("a stage that exits still hands the position back", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ read a; (exit 3) | true; read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+      );
+    });
+
+    it("PIPESTATUS is unaffected by the stdin wiring", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ read a; false | true | false; echo "${PIPESTATUS[*]}"; read b; echo "b=[$b]"; } < loop.txt',
+      );
+    });
+  });
+
+  describe("loops after a pipeline", () => {
+    it("a read loop after a pipeline sees every remaining line", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": "L1\nL2\nL3\nL4\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        '{ echo start | cat >/dev/null; while read l; do echo "L:$l"; done; } < loop.txt',
+      );
+    });
+
+    it("a pipeline in the loop condition does not drain the loop's stdin", async () => {
+      const env = await setupFiles(testDir, { "loop.txt": THREE_LINES });
+      await compareOutputs(
+        env,
+        testDir,
+        'n=0; while echo y | grep -q y && read a; do n=$((n+1)); done < loop.txt; echo "iterations: $n"',
+      );
+    });
+
+    it("nested read loops over separate files keep their own positions", async () => {
+      const env = await setupFiles(testDir, {
+        "outer.txt": "A\nB\n",
+        "inner.txt": "1\n2\n",
+      });
+      await compareOutputs(
+        env,
+        testDir,
+        'while read o; do while read i; do echo "$o$i"; echo x | cat >/dev/null; done < inner.txt; done < outer.txt',
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -50,6 +50,15 @@ export async function executePipeline(
   const isMultiCommandPipeline = node.commands.length > 1;
   const savedLastArg = ctx.state.lastArg;
 
+  // The enclosing shell's stdin (`< file`, `<<<`, a heredoc on a compound
+  // command, ...). Bash gives the first pipeline stage the shell's fd 0 and
+  // gives every later stage the previous stage's stdout, so only the first
+  // stage can move the shared read position — and only by actually reading.
+  // Running a pipeline is not itself a read: `true | true` must leave the
+  // position where it was. This variable carries that position across
+  // stages so the pipeline can hand it back afterwards.
+  let sharedStdin = ctx.state.groupStdin;
+
   for (let i = 0; i < node.commands.length; i++) {
     const command = node.commands[i];
     const isLast = i === node.commands.length - 1;
@@ -61,13 +70,11 @@ export async function executePipeline(
       // Clear $_ for each pipeline command - they each get fresh subshell context
       ctx.state.lastArg = "";
 
-      // After the first command, clear groupStdin so subsequent commands
-      // only see stdin from the pipeline (even if empty), not the original groupStdin
-      // This prevents commands like head from incorrectly falling back to groupStdin
-      // when they receive empty output from a previous command (e.g., grep with no matches)
-      if (!isFirst) {
-        ctx.state.groupStdin = undefined;
-      }
+      // Only the first stage inherits the shell's stdin. Later stages read
+      // the previous stage's stdout — even when that output is empty — so
+      // hide groupStdin from them; otherwise a command like `head` that got
+      // nothing from `grep` would silently fall back to the shell's stdin.
+      ctx.state.groupStdin = isFirst ? sharedStdin : undefined;
     }
 
     // Determine if this command runs in a subshell context
@@ -119,6 +126,18 @@ export async function executePipeline(
           ctx.state.arrays = savedArrays ?? new Map();
         }
         throw error;
+      }
+    } finally {
+      if (isMultiCommandPipeline) {
+        // The first stage held the shell's stdin, so whatever it consumed
+        // (a `read` builtin advances the position, `true` does not) is now
+        // the shared position. Every stage — including one that threw —
+        // hands that position back to the enclosing shell, so the pipeline
+        // itself never drains stdin.
+        if (isFirst) {
+          sharedStdin = ctx.state.groupStdin;
+        }
+        ctx.state.groupStdin = sharedStdin;
       }
     }
 

--- a/packages/just-bash/src/interpreter/pipeline-stdin.test.ts
+++ b/packages/just-bash/src/interpreter/pipeline-stdin.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * A pipeline inherits the enclosing shell's stdin for its first stage and
+ * must not consume it on the pipeline's behalf: running `true | true` reads
+ * nothing, so a following `read` still sees the next line. Regression tests
+ * for https://github.com/vercel-labs/just-bash/issues/323, where every
+ * pipeline drained the shared stdin to EOF.
+ */
+
+const FIVE_LINES = "L1\nL2\nL3\nL4\nL5\n";
+const THREE_LINES = "L1\nL2\nL3\n";
+
+function makeBash(content = FIVE_LINES): Bash {
+  return new Bash({ files: { "/loop.txt": content }, cwd: "/" });
+}
+
+describe("pipeline stdin — issue #323 repros", () => {
+  it("a pipeline between two reads leaves the shared position alone", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read a; echo "a=[$a]"; true | true; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1]\nb=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a `while read` loop with a pipeline in its body runs once per line", async () => {
+    const result = await makeBash().exec(
+      "n=0; while read a; do n=$((n+1)); echo hi | head -1 >/dev/null; done < /loop.txt\n" +
+        'echo "iterations: $n"',
+    );
+    expect(result.stdout).toBe("iterations: 5\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("pipeline stdin — loop body scope table (issue #323)", () => {
+  // Mirrors the table in issue #323: every one of these bodies must leave the
+  // loop's stdin untouched, so the loop sees all five lines.
+  const bodies: Array<[label: string, body: string]> = [
+    ["empty body", ":"],
+    ["command group", "{ echo x; } >/dev/null"],
+    ["command substitution in body does not consume loop input", "y=$(echo z)"],
+    ["true | true", "true | true"],
+    ["echo x | echo y", "echo x | echo y >/dev/null"],
+    ["echo abc | tr a-z A-Z", "echo abc | tr a-z A-Z >/dev/null"],
+    ["echo hi | head -1", "echo hi | head -1 >/dev/null"],
+    ["printf | sed 1q", "printf 'x\\ny\\n' | sed 1q >/dev/null"],
+    ["three-stage pipeline", "echo a | cat | cat >/dev/null"],
+    ["negated pipeline", "! echo a | grep -q zzz"],
+    ["|& pipeline", "echo a |& cat >/dev/null"],
+    ["pipeline inside a command group", "{ echo x | cat; } >/dev/null"],
+    ["pipeline inside a subshell", "(echo x | cat) >/dev/null"],
+    [
+      "pipeline inside a for loop",
+      "for i in 1 2; do echo x | cat; done >/dev/null",
+    ],
+    [
+      "pipeline inside a case arm",
+      "case x in x) echo q | cat;; esac >/dev/null",
+    ],
+    ["pipeline inside eval", "eval 'echo x | cat' >/dev/null"],
+  ];
+
+  for (const [label, body] of bodies) {
+    it(`${label} → 5 iterations`, async () => {
+      const result = await makeBash().exec(
+        `n=0; while read a; do n=$((n+1)); ${body}; done < /loop.txt\necho "iterations: $n"`,
+      );
+      expect(result.stdout).toBe("iterations: 5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  }
+
+  it("a pipeline in a function called from the loop body → 5 iterations", async () => {
+    const result = await makeBash().exec(
+      "f() { echo x | cat >/dev/null; }\n" +
+        'n=0; while read a; do n=$((n+1)); f; done < /loop.txt\necho "iterations: $n"',
+    );
+    expect(result.stdout).toBe("iterations: 5\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("the loop still sees every line, not just the count", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      'while read a; do echo "got:$a"; echo z | cat >/dev/null; done < /loop.txt',
+    );
+    expect(result.stdout).toBe("got:L1\ngot:L2\ngot:L3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("pipeline stdin — stdin sources other than `< file`", () => {
+  it("here-string backing the loop survives a pipeline", async () => {
+    const result = await new Bash().exec(
+      "n=0; while read a; do n=$((n+1)); true | true; done <<< $'L1\\nL2\\nL3'\n" +
+        'echo "iterations: $n"',
+    );
+    expect(result.stdout).toBe("iterations: 3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("here-doc backing the loop survives a pipeline", async () => {
+    const result = await new Bash().exec(
+      "n=0; while read a; do n=$((n+1)); echo x | cat >/dev/null; done <<EOT\nL1\nL2\nL3\nEOT\n" +
+        'echo "iterations: $n"',
+    );
+    expect(result.stdout).toBe("iterations: 3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a group's here-doc stdin survives a pipeline", async () => {
+    const result = await new Bash().exec(
+      '{ read a; true | true; read b; echo "a=[$a] b=[$b]"; } <<EOT\nL1\nL2\nEOT',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("pipeline stdin — stage wiring", () => {
+  it("the first stage reads the shell's stdin", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      "{ cat | tr a-z A-Z; } < /loop.txt",
+    );
+    expect(result.stdout).toBe("L1\nL2\nL3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a read in the first stage advances the shared position", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read x | cat; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a later stage reads the previous stage's stdout, not the shell's stdin", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      "{ echo A | cat; } < /loop.txt",
+    );
+    expect(result.stdout).toBe("A\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a later stage fed empty output does not fall back to the shell's stdin", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ true | cat; echo "---"; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("---\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a non-matching grep does not let the next stage see the shell's stdin", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ echo abc | grep zzz | head -1; echo "---"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("---\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a read in a non-first stage takes the pipe, leaving the shell's stdin alone", async () => {
+    const result = await makeBash("L1\nL2\n").exec(
+      '{ echo piped | read v; echo "v=[$v]"; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("v=[]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a pipeline that exits mid-stage still hands the position back", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read a; (exit 3) | true; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a failing command in a pipeline still hands the position back", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read a; no_such_command_xyz | true; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe(
+      "bash: no_such_command_xyz: command not found\n",
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("PIPESTATUS is unaffected by the stdin wiring", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read a; false | true | false; echo "${PIPESTATUS[*]}"; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("1 0 1\nb=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("pipeline stdin — mapfile and nested loops", () => {
+  it("mapfile after a pipeline still sees the remaining lines", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      '{ read a; true | true; mapfile -t arr; echo "a=[$a] n=${#arr[@]} first=[${arr[0]}]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] n=2 first=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a read loop after a pipeline still sees every remaining line", async () => {
+    const result = await makeBash("L1\nL2\nL3\nL4\n").exec(
+      '{ echo start | cat >/dev/null; while read l; do echo "L:$l"; done; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("L:L1\nL:L2\nL:L3\nL:L4\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a pipeline in the loop condition does not drain the loop's stdin", async () => {
+    const result = await makeBash(THREE_LINES).exec(
+      "n=0; while echo y | grep -q y && read a; do n=$((n+1)); done < /loop.txt\n" +
+        'echo "iterations: $n"',
+    );
+    expect(result.stdout).toBe("iterations: 3\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("nested read loops over separate files keep their own positions", async () => {
+    const bash = new Bash({
+      files: { "/outer.txt": "A\nB\n", "/inner.txt": "1\n2\n" },
+      cwd: "/",
+    });
+    const result = await bash.exec(
+      "while read o; do\n" +
+        '  while read i; do echo "$o$i"; echo x | cat >/dev/null; done < /inner.txt\n' +
+        "done < /outer.txt",
+    );
+    expect(result.stdout).toBe("A1\nA2\nB1\nB2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("the exec() stdin option survives a pipeline, like `bash -c … < file`", async () => {
+    const result = await new Bash().exec(
+      'read a; echo "a=[$a]"; true | true; read b; echo "b=[$b]"; ' +
+        'n=0; while read l; do n=$((n+1)); echo x | cat >/dev/null; done; echo "rest: $n"',
+      { stdin: "L1\nL2\nL3\nL4\n" },
+    );
+    expect(result.stdout).toBe("a=[L1]\nb=[L2]\nrest: 2\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Any pipeline drained the enclosing shell's stdin to EOF, even one where no stage reads stdin. `{ read a; true | true; read b; }` lost the second line, and `while read …; do … | …; done < file` — one of the most common shell idioms there is — ran its body exactly once and then exited. An agent looping over a batch of records silently processed the first one and stopped.

Closes #323.

The shared-stdin model this regressed is the `groupStdin` position that `read` and `mapfile` advance for everyone in scope — the "reading is consuming" contract that #285 set out to make structural. #285 was closed unmerged, so `groupStdin` is still the single representation; this PR fixes the pipeline's handling of it without changing the model.

## Details

### Root cause

`executePipeline` clears `state.groupStdin` before every stage after the first:

```ts
if (!isFirst) {
  ctx.state.groupStdin = undefined;
}
```

That part is right — a later stage's stdin is the previous stage's stdout, so `grep` matching nothing must not let the following `head` quietly fall back to the shell's stdin. What was missing is the other half: nothing ever put `groupStdin` back. The clear is a permanent write to shared interpreter state, so after any multi-command pipeline the enclosing shell saw `undefined`, which `read` treats as EOF.

That also explains the shape of the scope table in the issue. `{ echo x | cat; }`, `(echo x | cat)`, `eval 'echo x | cat'` and a pipeline inside a function all looked fine — groups, subshells, `eval` and function calls save and restore `groupStdin` around their body, so they happened to undo the clobber. A bare pipeline in the loop body had nothing to undo it. `for` and `case` do *not* save/restore, so a pipeline inside them regressed just like a bare one.

### The fix

`packages/just-bash/src/interpreter/pipeline-execution.ts`, three hunks:

- Capture the shell's stdin once, before the stage loop (`sharedStdin`).
- The first stage runs with it installed, later stages with `undefined` — bash gives fd 0 to the head of a pipeline and a pipe to everyone else.
- In a `finally` on each stage: the first stage's leftover *becomes* the shared position (a `read` builtin there advanced it; `true` did not), and every stage hands that position back to the enclosing shell.

So consumption follows reads, not runs. `true | true` reads nothing and leaves the position where it was; `read x | cat` consumes exactly its line. Putting the hand-back in a `finally` means a stage that throws — `ExecutionLimitError`, `break` out of a pipeline segment — doesn't strand the shell at EOF either.

No new state, no signature changes; the pipeline just stops writing to shared state it didn't own.

### Semantics matrix (verified against real bash, not assumed)

Every row below was run in both interpreters. Loop = `n=0; while read a; do n=$((n+1)); <body>; done < 5-line-file`.

| Case | bash | before | after |
|---|---|---|---|
| loop, empty body | 5 | 5 | 5 |
| loop, `{ echo x; }` | 5 | 5 | 5 |
| loop, `true \| true` | 5 | **1** | 5 |
| loop, `echo x \| echo y` | 5 | **1** | 5 |
| loop, `echo abc \| tr a-z A-Z` | 5 | **1** | 5 |
| loop, `echo hi \| head -1` | 5 | **1** | 5 |
| loop, `printf 'x\ny\n' \| sed 1q` | 5 | **1** | 5 |
| loop, `echo a \| cat \| cat` | 5 | **1** | 5 |
| loop, `! echo a \| grep -q zzz` | 5 | **1** | 5 |
| loop, `{ echo x \| cat; }` | 5 | 5 | 5 |
| loop, `(echo x \| cat)` | 5 | 5 | 5 |
| loop, pipeline in a function | 5 | 5 | 5 |
| loop, `eval 'echo x \| cat'` | 5 | 5 | 5 |
| loop, `for i in 1 2; do echo x \| cat; done` | 5 | **1** | 5 |
| loop, `case x in x) echo q \| cat;; esac` | 5 | **1** | 5 |
| loop over `<<<` / heredoc, `true \| true` | 3 | **1** | 3 |
| loop, pipeline in the *condition* | 3 | **1** | 3 |
| nested loops over two files, pipeline in inner body | `A1 A2 B1 B2` | **`A1`** | `A1 A2 B1 B2` |
| `{ read a; true \| true; read b; }` | `L1`,`L2` | `L1`,`""` | `L1`,`L2` |
| `{ read x \| cat; read b; }` | `L2` | `""` | `L2` |
| `{ echo A \| cat; read b; }` | `A`,`L1` | `A`,`""` | `A`,`L1` |
| `{ true \| cat; read b; }` | `L1` | `""` | `L1` |
| `{ echo abc \| grep zzz \| head -1; }` | *(empty)* | *(empty)* | *(empty)* |
| `{ echo piped \| read v; read b; }` | `""`,`L1` | `""`,`""` | `""`,`L1` |
| `{ read a; (exit 3) \| true; read b; }` | `L1`,`L2` | `L1`,`""` | `L1`,`L2` |
| `{ read a; false \| true \| false; ... }` PIPESTATUS | `1 0 1` | `1 0 1` | `1 0 1` |
| `exec(script, { stdin })` + pipeline + `read` | `L1`,`L2`, rest 2 | `L1`,`""`, rest 0 | `L1`,`L2`, rest 2 |

One row could not be checked against the local bash: `echo a \|& cat` in the loop body — macOS ships bash 3.2.57, which predates `\|&`. just-bash gives 5, matching how `\|` behaves; it is covered by a unit test but deliberately left out of the comparison fixtures.

### Known gap this does *not* close (unchanged by this PR)

Only `read` and `mapfile` advance the shared position today. Ordinary commands are handed the shell's stdin and read it without consuming, so:

```bash
{ cat; read b; echo "b=[$b]"; } < file   # bash: b=[]   just-bash: b=[L1]
```

That is pre-existing and independent of pipelines — `while read a; do cat; done < file` runs 5 times instead of 1 on `main` too, and the issue's own table lists `y=$(cat)` as "5 iterations, matching bash" when real bash gives 1.

This PR makes the pipeline case *consistent* with the single-command case rather than fixing the model. Two cases therefore lose an agreement with bash that only ever came from the bug being fixed here — where the pipeline clobbered `groupStdin` to `undefined`, a following `read` saw EOF, which is coincidentally what bash reports after a first stage drains the file:

| case (3-line file) | bash | main | this branch |
|---|---|---|---|
| `{ cat \| tr a-z A-Z; read b; }` | `b=[]` | `b=[]` | `b=[L1]` |
| `{ while read q; do echo "q=$q"; done \| cat; read b; }` | `b=[]` | `b=[]` | `b=[L1]` |

Both now report what the interpreter already reports for the equivalent single command (`{ cat; read b; }` → `b=[L1]` on `main` today). Closing the gap properly means giving commands a way to report how much they consumed, i.e. the #285 redesign; that is a much larger change and does not belong in a regression fix.

Related cases in the same family are wrong before *and* after, just differently: `{ read a; } | cat`, `( read a ) | cat`, and a function whose body reads stdin as the first stage all give `b=[]` on `main` and `b=[L1]` here, where bash gives `b=[L2]` — a first-stage `read` inside a group, subshell or function has its position advance thrown away by that construct's own `groupStdin` restore before the pipeline can hand it back. The bare form (`read x | cat`) does work and is tested.

That construct-level restore is the second adjacent bug: a group, subshell or function restores `groupStdin` on exit even when it never replaced it, so `{ { read a; }; read b; }` re-reads `L1` where bash gives `L2`. Same root pattern (a construct rewinding a position it doesn't own), different construct — happy to file it separately.

### Relationship to other open work

- **#318** (interleave duplicated streams in write order) touches `ExecutionOutputAccumulator` and `applyRedirections` — the *output* side of a result. This PR touches only the stdin wiring in the stage loop and adds no fields to `ExecResult`. No overlap; they should merge in either order.
- **#321** (numeric fd table: `exec 3< file`, `read -u 3`, `done 3< file`) is the sanctioned workaround for this bug and is being implemented separately. Nothing here implements or presumes numeric fds; `read`'s existing `-u` path is untouched.
- **#320** (process substitution) and **#322** (`grep -f`) are unrelated.

## Tests

**`packages/just-bash/src/interpreter/pipeline-stdin.test.ts`** — 37 tests, new file, collocated with `pipeline-execution.ts`. Both exact repros from #323 (`a=[L1] b=[L2]`, `iterations: 5`); a table mirroring the issue's scope table (16 loop bodies including the pipeline-inside-group / subshell / for / case / eval nestings, plus a pipeline in a called function); `<<<` and heredoc as the stdin source; stage-wiring cases (first stage reads shell stdin, `read` in the first stage advances the position, later stages take the pipe, empty upstream doesn't leak, non-matching `grep` doesn't leak, `read` in a non-first stage); throwing/failing stages still hand the position back; PIPESTATUS unchanged; `mapfile` after a pipeline; nested read loops; and the public `exec(script, { stdin })` path, which was affected too since `Bash.exec` seeds `groupStdin` from it.

**`packages/just-bash/src/comparison-tests/pipeline-stdin.comparison.test.ts`** + `fixtures/pipeline-stdin.comparison.fixtures.json` — 31 tests / 30 fixtures (two cases share a command), recorded against real bash with `RECORD_FIXTURES=1`.

Fixtures recorded with **GNU bash 3.2.57(1)-release (arm64-apple-darwin25)**, the `/bin/bash` the fixture runner shells out to. None are locked. Every case is plain builtins plus `cat`/`head -1`/`tr`/`sed 1q`/`grep -q`, so I *expect* them to reproduce under Ubuntu + bash 5.x — but that is a judgement, not a measurement: I have no GNU bash to hand and did not re-record there. If CI re-records and something diffs, the entry to look at first is `{ read x | cat; read b; }` → `b=[L2]`, which depends on how bash reads from a seekable fd in a forked stage (read-ahead plus `lseek` back). Locking it would be the fix if 5.x disagrees. Anything bash 3.2 simply lacks — `|&`, `mapfile` — is deliberately not in the fixture set and lives in the unit tests only.

### Verification

All runs on this branch, macOS/arm64, node 26.

```
pnpm typecheck        clean (both workspace packages)
pnpm lint             clean (workflow security + biome 1040 files + banned patterns)
pnpm lint:fix         clean, no diff
pnpm knip             clean (2 pre-existing config hints, unchanged)
```

| Suite | Result |
|---|---|
| unit, `--exclude src/spec-tests` (+ the excludes `test:run` already applies) | **10530 passed, 6 failed, 96 skipped / 10632** |
| comparison (`vitest.comparison.config.ts`) | **598 passed / 598**, 36 files (was 567 / 35) |
| spec tests (`src/spec-tests`) | **3825 passed, 1 skipped, 0 failed** — identical to `main` |

The 6 unit failures are all python3/CPython-WASM tests: `vendor/cpython-emscripten/python.wasm` is a 132-byte git-LFS pointer in this checkout. They fail identically on `main`.

Regression run was done by name, not by count: full suite JSON on a clean `upstream/main` checkout vs. this branch, `dist/` built for both so the bundle/CLI/worker tests are comparable, diffed per assertion.

```
main  : 10462 passed, 6 failed, 96 skipped / 10564
branch: 10530 passed, 6 failed, 96 skipped / 10632
NEW failures: 0    newly passing: 0
```

The +68 is exactly the tests this PR adds (37 unit + 31 comparison). Spec tests diffed the same way: 0 new failures, 0 newly passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
