### PR TITLE
fix(interpreter): apply output redirections on while/until loops

### DIFF
--- a/.changeset/loop-output-redirections.md
+++ b/.changeset/loop-output-redirections.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Apply output redirections attached to `while` and `until` loops. `while true; do echo x; break; done >/dev/null` no longer leaks its output to the caller, and `> file`, `>>`, `2>`, `2>&1`, `&>` and `>|` now behave on loops the way they already did on `for` and `case`. `until` loops also gained the input-redirection handling `while` loops already had, so `until ! read l; do ...; done < file` reads from the file. A loop now only restores stdin it owns, so reading inside a loop no longer rewinds an enclosing group's read position: `printf 'a\nb\n' | { while read x; do break; done; read y; }` sees `y=b`.

--- a/packages/just-bash/src/comparison-tests/fixtures/loop-redirection-order.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/loop-redirection-order.comparison.fixtures.json
@@ -1,0 +1,96 @@
+{
+  "029ef9a4af22f501": {
+    "command": "while true; do echo x; break; done > o.txt < nosuch\necho \"rc=$?\"\necho \"o=[$(cat o.txt)]\"",
+    "files": {
+      "o.txt": "keep\n"
+    },
+    "stdout": "rc=1\no=[]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "4056dc47122a0f15": {
+    "command": "while true; do echo x; break; done > a.txt < nosuch > b.txt\necho \"rc=$?\"\necho \"a=[$(cat a.txt)] b=[$(cat b.txt)]\"",
+    "files": {
+      "a.txt": "keepa\n",
+      "b.txt": "keepb\n"
+    },
+    "stdout": "rc=1\na=[] b=[keepb]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "55c304dbea2f9c5f": {
+    "command": "until false; do echo u; break; done > o.txt < nosuch\necho \"rc=$?\"\necho \"o=[$(cat o.txt)]\"",
+    "files": {
+      "o.txt": "keep\n"
+    },
+    "stdout": "rc=1\no=[]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "5ba4d3c97b929674": {
+    "command": "while true; do echo x; break; done > a.txt < nosuch > b.txt\necho \"rc=$?\"\necho \"a=$([ -e a.txt ] && echo yes || echo no) b=$([ -e b.txt ] && echo yes || echo no)\"",
+    "files": {},
+    "stdout": "rc=1\na=yes b=no\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "625853946873d829": {
+    "command": "while true; do echo x; break; done 2> e.txt < nosuch\necho \"rc=$?\"\necho \"hits=$(grep -c 'No such file or directory' e.txt)\"",
+    "files": {
+      "e.txt": "keep\n"
+    },
+    "stdout": "rc=1\nhits=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "91da5cb96c38ee37": {
+    "command": "while read l; do echo \"h:$l\"; done > o.txt <<EOF < nosuch\nalpha\nEOF\necho \"rc=$?\"\necho \"o=[$(cat o.txt)]\"",
+    "files": {
+      "o.txt": "keep\n"
+    },
+    "stdout": "rc=1\no=[]\n",
+    "stderr": "/bin/bash: line 2: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c37167907026f157": {
+    "command": "while true; do echo x; break; done >> o.txt < nosuch\necho \"rc=$?\"\necho \"o=[$(cat o.txt)]\"",
+    "files": {
+      "o.txt": "keep\n"
+    },
+    "stdout": "rc=1\no=[keep]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d15827827b1e9040": {
+    "command": "while true; do echo x; break; done >> o.txt < nosuch\necho \"rc=$?\"\necho \"exists=$([ -e o.txt ] && echo yes || echo no) o=[$(cat o.txt)]\"",
+    "files": {},
+    "stdout": "rc=1\nexists=yes o=[]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e6247bbd96681489": {
+    "command": "while true; do echo x; break; done < nosuch > o.txt\necho \"rc=$?\"\necho \"o=[$(cat o.txt)]\"",
+    "files": {
+      "o.txt": "keep\n"
+    },
+    "stdout": "rc=1\no=[keep]\n",
+    "stderr": "/bin/bash: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f77f9201e0a8db50": {
+    "command": "n=0\nwhile true; do echo x; break; done > \"s$((n++)).txt\" < nosuch\necho \"rc=$? n=$n\"\necho \"s0=$([ -e s0.txt ] && echo yes || echo no) s1=$([ -e s1.txt ] && echo yes || echo no)\"",
+    "files": {},
+    "stdout": "rc=1 n=1\ns0=yes s1=no\n",
+    "stderr": "/bin/bash: line 1: nosuch: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/fixtures/loop-redirections-stdin.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/loop-redirections-stdin.comparison.fixtures.json
@@ -1,0 +1,106 @@
+{
+  "1bb58c023a7e3d11": {
+    "command": "printf 'p1\\np2\\n' | until ! read l; do echo \"u:$l\"; done > out.txt\ncat out.txt",
+    "files": {},
+    "stdout": "u:p1\nu:p2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1e0e9742faa27b5b": {
+    "command": "while read l; do echo \"s:$l\"; done <<< \"hello\" > out.txt\ncat out.txt",
+    "files": {},
+    "stdout": "s:hello\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "39035298fab339d9": {
+    "command": "while read l; do echo \"h:$l\"; done > out.txt <<EOF\nalpha\nbeta\nEOF\ncat out.txt",
+    "files": {},
+    "stdout": "h:alpha\nh:beta\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "40fe41c114c96981": {
+    "command": "while read l; do echo \"s:[$l]\"; done <<< *",
+    "files": {
+      "aglob1": "",
+      "aglob2": ""
+    },
+    "stdout": "s:[*]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "42305949b7a93f3e": {
+    "command": "while read l; do echo \"[$l]\"; done < in.txt > out.txt\ncat out.txt",
+    "files": {
+      "in.txt": "a\nb\n"
+    },
+    "stdout": "[a]\n[b]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "574598a08fc6451d": {
+    "command": "while true; do echo x; break; done > out.txt | cat\necho \"---\"\ncat out.txt",
+    "files": {},
+    "stdout": "---\nx\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "9087f53db0e40105": {
+    "command": "while true; do echo o; echo e >&2; break; done 2>&1 | cat",
+    "files": {},
+    "stdout": "o\ne\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "90f788b3434d6ffa": {
+    "command": "while read l; do echo \"got:$l\"; done < in.txt",
+    "files": {
+      "in.txt": "one\ntwo\n"
+    },
+    "stdout": "got:one\ngot:two\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "98da27b468bc4899": {
+    "command": "while read l; do echo \"$l\"; done < nosuch.txt > out.txt\necho \"rc=$?\"\ncat out.txt",
+    "files": {
+      "out.txt": "keep\n"
+    },
+    "stdout": "rc=1\nkeep\n",
+    "stderr": "/bin/bash: nosuch.txt: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ab01f4156de7358b": {
+    "command": "for i in 1 2; do\n  while true; do echo \"n$i\"; break; done\ndone > out.txt\ncat out.txt",
+    "files": {},
+    "stdout": "n1\nn2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ad1c8cf5e7b450d8": {
+    "command": "until ! read l; do echo \"$l\"; done < nosuch.txt\necho \"rc=$?\"",
+    "files": {},
+    "stdout": "rc=1\n",
+    "stderr": "/bin/bash: nosuch.txt: No such file or directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "babe1561e72daf4a": {
+    "command": "until ! read l; do echo \"<$l>\"; done < in.txt > out.txt\ncat out.txt",
+    "files": {
+      "in.txt": "c\nd\n"
+    },
+    "stdout": "<c>\n<d>\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "be7575df70c1b6e1": {
+    "command": "while true; do\n  while true; do echo inner; break; done > inner.txt\n  echo outer\n  break\ndone > outer.txt\necho \"inner=[$(cat inner.txt)] outer=[$(cat outer.txt)]\"",
+    "files": {},
+    "stdout": "inner=[inner] outer=[outer]\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/fixtures/loop-redirections-stdin.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/loop-redirections-stdin.comparison.fixtures.json
@@ -72,6 +72,15 @@
     "exitCode": 0,
     "locked": true
   },
+  "a749acbf5a19012b": {
+    "command": "while read l; do echo \"{$l}\"; done > a.txt < in.txt > b.txt\necho \"a=[$(cat a.txt)] b=[$(cat b.txt)]\"",
+    "files": {
+      "in.txt": "e\nf\n"
+    },
+    "stdout": "a=[] b=[{e}\n{f}]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
   "ab01f4156de7358b": {
     "command": "for i in 1 2; do\n  while true; do echo \"n$i\"; break; done\ndone > out.txt\ncat out.txt",
     "files": {},
@@ -100,6 +109,15 @@
     "command": "while true; do\n  while true; do echo inner; break; done > inner.txt\n  echo outer\n  break\ndone > outer.txt\necho \"inner=[$(cat inner.txt)] outer=[$(cat outer.txt)]\"",
     "files": {},
     "stdout": "inner=[inner] outer=[outer]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "cf6e0185b56c7166": {
+    "command": "while read l; do echo \"got:$l\"; done > f.txt < f.txt\necho \"rc=$? f=[$(cat f.txt)]\"",
+    "files": {
+      "f.txt": "l1\nl2\n"
+    },
+    "stdout": "rc=0 f=[]\n",
     "stderr": "",
     "exitCode": 0
   }

--- a/packages/just-bash/src/comparison-tests/fixtures/loop-redirections.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/loop-redirections.comparison.fixtures.json
@@ -1,0 +1,140 @@
+{
+  "1516b1c98aa98f7e": {
+    "command": "while true; do echo o; echo e >&2; break; done > out.txt 2>&1\ncat out.txt",
+    "files": {},
+    "stdout": "o\ne\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "18b98cfdead862dc": {
+    "command": "while true; do echo o; echo e >&2; break; done &> both.txt\ncat both.txt",
+    "files": {},
+    "stdout": "o\ne\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1995fbe9ff526939": {
+    "command": "i=0\nuntil [ $i -ge 2 ]; do echo \"e$i\" >&2; i=$((i + 1)); done 2> err.txt\ncat err.txt",
+    "files": {},
+    "stdout": "e0\ne1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "240730055fc830ec": {
+    "command": "set -o noclobber\nwhile true; do echo new; break; done > out.txt\necho \"rc=$?\"\ncat out.txt",
+    "files": {
+      "out.txt": "keep\n"
+    },
+    "stdout": "rc=1\nkeep\n",
+    "stderr": "/bin/bash: line 1: out.txt: cannot overwrite existing file\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "2a8eb5563a36d6bb": {
+    "command": "while true; do echo x; break; done >/dev/null; echo end",
+    "files": {},
+    "stdout": "end\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3fc85eff2215430f": {
+    "command": "i=0\nwhile [ $i -lt 2 ]; do echo \"l$i\"; i=$((i + 1)); done >> out.txt\ncat out.txt",
+    "files": {
+      "out.txt": "pre\n"
+    },
+    "stdout": "pre\nl0\nl1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "474ab3fefca3fa47": {
+    "command": "while true; do cat data.txt; break; done > data.txt\necho \"[$(cat data.txt)]\"",
+    "files": {
+      "data.txt": "hi\n"
+    },
+    "stdout": "[]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5f5768916ce1da79": {
+    "command": "i=0\nuntil [ $i -ge 2 ]; do echo \"a$i\"; i=$((i + 1)); done >> out.txt\ncat out.txt",
+    "files": {
+      "out.txt": "start\n"
+    },
+    "stdout": "start\na0\na1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "7956292b021c575e": {
+    "command": "i=0\nwhile [ $i -lt 2 ]; do echo \"o$i\"; echo \"e$i\" >&2; i=$((i + 1)); done 2> err.txt\necho \"---\"\ncat err.txt",
+    "files": {},
+    "stdout": "o0\no1\n---\ne0\ne1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "86302b057065df77": {
+    "command": "while true; do echo o; echo e >&2; break; done 2>&1 > out.txt\necho \"---\"\ncat out.txt",
+    "files": {},
+    "stdout": "e\n---\no\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "8860cf8620c0a965": {
+    "command": "n=0\nwhile true; do echo body; break; done > \"f$((n++)).txt\"\necho \"n=$n\"\ncat f0.txt",
+    "files": {},
+    "stdout": "n=1\nbody\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "8d177db5bb17f139": {
+    "command": "i=0\nuntil [ $i -ge 2 ]; do echo \"u$i\"; i=$((i + 1)); done > out.txt\necho \"---\"\ncat out.txt",
+    "files": {},
+    "stdout": "---\nu0\nu1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "af9bc97128cbe3f2": {
+    "command": "set -o noclobber\nwhile true; do echo new; break; done >| out.txt\ncat out.txt",
+    "files": {
+      "out.txt": "keep\n"
+    },
+    "stdout": "new\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "c91522d33ec1a604": {
+    "command": "i=0\nuntil [ $i -ge 4 ]; do\n  i=$((i + 1))\n  if [ $i -eq 2 ]; then continue; fi\n  if [ $i -eq 4 ]; then break; fi\n  echo \"u$i\"\ndone > out.txt\ncat out.txt",
+    "files": {},
+    "stdout": "u1\nu3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ca463149cbfe2ce0": {
+    "command": "i=0\nwhile [ $i -lt 3 ]; do echo \"line$i\"; i=$((i + 1)); done > out.txt\necho \"---\"\ncat out.txt",
+    "files": {},
+    "stdout": "---\nline0\nline1\nline2\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "e088333f17a0f331": {
+    "command": "while true; do echo m; break; done > a.txt > b.txt\necho \"a=[$(cat a.txt)] b=[$(cat b.txt)]\"",
+    "files": {},
+    "stdout": "a=[] b=[m]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "eb83615d48785472": {
+    "command": "mkdir adir\nwhile true; do echo x; break; done > adir\necho \"rc=$?\"",
+    "files": {},
+    "stdout": "rc=1\n",
+    "stderr": "/bin/bash: line 1: adir: Is a directory\n",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f50a400206877f2b": {
+    "command": "i=0\nwhile echo \"cond$i\"; [ $i -lt 1 ]; do echo \"body$i\"; i=$((i + 1)); done > out.txt\necho \"---\"\ncat out.txt",
+    "files": {},
+    "stdout": "---\ncond0\nbody0\ncond1\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/loop-redirection-order.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/loop-redirection-order.comparison.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Left-to-right processing of a loop's redirection list: a failing redirection
+ * leaves every earlier one already applied.
+ *
+ * Each case prints the state of its targets so the file effects land in the
+ * compared stdout. Recorded outputs are identical on bash 3.2.57 and 5.3.15,
+ * which were both measured before these expectations were written.
+ *
+ * Nine of the ten fixtures here are locked. Those cases let a redirection
+ * FAIL, so bash writes a diagnostic, and the recorded stderr carries bash's
+ * shell path and "line N:" script-position prefix. Both move between bash
+ * versions — re-recording this file against bash 5.3.15 rewrote every one of
+ * them (`/bin/bash: nosuch:` → `/opt/homebrew/bin/bash: line 1: nosuch:`,
+ * `line 1:` → `line 2:`) while leaving stdout and exit code byte-identical.
+ * The runner compares only stdout and exit code, but it still records stderr,
+ * and the comparison-tests workflow fails on any git diff after CI re-records
+ * on ubuntu bash 5.x — so locking is what keeps that green, and it costs no
+ * coverage.
+ *
+ * The tenth fixture (`625853946873d829`, the `2> e.txt` case) is deliberately
+ * NOT locked: its diagnostic goes into the redirect target rather than to
+ * stderr, so its recorded stderr is empty and stable.
+ */
+describe("loop redirection order - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  it("should truncate a > target that precedes a failing input redirect", async () => {
+    const env = await setupFiles(testDir, { "o.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done > o.txt < nosuch",
+        'echo "rc=$?"',
+        'echo "o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should truncate a > target preceding a failing input on until loops", async () => {
+    const env = await setupFiles(testDir, { "o.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "until false; do echo u; break; done > o.txt < nosuch",
+        'echo "rc=$?"',
+        'echo "o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should keep the contents of an earlier >> target", async () => {
+    const env = await setupFiles(testDir, { "o.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done >> o.txt < nosuch",
+        'echo "rc=$?"',
+        'echo "o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should create a missing >> target before failing", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done >> o.txt < nosuch",
+        'echo "rc=$?"',
+        'echo "exists=$([ -e o.txt ] && echo yes || echo no) o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should apply only the outputs left of a failing input", async () => {
+    const env = await setupFiles(testDir, {
+      "a.txt": "keepa\n",
+      "b.txt": "keepb\n",
+    });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done > a.txt < nosuch > b.txt",
+        'echo "rc=$?"',
+        'echo "a=[$(cat a.txt)] b=[$(cat b.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should create only the target left of a failing input", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done > a.txt < nosuch > b.txt",
+        'echo "rc=$?"',
+        'echo "a=$([ -e a.txt ] && echo yes || echo no) b=$([ -e b.txt ] && echo yes || echo no)"',
+      ].join("\n"),
+    );
+  });
+
+  // Compares the diagnostic's PRESENCE in the file, not its text: the message
+  // body ("No such file or directory") is stable across bash versions but its
+  // "line N:" prefix is not.
+  it("should route the diagnostic through an earlier 2>", async () => {
+    const env = await setupFiles(testDir, { "e.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done 2> e.txt < nosuch",
+        'echo "rc=$?"',
+        "echo \"hits=$(grep -c 'No such file or directory' e.txt)\"",
+      ].join("\n"),
+    );
+  });
+
+  it("should expand an earlier target exactly once", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "n=0",
+        'while true; do echo x; break; done > "s$((n++)).txt" < nosuch',
+        'echo "rc=$? n=$n"',
+        'echo "s0=$([ -e s0.txt ] && echo yes || echo no) s1=$([ -e s1.txt ] && echo yes || echo no)"',
+      ].join("\n"),
+    );
+  });
+
+  it("should leave a > target that follows a failing input untouched", async () => {
+    const env = await setupFiles(testDir, { "o.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        "while true; do echo x; break; done < nosuch > o.txt",
+        'echo "rc=$?"',
+        'echo "o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+
+  it("should apply an earlier output redirect around a here-doc", async () => {
+    const env = await setupFiles(testDir, { "o.txt": "keep\n" });
+    await compareOutputs(
+      env,
+      testDir,
+      [
+        'while read l; do echo "h:$l"; done > o.txt <<EOF < nosuch',
+        "alpha",
+        "EOF",
+        'echo "rc=$?"',
+        'echo "o=[$(cat o.txt)]"',
+      ].join("\n"),
+    );
+  });
+});

--- a/packages/just-bash/src/comparison-tests/loop-redirections-stdin.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/loop-redirections-stdin.comparison.test.ts
@@ -57,6 +57,30 @@ describe("loop stdin redirections - Real Bash Comparison", () => {
       );
     });
 
+    it("should send output to the last target with > a < in > b", async () => {
+      const env = await setupFiles(testDir, { "in.txt": "e\nf\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "{$l}"; done > a.txt < in.txt > b.txt',
+          'echo "a=[$(cat a.txt)] b=[$(cat b.txt)]"',
+        ].join("\n"),
+      );
+    });
+
+    it("should truncate before reading with > f < f", async () => {
+      const env = await setupFiles(testDir, { "f.txt": "l1\nl2\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "got:$l"; done > f.txt < f.txt',
+          'echo "rc=$? f=[$(cat f.txt)]"',
+        ].join("\n"),
+      );
+    });
+
     it("should keep plain `done < file` working", async () => {
       const env = await setupFiles(testDir, { "in.txt": "one\ntwo\n" });
       await compareOutputs(

--- a/packages/just-bash/src/comparison-tests/loop-redirections-stdin.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/loop-redirections-stdin.comparison.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Loop-level input redirection (`done < file`, here-docs, here-strings, pipes)
+ * combined with output redirection, plus nested and piped loops.
+ *
+ * As in loop-redirections.comparison.test.ts, each case prints the redirect
+ * target so file contents land in the compared stdout.
+ *
+ * The two missing-input-file fixtures are locked. The runner compares stdout
+ * and exit code only, but it still RECORDS stderr, and bash's
+ * "No such file or directory" diagnostic carries a script line-number prefix
+ * that differs between 3.2 and 5.x — re-recording on another bash would
+ * rewrite those strings and fail the comparison-tests workflow on the git
+ * diff. Their stdout and exit code are version-stable, so locking loses no
+ * coverage.
+ */
+describe("loop stdin redirections - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  describe("input redirection combined with output redirection", () => {
+    it("should read a file and write another (while)", async () => {
+      const env = await setupFiles(testDir, { "in.txt": "a\nb\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "[$l]"; done < in.txt > out.txt',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should read a file and write another (until)", async () => {
+      const env = await setupFiles(testDir, { "in.txt": "c\nd\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'until ! read l; do echo "<$l>"; done < in.txt > out.txt',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should keep plain `done < file` working", async () => {
+      const env = await setupFiles(testDir, { "in.txt": "one\ntwo\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        'while read l; do echo "got:$l"; done < in.txt',
+      );
+    });
+
+    it("should redirect a here-doc-fed loop", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "h:$l"; done > out.txt <<EOF',
+          "alpha",
+          "beta",
+          "EOF",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect a here-string-fed loop", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "s:$l"; done <<< "hello" > out.txt',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should not glob-expand a here-string target", async () => {
+      const env = await setupFiles(testDir, { aglob1: "", aglob2: "" });
+      await compareOutputs(
+        env,
+        testDir,
+        'while read l; do echo "s:[$l]"; done <<< *',
+      );
+    });
+
+    // Fixture 98da27b468bc4899 is locked: recorded stderr is
+    // bash-version-sensitive (see file header).
+    it("should not truncate a later target when the input file is missing", async () => {
+      const env = await setupFiles(testDir, { "out.txt": "keep\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'while read l; do echo "$l"; done < nosuch.txt > out.txt',
+          'echo "rc=$?"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    // Fixture ad1c8cf5e7b450d8 is locked: recorded stderr is
+    // bash-version-sensitive (see file header).
+    it("should report a missing input file for until loops", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          'until ! read l; do echo "$l"; done < nosuch.txt',
+          'echo "rc=$?"',
+        ].join("\n"),
+      );
+    });
+  });
+
+  describe("nesting and pipelines", () => {
+    it("should redirect an outer for loop containing a while loop", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "for i in 1 2; do",
+          '  while true; do echo "n$i"; break; done',
+          "done > out.txt",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect nested while loops independently", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do",
+          "  while true; do echo inner; break; done > inner.txt",
+          "  echo outer",
+          "  break",
+          "done > outer.txt",
+          'echo "inner=[$(cat inner.txt)] outer=[$(cat outer.txt)]"',
+        ].join("\n"),
+      );
+    });
+
+    it("should apply the redirect before the pipe", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do echo x; break; done > out.txt | cat",
+          'echo "---"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should merge stderr into the pipe with 2>&1", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        "while true; do echo o; echo e >&2; break; done 2>&1 | cat",
+      );
+    });
+
+    it("should feed a piped until loop from stdin", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "printf 'p1\\np2\\n' | until ! read l; do echo \"u:$l\"; done > out.txt",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/comparison-tests/loop-redirections.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/loop-redirections.comparison.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Output redirections attached to a whole loop (`while ... done > file`).
+ *
+ * Every case ends by printing the redirect target so the file contents show up
+ * in the compared stdout.
+ *
+ * Two fixtures here are locked, because their RECORDED stderr is
+ * bash-version-sensitive even though the runner only compares stdout and exit
+ * code: bash prefixes redirection diagnostics with the script line number
+ * ("cannot overwrite existing file", "Is a directory"), and the line bash
+ * attributes them to differs between 3.2 and 5.x. Re-recording on another bash
+ * would rewrite those strings and make the comparison-tests workflow fail on
+ * the resulting git diff. Their stdout and exit code are version-stable, so
+ * locking loses no coverage.
+ *
+ * Loop-level input redirection lives in
+ * loop-redirections-stdin.comparison.test.ts.
+ */
+describe("loop output redirections - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  describe("while loops", () => {
+    it("should discard output redirected to /dev/null", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        "while true; do echo x; break; done >/dev/null; echo end",
+      );
+    });
+
+    it("should write loop output to a file", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'while [ $i -lt 3 ]; do echo "line$i"; i=$((i + 1)); done > out.txt',
+          'echo "---"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should append loop output with >>", async () => {
+      const env = await setupFiles(testDir, { "out.txt": "pre\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'while [ $i -lt 2 ]; do echo "l$i"; i=$((i + 1)); done >> out.txt',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect stderr with 2>", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'while [ $i -lt 2 ]; do echo "o$i"; echo "e$i" >&2; i=$((i + 1)); done 2> err.txt',
+          'echo "---"',
+          "cat err.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should merge stderr into the file with > out 2>&1", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do echo o; echo e >&2; break; done > out.txt 2>&1",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should keep stderr on stdout with 2>&1 > out", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do echo o; echo e >&2; break; done 2>&1 > out.txt",
+          'echo "---"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should send both streams to a file with &>", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do echo o; echo e >&2; break; done &> both.txt",
+          "cat both.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect output produced by the loop condition", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'while echo "cond$i"; [ $i -lt 1 ]; do echo "body$i"; i=$((i + 1)); done > out.txt',
+          'echo "---"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should truncate the target before the loop body reads it", async () => {
+      const env = await setupFiles(testDir, { "data.txt": "hi\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do cat data.txt; break; done > data.txt",
+          'echo "[$(cat data.txt)]"',
+        ].join("\n"),
+      );
+    });
+
+    it("should expand the redirect target before running the body", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "n=0",
+          'while true; do echo body; break; done > "f$((n++)).txt"',
+          'echo "n=$n"',
+          "cat f0.txt",
+        ].join("\n"),
+      );
+    });
+
+    // Fixture eb83615d48785472 is locked: recorded stderr carries a
+    // bash-version-sensitive "line N:" prefix (see file header).
+    it("should fail when the target is a directory", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "mkdir adir",
+          "while true; do echo x; break; done > adir",
+          'echo "rc=$?"',
+        ].join("\n"),
+      );
+    });
+
+    // Fixture 240730055fc830ec is locked: recorded stderr carries a
+    // bash-version-sensitive "line N:" prefix (see file header).
+    it("should honor noclobber", async () => {
+      const env = await setupFiles(testDir, { "out.txt": "keep\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "set -o noclobber",
+          "while true; do echo new; break; done > out.txt",
+          'echo "rc=$?"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should override noclobber with >|", async () => {
+      const env = await setupFiles(testDir, { "out.txt": "keep\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "set -o noclobber",
+          "while true; do echo new; break; done >| out.txt",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should keep the last of two stdout targets", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "while true; do echo m; break; done > a.txt > b.txt",
+          'echo "a=[$(cat a.txt)] b=[$(cat b.txt)]"',
+        ].join("\n"),
+      );
+    });
+  });
+
+  describe("until loops", () => {
+    it("should write loop output to a file", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'until [ $i -ge 2 ]; do echo "u$i"; i=$((i + 1)); done > out.txt',
+          'echo "---"',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should append loop output with >>", async () => {
+      const env = await setupFiles(testDir, { "out.txt": "start\n" });
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'until [ $i -ge 2 ]; do echo "a$i"; i=$((i + 1)); done >> out.txt',
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect stderr with 2>", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          'until [ $i -ge 2 ]; do echo "e$i" >&2; i=$((i + 1)); done 2> err.txt',
+          "cat err.txt",
+        ].join("\n"),
+      );
+    });
+
+    it("should redirect around break and continue", async () => {
+      const env = await setupFiles(testDir, {});
+      await compareOutputs(
+        env,
+        testDir,
+        [
+          "i=0",
+          "until [ $i -ge 4 ]; do",
+          "  i=$((i + 1))",
+          "  if [ $i -eq 2 ]; then continue; fi",
+          "  if [ $i -eq 4 ]; then break; fi",
+          '  echo "u$i"',
+          "done > out.txt",
+          "cat out.txt",
+        ].join("\n"),
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/control-flow.loop-redirection-order.test.ts
+++ b/packages/just-bash/src/interpreter/control-flow.loop-redirection-order.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * Left-to-right processing of a loop's redirection list.
+ *
+ * Bash installs loop redirections in order, so a failing one leaves every
+ * earlier redirection already applied: `done > out < nosuch` truncates `out`
+ * and then fails, while `done < nosuch > out` fails first and never touches
+ * `out`. Reported by the Vercel review bot on control-flow.ts:134.
+ *
+ * Every expectation here was measured against real bash before being written,
+ * and is identical on /bin/bash 3.2.57 and /opt/homebrew/bin/bash 5.3.15.
+ */
+describe("while/until loop redirection order", () => {
+  describe("output redirection before a failing input redirection", () => {
+    it("should truncate an earlier > target", async () => {
+      const env = new Bash({ files: { "/o.txt": "keep\n" } });
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done > o.txt < nosuch
+        echo "rc=$?"
+        echo "o=[$(cat o.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\no=[]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should truncate an earlier > target on until loops", async () => {
+      const env = new Bash({ files: { "/o.txt": "keep\n" } });
+      const result = await env.exec(`
+        cd /
+        until false; do echo u; break; done > o.txt < nosuch
+        echo "rc=$?"
+        echo "o=[$(cat o.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\no=[]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should leave an earlier >> target's contents alone", async () => {
+      const env = new Bash({ files: { "/o.txt": "keep\n" } });
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done >> o.txt < nosuch
+        echo "rc=$?"
+        echo "o=[$(cat o.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\no=[keep]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should create a missing >> target before failing", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done >> o.txt < nosuch
+        echo "rc=$?"
+        echo "exists=$([ -e o.txt ] && echo yes || echo no) o=[$(cat o.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\nexists=yes o=[]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should expand an earlier target exactly once", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        cd /
+        n=0
+        while true; do echo x; break; done > "s$((n++)).txt" < nosuch
+        echo "rc=$? n=$n"
+        echo "s0=$([ -e s0.txt ] && echo yes || echo no) s1=$([ -e s1.txt ] && echo yes || echo no)"
+      `);
+      expect(result.stdout).toBe("rc=1 n=1\ns0=yes s1=no\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should route the diagnostic through an earlier 2>", async () => {
+      const env = new Bash({ files: { "/e.txt": "keep\n" } });
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done 2> e.txt < nosuch
+        echo "rc=$?"
+        echo "e=[$(cat e.txt)]"
+      `);
+      expect(result.stdout).toBe(
+        "rc=1\ne=[bash: nosuch: No such file or directory]\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("failing input redirection before an output redirection", () => {
+    it("should leave a later > target untouched", async () => {
+      const env = new Bash({ files: { "/o.txt": "keep\n" } });
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done < nosuch > o.txt
+        echo "rc=$?"
+        echo "o=[$(cat o.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\no=[keep]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should leave a later > target uncreated", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        cd /
+        until false; do echo u; break; done < nosuch > o.txt
+        echo "rc=$?"
+        echo "exists=$([ -e o.txt ] && echo yes || echo no)"
+      `);
+      expect(result.stdout).toBe("rc=1\nexists=no\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("outputs straddling a failing input redirection", () => {
+    it("should apply only the redirections to the left", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "keepa\n", "/b.txt": "keepb\n" },
+      });
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done > a.txt < nosuch > b.txt
+        echo "rc=$?"
+        echo "a=[$(cat a.txt)] b=[$(cat b.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=1\na=[] b=[keepb]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should create only the target to the left", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        cd /
+        while true; do echo x; break; done > a.txt < nosuch > b.txt
+        echo "rc=$?"
+        echo "a=$([ -e a.txt ] && echo yes || echo no) b=$([ -e b.txt ] && echo yes || echo no)"
+      `);
+      expect(result.stdout).toBe("rc=1\na=yes b=no\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should apply an earlier output redirect before a failing here-doc-adjacent input", async () => {
+      const env = new Bash({ files: { "/o.txt": "keep\n" } });
+      const result = await env.exec(`cd /
+while read l; do echo "h:$l"; done > o.txt <<EOF < nosuch
+alpha
+EOF
+echo "rc=$?"
+echo "o=[$(cat o.txt)]"`);
+      expect(result.stdout).toBe("rc=1\no=[]\n");
+      expect(result.stderr).toBe("bash: nosuch: No such file or directory\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("self-referential redirection", () => {
+    it("should truncate before reading with > f < f", async () => {
+      const env = new Bash({ files: { "/f.txt": "l1\nl2\n" } });
+      const result = await env.exec(`
+        cd /
+        while read l; do echo "got:$l"; done > f.txt < f.txt
+        echo "rc=$?"
+        echo "f=[$(cat f.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=0\nf=[]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("success paths keep working", () => {
+    it("should handle > out < in", async () => {
+      const env = new Bash({ files: { "/in.txt": "a\nb\n" } });
+      const result = await env.exec(`
+        cd /
+        while read l; do echo "[$l]"; done > out.txt < in.txt
+        echo "rc=$?"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("rc=0\n[a]\n[b]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should handle < in > out", async () => {
+      const env = new Bash({ files: { "/in.txt": "c\nd\n" } });
+      const result = await env.exec(`
+        cd /
+        until ! read l; do echo "<$l>"; done < in.txt > out.txt
+        echo "rc=$?"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("rc=0\n<c>\n<d>\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should handle an output redirect on each side of the input", async () => {
+      const env = new Bash({ files: { "/in.txt": "e\nf\n" } });
+      const result = await env.exec(`
+        cd /
+        while read l; do echo "{$l}"; done > a.txt < in.txt > b.txt
+        echo "rc=$?"
+        echo "a=[$(cat a.txt)] b=[$(cat b.txt)]"
+      `);
+      expect(result.stdout).toBe("rc=0\na=[] b=[{e}\n{f}]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/control-flow.loop-redirections-flow.test.ts
+++ b/packages/just-bash/src/interpreter/control-flow.loop-redirections-flow.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * Loop-level redirections under multi-level break/continue and inside
+ * pipelines. Companion to control-flow.loop-redirections.test.ts; every
+ * expectation was verified against real bash before being written.
+ */
+describe("while/until loop redirections under flow control", () => {
+  describe("multi-level break and continue", () => {
+    // Only the redirect on the loop that `break 2`/`continue 2` TARGETS is
+    // covered here. Breaking out of an inner loop that carries its own
+    // redirect still leaks that loop's output to the caller, exactly as it
+    // does for `for` — the unwinding error carries the output past
+    // applyRedirections.
+    it("should redirect the loop targeted by break 2", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while true; do
+          while true; do echo inner; break 2; done
+          echo "not reached"
+        done > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("inner\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect the loop targeted by continue 2", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        i=0
+        while [ $i -lt 2 ]; do
+          i=$((i + 1))
+          while true; do echo "d$i"; continue 2; done
+          echo "not reached"
+        done > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("d1\nd2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect the until loop targeted by break 2", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        until false; do
+          until false; do echo uinner; break 2; done
+          echo "not reached"
+        done > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("uinner\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("piped loops", () => {
+    it("should redirect before the pipe", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while true; do echo x; break; done > out.txt | cat
+        echo "---"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("---\nx\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should merge stderr into the pipe with 2>&1", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `while true; do echo o; echo e >&2; break; done 2>&1 | cat`,
+      );
+      expect(result.stdout).toBe("o\ne\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should feed a piped until loop from stdin", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        printf 'p1\\np2\\n' | until ! read l; do echo "u:$l"; done > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("u:p1\nu:p2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/control-flow.loop-redirections.test.ts
+++ b/packages/just-bash/src/interpreter/control-flow.loop-redirections.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * Loop-level redirections (`while ... done > file`, `until ... done 2> file`).
+ *
+ * Bash installs these before the loop runs and keeps them in effect for the
+ * condition and every iteration. Every expectation here was verified against
+ * real bash before being written down.
+ */
+describe("while/until loop-level redirections", () => {
+  describe("stdout redirection", () => {
+    it("should discard loop output with >/dev/null", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `while true; do echo x; break; done >/dev/null; echo end`,
+      );
+      expect(result.stdout).toBe("end\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should write while-loop output to a file", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        i=0
+        while [ $i -lt 3 ]; do echo "line$i"; i=$((i + 1)); done > out.txt
+        echo "---"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("---\nline0\nline1\nline2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should append while-loop output with >>", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        echo pre > out.txt
+        i=0
+        while [ $i -lt 2 ]; do echo "l$i"; i=$((i + 1)); done >> out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("pre\nl0\nl1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should write until-loop output to a file", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        i=0
+        until [ $i -ge 2 ]; do echo "u$i"; i=$((i + 1)); done > out.txt
+        echo "---"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("---\nu0\nu1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect output produced by the loop condition", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        i=0
+        while echo "cond$i"; [ $i -lt 1 ]; do echo "body$i"; i=$((i + 1)); done > out.txt
+        echo "---"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("---\ncond0\nbody0\ncond1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("stderr redirection", () => {
+    it("should send loop stderr to a file with 2>", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        i=0
+        while [ $i -lt 2 ]; do echo "o$i"; echo "e$i" >&2; i=$((i + 1)); done 2> err.txt
+        echo "---"
+        cat err.txt
+      `);
+      expect(result.stdout).toBe("o0\no1\n---\ne0\ne1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should merge stderr into the file with > out 2>&1", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while true; do echo o; echo e >&2; break; done > out.txt 2>&1
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("o\ne\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep stderr on the caller's stdout with 2>&1 > out", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while true; do echo o; echo e >&2; break; done 2>&1 > out.txt
+        echo "---"
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("e\n---\no\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should send both streams to a file with &>", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        until false; do echo o; echo e >&2; break; done &> both.txt
+        cat both.txt
+      `);
+      expect(result.stdout).toBe("o\ne\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("combined with input redirection", () => {
+    it("should read from a file and write to another (while)", async () => {
+      const env = new Bash({ files: { "/in.txt": "a\nb\n" } });
+      const result = await env.exec(`
+        while read l; do echo "[$l]"; done < /in.txt > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("[a]\n[b]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should read from a file and write to another (until)", async () => {
+      const env = new Bash({ files: { "/in.txt": "c\nd\n" } });
+      const result = await env.exec(`
+        until ! read l; do echo "<$l>"; done < /in.txt > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("<c>\n<d>\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep plain `done < file` working", async () => {
+      const env = new Bash({ files: { "/in.txt": "one\ntwo\n" } });
+      const result = await env.exec(
+        `while read l; do echo "got:$l"; done < /in.txt`,
+      );
+      expect(result.stdout).toBe("got:one\ngot:two\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect a here-doc-fed loop", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while read l; do echo "h:$l"; done > out.txt <<EOF
+alpha
+beta
+EOF
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("h:alpha\nh:beta\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should redirect a here-string-fed loop", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        while read l; do echo "s:$l"; done <<< "hello" > out.txt
+        cat out.txt
+      `);
+      expect(result.stdout).toBe("s:hello\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not glob-expand a here-string target", async () => {
+      const env = new Bash({ files: { "/aglob1": "", "/aglob2": "" } });
+      const result = await env.exec(
+        `cd / && while read l; do echo "s:[$l]"; done <<< *`,
+      );
+      expect(result.stdout).toBe("s:[*]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should fail without truncating a later output target", async () => {
+      const env = new Bash({ files: { "/out.txt": "keep\n" } });
+      const result = await env.exec(`
+        while read l; do echo "$l"; done < /nosuch.txt > /out.txt
+        echo "rc=$?"
+        cat /out.txt
+      `);
+      expect(result.stdout).toBe("rc=1\nkeep\n");
+      expect(result.stderr).toBe(
+        "bash: /nosuch.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report a missing input file for until loops", async () => {
+      const env = new Bash();
+      const result = await env.exec(`
+        until ! read l; do echo "$l"; done < /nosuch.txt
+        echo "rc=$?"
+      `);
+      expect(result.stdout).toBe("rc=1\n");
+      expect(result.stderr).toBe(
+        "bash: /nosuch.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/control-flow.loop-stdin-ownership.test.ts
+++ b/packages/just-bash/src/interpreter/control-flow.loop-stdin-ownership.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * Which loops own the shared read stream (`ctx.state.groupStdin`).
+ *
+ * A `while`/`until` loop installs — and therefore restores — stdin only when
+ * it brought its own: an input redirection on the loop, or the stdin handed to
+ * it as a pipeline stage. A stream inherited from an enclosing group must be
+ * left alone so reads inside the loop advance it, otherwise restoring it
+ * rewinds the shared read position and the next `read` re-reads a consumed
+ * line.
+ *
+ * Every expectation here was verified against real bash before being written.
+ */
+describe("while/until loop stdin ownership", () => {
+  describe("inherited streams keep advancing", () => {
+    it("should not rewind the group stream after an until loop", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\n' | { until ! read l; do echo "loop $l"; break; done; read r; echo "after=[$r]"; }`,
+      );
+      expect(result.stdout).toBe("loop a\nafter=[b]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not rewind the group stream after a while loop", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\n' | { while read l; do echo "loop $l"; break; done; read r; echo "after=[$r]"; }`,
+      );
+      expect(result.stdout).toBe("loop a\nafter=[b]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should advance across two sequential until loops", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\n' | { until ! read x; do break; done; until ! read y; do break; done; echo "x=$x y=$y"; }`,
+      );
+      expect(result.stdout).toBe("x=a y=b\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should advance across two sequential while loops", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\n' | { while read x; do break; done; while read y; do break; done; echo "x=$x y=$y"; }`,
+      );
+      expect(result.stdout).toBe("x=a y=b\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should leave the stream at EOF after an until loop drains it", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\n' | { until ! read l; do echo "l=$l"; done; read r; echo "after=[$r] code=$?"; }`,
+      );
+      expect(result.stdout).toBe("l=a\nl=b\nafter=[] code=1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should leave the stream at EOF after a while loop drains it", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\n' | { while read l; do echo "l=$l"; done; read r; echo "after=[$r] code=$?"; }`,
+      );
+      expect(result.stdout).toBe("l=a\nl=b\nafter=[] code=1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should share one stream between nested while loops", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\nd\\n' | while read x; do while read y; do echo "$x-$y"; break; done; done`,
+      );
+      expect(result.stdout).toBe("a-b\nc-d\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should share one stream between nested until loops", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `printf 'a\\nb\\nc\\nd\\n' | until ! read x; do until ! read y; do echo "$x=$y"; break; done; done`,
+      );
+      expect(result.stdout).toBe("a=b\nc=d\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("own streams are installed and restored", () => {
+    it("should restore the outer stream after a redirected while loop", async () => {
+      const env = new Bash({
+        files: { "/four.txt": "a\nb\nc\nd\n", "/inner.txt": "x\ny\n" },
+      });
+      const result = await env.exec(
+        `{ read first; while read l; do echo "in:$l"; break; done < /inner.txt; read r; echo "first=$first r=[$r]"; } < /four.txt`,
+      );
+      expect(result.stdout).toBe("in:x\nfirst=a r=[b]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should restore the outer stream after a redirected until loop", async () => {
+      const env = new Bash({
+        files: { "/four.txt": "a\nb\nc\nd\n", "/inner.txt": "x\ny\n" },
+      });
+      const result = await env.exec(
+        `{ until ! read l; do echo "in:$l"; break; done < /inner.txt; read r; echo "r=[$r]"; } < /four.txt`,
+      );
+      expect(result.stdout).toBe("in:x\nr=[a]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should give a while loop an empty stream from an empty file", async () => {
+      const env = new Bash({
+        files: { "/four.txt": "a\nb\nc\nd\n", "/empty.txt": "" },
+      });
+      const result = await env.exec(
+        `{ while read l; do echo "L$l"; done < /empty.txt; read r; echo "r=[$r]"; } < /four.txt`,
+      );
+      expect(result.stdout).toBe("r=[a]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should give an until loop an empty stream from an empty file", async () => {
+      const env = new Bash({
+        files: { "/four.txt": "a\nb\nc\nd\n", "/empty.txt": "" },
+      });
+      const result = await env.exec(
+        `{ until ! read l; do echo "U$l"; done < /empty.txt; read r; echo "r=[$r]"; } < /four.txt`,
+      );
+      expect(result.stdout).toBe("r=[a]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should restore the outer stream after a here-doc-fed loop", async () => {
+      const env = new Bash({ files: { "/four.txt": "a\nb\nc\nd\n" } });
+      const result = await env.exec(`{ while read l; do echo "h:$l"; done <<EOF
+z1
+EOF
+read r; echo "r=[$r]"; } < /four.txt`);
+      expect(result.stdout).toBe("h:z1\nr=[a]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/control-flow.ts
+++ b/packages/just-bash/src/interpreter/control-flow.ts
@@ -84,22 +84,35 @@ type LoopRedirectPrep =
 /**
  * Prepare the loop-level redirections of a `while`/`until` loop.
  *
- * Bash installs a loop's redirections once, before the loop starts, and keeps
- * them in effect for the condition and every iteration. That happens in two
- * steps here:
+ * Bash installs a loop's redirections once, before the loop starts, keeps them
+ * in effect for the condition and every iteration, and processes the list
+ * STRICTLY LEFT TO RIGHT — so a redirection that fails leaves every earlier
+ * one already applied. `done > out < nosuch` truncates `out` and then fails;
+ * `done < nosuch > out` fails first and leaves `out` alone.
  *
- * 1. Input redirections (`< file`, here-docs, here-strings) are consumed to
- *    produce the stdin the loop body reads from — this is what makes
- *    `while read line; do ...; done < file` work.
- * 2. Every other redirection is treated exactly like the redirections on a
- *    `for`/`case` compound command: pre-opened now (so `>` truncates its
- *    target before the condition can read it) and applied to the loop's
- *    collected output once the loop finishes.
+ * The walk below reproduces that order:
  *
- * Input redirections are deliberately kept out of the pre-open/apply list.
- * They are already fully consumed here, and routing them through
- * `preOpenOutputRedirects` would expand their targets a second time — with
- * here-string globbing semantics that bash does not apply to `<<<`.
+ * - Input redirections (`< file`, here-docs, here-strings) are consumed as
+ *   encountered to produce the stdin the loop body reads from — this is what
+ *   makes `while read line; do ...; done < file` work. A failure here aborts
+ *   with the diagnostic routed through the redirections opened so far, which
+ *   is why `done 2> err < nosuch` lands the message in `err` like bash does.
+ * - Every other redirection is collected into a pending run and pre-opened the
+ *   moment an input redirection (or the end of the list) is reached, using the
+ *   same `preOpenOutputRedirects`/`applyRedirections` pair as `for`/`case`.
+ *   Pre-opening truncates `>` targets before the condition can read them, so
+ *   `done > f < f` sees an empty `f`.
+ *
+ * Two invariants worth preserving when touching this:
+ *
+ * - `ExpandedRedirectTargets` is keyed by POSITION in the array handed to
+ *   `preOpenOutputRedirects`. Each pending run is a fresh call, so its keys
+ *   are rebased onto the accumulated `opened` array before being merged —
+ *   `opened` and `targets` must stay index-coherent for `applyRedirections`.
+ * - Input redirections never enter the pre-open/apply list. They are already
+ *   fully consumed here, and routing them through `preOpenOutputRedirects`
+ *   would expand their targets a second time — with here-string globbing
+ *   semantics that bash does not apply to `<<<`.
  */
 async function prepareLoopRedirections(
   ctx: InterpreterContext,
@@ -107,7 +120,46 @@ async function prepareLoopRedirections(
 ): Promise<LoopRedirectPrep> {
   let ownStdin: string | undefined;
 
+  // Output redirections already pre-opened, in list order, with their
+  // pre-expanded targets keyed by position in `opened`.
+  const opened: RedirectionNode[] = [];
+  const targets: ExpandedRedirectTargets = new Map();
+  // The run of output redirections seen since the last input redirection.
+  let pending: RedirectionNode[] = [];
+
+  /** Pre-open the pending run, rebasing its target keys onto `opened`. */
+  const openPending = async (): Promise<ExecResult | null> => {
+    if (pending.length === 0) {
+      return null;
+    }
+    const run = pending;
+    pending = [];
+    const prepared = await preOpenOutputRedirects(ctx, run);
+    if (prepared.error) {
+      return prepared.error;
+    }
+    const offset = opened.length;
+    for (const [index, target] of prepared.targets) {
+      targets.set(offset + index, target);
+    }
+    opened.push(...run);
+    return null;
+  };
+
   for (const redir of redirections) {
+    if (!LOOP_STDIN_OPERATORS.has(redir.operator)) {
+      pending.push(redir);
+      continue;
+    }
+
+    // Everything to the left of this input redirection is opened first.
+    const openError = await openPending();
+    if (openError) {
+      return {
+        error: await applyRedirections(ctx, openError, opened, targets),
+      };
+    }
+
     if (
       (redir.operator === "<<" || redir.operator === "<<-") &&
       redir.target.type === "HereDoc"
@@ -129,28 +181,26 @@ async function prepareLoopRedirections(
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
         ownStdin = await ctx.fs.readFile(filePath);
       } catch {
-        // A failed input redirection aborts the loop before any output
-        // redirection is opened, so a later `> file` is left untouched.
+        // Redirections to the left are already installed and apply to the
+        // diagnostic; the ones to the right are never opened.
         return {
-          error: failure(`bash: ${target}: No such file or directory\n`),
+          error: await applyRedirections(
+            ctx,
+            failure(`bash: ${target}: No such file or directory\n`),
+            opened,
+            targets,
+          ),
         };
       }
     }
   }
 
-  const outputRedirections = redirections.filter(
-    (redir) => !LOOP_STDIN_OPERATORS.has(redir.operator),
-  );
-  const prepared = await preOpenOutputRedirects(ctx, outputRedirections);
-  if (prepared.error) {
-    return { error: prepared.error };
+  const openError = await openPending();
+  if (openError) {
+    return { error: await applyRedirections(ctx, openError, opened, targets) };
   }
 
-  return {
-    ownStdin,
-    redirections: outputRedirections,
-    targets: prepared.targets,
-  };
+  return { ownStdin, redirections: opened, targets };
 }
 
 /**

--- a/packages/just-bash/src/interpreter/control-flow.ts
+++ b/packages/just-bash/src/interpreter/control-flow.ts
@@ -17,6 +17,7 @@ import type {
   ForNode,
   HereDocNode,
   IfNode,
+  RedirectionNode,
   StatementNode,
   UntilNode,
   WhileNode,
@@ -47,8 +48,138 @@ import { executeCondition } from "./helpers/condition.js";
 import { getErrorMessage } from "./helpers/errors.js";
 import { handleLoopError } from "./helpers/loop.js";
 import { failure, throwExecutionLimit } from "./helpers/result.js";
-import { applyRedirections, preOpenOutputRedirects } from "./redirections.js";
+import {
+  applyRedirections,
+  type ExpandedRedirectTargets,
+  preOpenOutputRedirects,
+} from "./redirections.js";
 import type { InterpreterContext } from "./types.js";
+
+/**
+ * Redirection operators a `while`/`until` loop consumes itself to seed the
+ * stdin its body and condition read from. Everything else on the loop is an
+ * ordinary compound-command redirection handled by preOpen/applyRedirections.
+ */
+const LOOP_STDIN_OPERATORS: ReadonlySet<string> = new Set([
+  "<",
+  "<<",
+  "<<-",
+  "<<<",
+]);
+
+type LoopRedirectPrep =
+  | { error: ExecResult }
+  | {
+      /**
+       * stdin supplied by the loop's OWN input redirections, or undefined when
+       * the loop has none. Distinguishing "no input redirection" from "an input
+       * redirection that produced an empty stream" matters: the first inherits
+       * the enclosing read stream, the second replaces it with an empty one.
+       */
+      ownStdin: string | undefined;
+      redirections: RedirectionNode[];
+      targets: ExpandedRedirectTargets;
+    };
+
+/**
+ * Prepare the loop-level redirections of a `while`/`until` loop.
+ *
+ * Bash installs a loop's redirections once, before the loop starts, and keeps
+ * them in effect for the condition and every iteration. That happens in two
+ * steps here:
+ *
+ * 1. Input redirections (`< file`, here-docs, here-strings) are consumed to
+ *    produce the stdin the loop body reads from — this is what makes
+ *    `while read line; do ...; done < file` work.
+ * 2. Every other redirection is treated exactly like the redirections on a
+ *    `for`/`case` compound command: pre-opened now (so `>` truncates its
+ *    target before the condition can read it) and applied to the loop's
+ *    collected output once the loop finishes.
+ *
+ * Input redirections are deliberately kept out of the pre-open/apply list.
+ * They are already fully consumed here, and routing them through
+ * `preOpenOutputRedirects` would expand their targets a second time — with
+ * here-string globbing semantics that bash does not apply to `<<<`.
+ */
+async function prepareLoopRedirections(
+  ctx: InterpreterContext,
+  redirections: RedirectionNode[],
+): Promise<LoopRedirectPrep> {
+  let ownStdin: string | undefined;
+
+  for (const redir of redirections) {
+    if (
+      (redir.operator === "<<" || redir.operator === "<<-") &&
+      redir.target.type === "HereDoc"
+    ) {
+      const hereDoc = redir.target as HereDocNode;
+      let content = await expandWord(ctx, hereDoc.content);
+      if (hereDoc.stripTabs) {
+        content = content
+          .split("\n")
+          .map((line) => line.replace(/^\t+/, ""))
+          .join("\n");
+      }
+      ownStdin = content;
+    } else if (redir.operator === "<<<" && redir.target.type === "Word") {
+      ownStdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
+    } else if (redir.operator === "<" && redir.target.type === "Word") {
+      const target = await expandWord(ctx, redir.target as WordNode);
+      try {
+        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
+        ownStdin = await ctx.fs.readFile(filePath);
+      } catch {
+        // A failed input redirection aborts the loop before any output
+        // redirection is opened, so a later `> file` is left untouched.
+        return {
+          error: failure(`bash: ${target}: No such file or directory\n`),
+        };
+      }
+    }
+  }
+
+  const outputRedirections = redirections.filter(
+    (redir) => !LOOP_STDIN_OPERATORS.has(redir.operator),
+  );
+  const prepared = await preOpenOutputRedirects(ctx, outputRedirections);
+  if (prepared.error) {
+    return { error: prepared.error };
+  }
+
+  return {
+    ownStdin,
+    redirections: outputRedirections,
+    targets: prepared.targets,
+  };
+}
+
+/**
+ * Decide whether a loop takes ownership of the shared read stream
+ * (`ctx.state.groupStdin`).
+ *
+ * A loop only installs — and therefore only restores — a stdin it brought
+ * itself: its own input redirection (`< file`, here-doc, here-string), or the
+ * stdin handed to it as a pipeline stage. A stream merely INHERITED from an
+ * enclosing group or loop must be left in place, because reads inside the body
+ * advance it and restoring it afterwards would rewind the shared read
+ * position: `printf 'a\nb\n' | { while read x; do break; done; read y; }` has
+ * to see `y=b`, not `y=a`.
+ *
+ * `ownStdin` of `""` still counts as ownership — `done < empty-file` gives the
+ * body an empty stream rather than the enclosing one.
+ */
+function resolveLoopStdin(
+  ownStdin: string | undefined,
+  pipelineStdin: string,
+): { owns: true; stdin: string } | { owns: false } {
+  if (ownStdin !== undefined) {
+    return { owns: true, stdin: ownStdin };
+  }
+  if (pipelineStdin !== "") {
+    return { owns: true, stdin: pipelineStdin };
+  }
+  return { owns: false };
+}
 
 class CompoundOutput {
   private stdoutChunks: string[] = [];
@@ -382,44 +513,20 @@ export async function executeWhile(
   node: WhileNode,
   stdin = "",
 ): Promise<ExecResult> {
+  const prepared = await prepareLoopRedirections(ctx, node.redirections);
+  if ("error" in prepared) {
+    return prepared.error;
+  }
+
   const output = new CompoundOutput(ctx);
   let exitCode = 0;
   let iterations = 0;
 
-  // Process here-doc redirections to get stdin content
-  let effectiveStdin = stdin;
-  for (const redir of node.redirections) {
-    if (
-      (redir.operator === "<<" || redir.operator === "<<-") &&
-      redir.target.type === "HereDoc"
-    ) {
-      const hereDoc = redir.target as HereDocNode;
-      let content = await expandWord(ctx, hereDoc.content);
-      if (hereDoc.stripTabs) {
-        content = content
-          .split("\n")
-          .map((line) => line.replace(/^\t+/, ""))
-          .join("\n");
-      }
-      effectiveStdin = content;
-    } else if (redir.operator === "<<<" && redir.target.type === "Word") {
-      effectiveStdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
-    } else if (redir.operator === "<" && redir.target.type === "Word") {
-      try {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        effectiveStdin = await ctx.fs.readFile(filePath);
-      } catch {
-        const target = await expandWord(ctx, redir.target as WordNode);
-        return failure(`bash: ${target}: No such file or directory\n`);
-      }
-    }
-  }
-
-  // Save and set groupStdin for piped while loops
+  // Install groupStdin only for a stream this loop owns (see resolveLoopStdin)
+  const loopStdin = resolveLoopStdin(prepared.ownStdin, stdin);
   const savedGroupStdin = ctx.state.groupStdin;
-  if (effectiveStdin) {
-    ctx.state.groupStdin = effectiveStdin;
+  if (loopStdin.owns) {
+    ctx.state.groupStdin = loopStdin.stdin;
   }
 
   ctx.state.loopDepth++;
@@ -499,26 +606,53 @@ export async function executeWhile(
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") continue;
         if (loopResult.action === "error") {
-          return output.build(loopResult.exitCode ?? 1);
+          // Apply output redirections before returning
+          return applyRedirections(
+            ctx,
+            output.build(loopResult.exitCode ?? 1),
+            prepared.redirections,
+            prepared.targets,
+          );
         }
         throw loopResult.error;
       }
     }
   } finally {
     ctx.state.loopDepth--;
-    ctx.state.groupStdin = savedGroupStdin;
+    if (loopStdin.owns) {
+      ctx.state.groupStdin = savedGroupStdin;
+    }
   }
 
-  return output.build(exitCode);
+  // Apply output redirections
+  return applyRedirections(
+    ctx,
+    output.build(exitCode),
+    prepared.redirections,
+    prepared.targets,
+  );
 }
 
 export async function executeUntil(
   ctx: InterpreterContext,
   node: UntilNode,
+  stdin = "",
 ): Promise<ExecResult> {
+  const prepared = await prepareLoopRedirections(ctx, node.redirections);
+  if ("error" in prepared) {
+    return prepared.error;
+  }
+
   const output = new CompoundOutput(ctx);
   let exitCode = 0;
   let iterations = 0;
+
+  // Install groupStdin only for a stream this loop owns (see resolveLoopStdin)
+  const loopStdin = resolveLoopStdin(prepared.ownStdin, stdin);
+  const savedGroupStdin = ctx.state.groupStdin;
+  if (loopStdin.owns) {
+    ctx.state.groupStdin = loopStdin.stdin;
+  }
 
   ctx.state.loopDepth++;
   try {
@@ -556,16 +690,31 @@ export async function executeUntil(
         if (loopResult.action === "break") break;
         if (loopResult.action === "continue") continue;
         if (loopResult.action === "error") {
-          return output.build(loopResult.exitCode ?? 1);
+          // Apply output redirections before returning
+          return applyRedirections(
+            ctx,
+            output.build(loopResult.exitCode ?? 1),
+            prepared.redirections,
+            prepared.targets,
+          );
         }
         throw loopResult.error;
       }
     }
   } finally {
     ctx.state.loopDepth--;
+    if (loopStdin.owns) {
+      ctx.state.groupStdin = savedGroupStdin;
+    }
   }
 
-  return output.build(exitCode);
+  // Apply output redirections
+  return applyRedirections(
+    ctx,
+    output.build(exitCode),
+    prepared.redirections,
+    prepared.targets,
+  );
 }
 
 export async function executeCase(

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -547,7 +547,7 @@ export class Interpreter {
       case "While":
         return executeWhile(this.ctx, node, stdin);
       case "Until":
-        return executeUntil(this.ctx, node);
+        return executeUntil(this.ctx, node, stdin);
       case "Case":
         return executeCase(this.ctx, node);
       case "Subshell":


### PR DESCRIPTION
## Summary

Output redirections attached to a `while` or `until` loop were silently dropped:

```bash
while true; do echo x; break; done >/dev/null; echo end
# just-bash: "x\nend"
# bash:      "end"
```

Everything the loop wrote went straight to the caller — `> file`, `>> file`, `2> file`, `2>&1`, `&>` and `>|` on a loop all had no effect. `for`, C-style `for` and `case` were unaffected; only `while`/`until` were missing the wiring.

Found while verifying #328 (pipeline stdin). No issue was filed for it.

## Details

### Root cause

`executeFor`, `executeCStyleFor` and `executeCase` bracket their body with the compound-command redirection pair:

* `preOpenOutputRedirects(ctx, node.redirections)` before the body — expands the targets (so `> "f$((n++)).txt"` bumps `n` first) and truncates `>` targets before anything in the loop can read them.
* `applyRedirections(ctx, bodyResult, node.redirections, targets)` after the body — delivers the collected stdout/stderr to the fds' final sinks.

`executeWhile` did neither. It walked `node.redirections` only to pull *input* redirections (`< file`, here-docs, here-strings) into `ctx.state.groupStdin` — which is why `while read line; do ...; done < file` has always worked — and then returned `output.build(exitCode)` directly, so every output redirection on the loop was ignored. `executeUntil` did not look at `node.redirections` at all, so both its input and its output redirections were dropped.

### The fix

A new `prepareLoopRedirections()` helper in `control-flow.ts` runs the loop's redirection prologue once, and both loops now use it:

1. Input redirections (`<`, `<<`, `<<-`, `<<<`) are consumed to seed the loop's stdin — this is the existing `while` logic, moved.
2. Every remaining redirection is handed to `preOpenOutputRedirects` before the loop and to `applyRedirections` after it, exactly like `for`/`case`.

Two deliberate details:

* **Input redirections are kept out of the pre-open/apply list.** They are already fully consumed in step 1; routing them through `preOpenOutputRedirects` would expand their targets a second time and would apply `expandRedirectTarget`'s globbing to `<<<`, which bash does not do (`done <<< *` must yield a literal `*`). There is a comparison test pinning this.
* **Steps 1 and 2 interleave strictly left to right** (see below), so a failed redirection leaves exactly the redirections to its left applied.

`executeUntil` also gained the `stdin` parameter `executeWhile` already had (dispatch in `interpreter.ts`), so `printf 'a\nb\n' | until ! read l; do ...; done` reads from the pipe. That is the same loop-level redirection code path, and without it `until ... done < in > out` would have been only half fixed.

### Strict left-to-right redirection order

Thanks to the **Vercel review bot**, which flagged on `control-flow.ts:134` that a failing `< file` aborted before any output redirect was pre-opened — so an output redirect standing *to the left* of the failing input was never applied. Bash processes the list in order, so it truncates that target and only then fails.

`prepareLoopRedirections` now walks the list once, in order. Output redirections accumulate into a pending run that is pre-opened the moment an input redirection (or the end of the list) is reached; an input redirection is resolved where it stands, and on failure the diagnostic is routed through exactly the redirections opened so far. Because `ExpandedRedirectTargets` is keyed by position in the array handed to `preOpenOutputRedirects`, each run's keys are rebased onto the accumulated `opened` array before merging, so `opened`/`targets` stay index-coherent for `applyRedirections` — that is what keeps `done > "f$((n++))" < nosuch` expanding its target exactly once (verified: `n=1`, `f0` created, `f1` not).

Measured on `/bin/bash` 3.2.57 **and** `/opt/homebrew/bin/bash` 5.3.15 — byte-identical on both:

| script | bash | before | after |
| --- | --- | --- | --- |
| `done > o < nosuch` (o pre-exists) | `o` truncated, rc=1 | `o` unchanged | matches |
| `done > o < nosuch` on `until` | `o` truncated, rc=1 | `o` unchanged | matches |
| `done >> o < nosuch` (o pre-exists) | `o` kept, rc=1 | `o` kept | matches |
| `done >> o < nosuch` (o missing) | `o` created empty, rc=1 | `o` not created | matches |
| `done > a < nosuch > b` (both exist) | `a` truncated, `b` kept | both kept | matches |
| `done > a < nosuch > b` (neither exists) | `a` created, `b` not | neither created | matches |
| `done 2> e < nosuch` | diagnostic lands **in `e`** | `e` untouched, message to caller | matches |
| `done > "s$((n++))" < nosuch` | `n=1`, `s0` created | `n=0`, nothing created | matches |
| `done > f < f` | `f` truncated first, loop reads nothing, rc=0 | loop echoed the old contents back | matches |
| `done > o <<EOF < nosuch` | `o` truncated, rc=1 | `o` unchanged | matches |
| `done < nosuch > o` | `o` untouched, rc=1 | `o` untouched | unchanged |
| `done > a < in > b` (success) | `a` empty, `b` gets the output | already correct | unchanged |

### Stdin ownership (`resolveLoopStdin`)

Threading `until` through the same prologue exposed a trap in the pre-existing stdin handling: the loops installed `ctx.state.groupStdin` and then restored it *unconditionally* in `finally`, even when they had never installed anything. Restoring a stream the loop merely INHERITED rewinds the shared read position, so the next `read` re-reads a consumed line.

`resolveLoopStdin()` makes ownership explicit. A loop installs — and therefore restores — stdin only when it brought its own: its own input redirection, or the stdin handed to it as a pipeline stage. An inherited stream is left alone so reads inside the body advance it naturally. `ownStdin: ""` still counts as ownership, so `done < empty-file` gives the body an empty stream rather than the enclosing one.

The guard lives in the shared helper, so **`while` gets it too**. That fixes four `while` behaviours that were already wrong on `main` (verified against bash, now covered by tests):

| case | main | branch / bash |
| --- | --- | --- |
| `printf 'a\nb\nc\n' \| { while read l; do break; done; read r; }` | `r=a` | `r=b` |
| two sequential piped `while` reads | `x=a y=a` | `x=a y=b` |
| piped `while` drained to EOF, then `read r` | `r=a`, code 0 | `r=`, code 1 |
| nested `while` sharing one stream (4 lines) | `a-b b-c c-d` | `a-b c-d` |
| `while ... done < empty.txt` inside a group | ate the enclosing stream | leaves it untouched |

Nothing regressed from the guard: `{ while ...; done \| cat; read r; }` and `while` inside a function still behave exactly as on `main` (both are clobbered by the pipeline/function scope layers, not by the loop).

### Bash matrix verified

Every case below was run through `pnpm dev:exec --real-bash` against /bin/bash 3.2.57 before any expectation was written. All now match bash byte-for-byte on stdout:

| case | before | after |
| --- | --- | --- |
| `>/dev/null`, `> file`, `>> file` (while + until) | ignored | matches bash |
| `2> file`, `> out 2>&1`, `2>&1 > out`, `&>` | ignored | matches bash |
| `>\|` and noclobber refusal | ignored | matches bash |
| `> a > b` (two stdout targets) | ignored | matches bash |
| `> dir` → `Is a directory`, exit 1 | body ran, exit 0 | matches bash |
| target truncated before body reads it (`done > f` with `cat f` inside) | stale content | matches bash |
| target side effects (`> "f$((n++)).txt"`) | not expanded | matches bash |
| `\| cat` after the loop, `2>&1 \| cat` | already worked / stderr leaked | matches bash |
| `done < file` (classic read loop) | worked | still works |
| left-to-right ordering of a failing redirection (see table above) | earlier output redirects skipped | matches bash |
| `done < in > out` (while + until) | out empty | matches bash |
| here-doc / here-string + `> out` | out empty | matches bash |
| `done <<< *` (no globbing of here-strings) | literal `*` | still literal `*` |
| `done < nosuch > out` (out not truncated) | out kept | out kept |
| `until ... done < in`, `until` here-doc/here-string, piped `until` | produced nothing | matches bash |
| nested loops, inner and outer redirects | ignored | matches bash |
| `break` / `continue` inside a redirected loop | ignored | matches bash |
| `break 2` / `continue 2` where the redirect is on the loop they TARGET | ignored | matches bash |
| inherited-stream read positions (see table above) | wrong on `while`, would have been wrong on `until` | matches bash |
| `done <&3` (bad fd) | ran the body, exit 0 | `Bad file descriptor`, exit 1 (same as `for`) |

Known deviations left in place. All are pre-existing and shared with `for`, so they are out of scope here:

* `exit`, `return` and errexit unwinding out of a redirected loop still deliver the loop's output to the caller instead of the file (`for` behaves identically — the unwinding error carries the output past `applyRedirections`).
* Same class: `break 2` / `continue 2` out of an INNER loop that carries its own redirect leaks that inner loop's output. `for` does the same (`for a in 1; do for b in 1; do echo x; break 2; done > f; done` leaks `x` on both). Only the redirect on the loop the jump targets is fixed here; that is the case the tests cover.
* `for` and `case` still process their redirection list as "expand and validate everything, then truncate everything", so they keep the ordering divergence that `while`/`until` no longer have: `for i in 1; do echo x; done > out < nosuch` leaves `out` untouched where bash truncates it. Fixing that means reworking `executeFor`/`executeCStyleFor`/`executeCase` and is outside this PR's scope. The same all-then-truncate rule still applies *within* a single run of consecutive output redirections on any compound command (`> a > adir` validates both before truncating `a`) — unchanged here.
* `for ... done < file` still does not feed the body; only `while`/`until` consume loop-level input redirections.
* `done < f > f` echoes the file's old contents back into `f`, where bash ends up with an empty `f`. Our `<` snapshots the file's bytes when the redirection is set up, so a later `> f` cannot affect what the body reads; bash hands the loop a descriptor and reads lazily, after the truncation. The reverse order, `done > f < f`, does now match bash. Unchanged by this PR.
* `done < somedir` reports `bash: somedir: No such file or directory` and exit 1, where bash lets `read` fail with a read error and the loop exits 0. `while` has always behaved this way; `until` previously matched bash only by accident (it ignored the redirection entirely) and now shares `while`'s behaviour. Fixing it means changing how loop input redirection reports a directory, which is `while`'s long-standing path.
* `break` after a failing command reports the failing command's status rather than 0.
* `done < "nosuch$((n++))"` expands its target once (bash expands it twice, once for the failed open and once for the diagnostic, so bash reports `nosuch1` and leaves `n=2`). The branch is the more principled of the two; the divergence is obscure and untested either way.
* `done 3< in` is consumed as the loop's stdin rather than being bound to fd 3. That is a pre-existing wart in `while`'s input handling which `until` now inherits; numeric fds are #326's area.

### Coordination with open PR #326

This branch conflicts semantically (not textually in every hunk) with **#326 (numeric fds)**, which rewrites the same loop functions in `control-flow.ts`:

* #326 wraps the loop bodies in `withNumericFds` and adds `isNumericFdRedirection` skips inside the very input-redirection loop that this PR moved into `prepareLoopRedirections`.
* #326 threads a third `fdTargets` argument through `preOpenOutputRedirects`.
* #326's `executeUntilBody` has no `stdin` parameter, while this PR adds one to `executeUntil`.

Whoever lands second must: re-apply the `isNumericFdRedirection` skip inside `prepareLoopRedirections` (otherwise `done 3< in` keeps being swallowed as loop stdin), thread `fdTargets` through the `preOpenOutputRedirects` call in the helper, and reconcile the `executeUntil`/`executeUntilBody` signature so the pipeline stdin still reaches the loop.

## Tests

* `packages/just-bash/src/interpreter/control-flow.loop-redirections.test.ts` (221 lines, 17 tests) — the output/input redirect matrix, full-string stdout/stderr assertions, including the exact repro (`while true; do echo x; break; done >/dev/null; echo end` → `end\n`).
* `packages/just-bash/src/interpreter/control-flow.loop-redirections-flow.test.ts` (95 lines, 6 tests) — `break 2`/`continue 2` on the targeted loop, plus piped loops.
* `packages/just-bash/src/interpreter/control-flow.loop-stdin-ownership.test.ts` (159 lines, 13 tests) — the ownership rule: inherited streams keep advancing (the three regression cases above, for both `while` and `until`), own streams are installed and restored.
* `packages/just-bash/src/interpreter/control-flow.loop-redirection-order.test.ts` (211 lines, 15 tests) — the left-to-right ordering table above, both directions, plus the success paths.
* `packages/just-bash/src/comparison-tests/loop-redirections.comparison.test.ts` (18 tests — the output-redirection matrix), `loop-redirections-stdin.comparison.test.ts` (15 tests — input redirection, nesting, pipelines) and `loop-redirection-order.comparison.test.ts` (10 tests — the ordering cases), plus their three fixture files. Split to stay under the 300-line house limit. Fixtures recorded with `RECORD_FIXTURES=1` against **GNU bash 3.2.57(1)-release (arm64-apple-darwin25)**.

Every expectation in all seven files was checked against real bash before being written, and replays byte-identically under `/bin/bash` 3.2.57.

**Locked fixtures (13 of 43).** The runner compares only stdout and exit code, but it still *records* stderr into the fixture JSON, and the comparison-tests workflow fails on any git diff after re-recording. Every locked entry is one where a redirection FAILS and bash emits a diagnostic carrying its shell path and `line N:` script position:

| fixtures | case |
| --- | --- |
| `240730055fc830ec` | noclobber refusal (`cannot overwrite existing file`) |
| `eb83615d48785472` | `> adir` (`Is a directory`) |
| `98da27b468bc4899`, `ad1c8cf5e7b450d8` | `done < nosuch.txt` (`No such file or directory`) |
| 9 entries in `loop-redirection-order.comparison.fixtures.json` | the failing-redirection ordering cases |

This was **pre-validated against bash 5.x** rather than guessed: pointing `fixture-runner.ts`'s hardcoded `shell: "/bin/bash"` at `/opt/homebrew/bin/bash` (5.3.15) and re-recording all 43 loop fixtures with `RECORD_FIXTURES=force` changed **stderr on exactly those 13 entries** (`/bin/bash: nosuch:` → `/opt/homebrew/bin/bash: line 1: nosuch:`, `line 1:` → `line 2:`) and left **stdout and exit code byte-identical on all 43** — i.e. just-bash matches both bash versions everywhere, and only the unstable strings needed locking. The runner change was reverted and the bash-3.2 recordings restored. The 30 unlocked entries re-record cleanly, confirmed by a final `RECORD_FIXTURES=1` pass producing no fixture diff.

The one ordering fixture that is deliberately *not* locked is the `2> e.txt < nosuch` case: its diagnostic goes into the redirect target instead of stderr, so its recorded stderr is empty and stable. Its stdout asserts `grep -c 'No such file or directory' e.txt` rather than the message text, so it survives version changes.

* `.changeset/loop-output-redirections.md` — patch bump.

### Verification numbers

Baseline measured on a clean `upstream/main` in the same worktree (`git stash`), with `dist/` rebuilt via `pnpm build` first so the bundle tests behave the same in both runs.

| suite | baseline (upstream/main) | this branch |
| --- | --- | --- |
| `pnpm test:run` (just-bash) | 5 files failed / 518 passed (523); **6 tests failed** / 14287 passed / 97 skipped (14390) | 5 files failed / 525 passed (530); **6 tests failed** / 14381 passed / 97 skipped (14484) |
| `pnpm test:run` (just-bash-executor) | 4 files / 72 passed | 4 files / 72 passed |
| spec tests (`src/spec-tests`) | 3825 passed / 1 skipped | 3825 passed / 1 skipped |
| `pnpm test:comparison` | 35 files / 567 tests | 38 files / 610 tests, all passing |

**Zero new failures.** The 6 failures are identical before and after — all CPython-WASM tests failing on pre-existing LFS-pointer artifacts (`just-bash.bundle.test.ts` python3 lazy-load, `code-exec-exploit-regression`, `defense-in-depth-independence`, `python-sqlite-information-disclosure` ×2, `worker-protocol-runtime-desync`).

Two other tests flaked once each under parallel load while measuring — `find.perf.test.ts` "pure evaluation overhead" (a 5 s-timeout micro-benchmark) and `defense-in-depth-exploit-regression.test.ts` "compat mode (audit)" (cross-file global state). Both pass in isolation, neither appeared in the run reported above, and neither touches loops or redirections.

Also clean: `pnpm typecheck`, `pnpm lint` (biome + workflow security + `lint:banned`), `pnpm lint:fix`, `pnpm knip`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
