### PR TITLE
fix(interpreter): groups no longer rewind stdin they never replaced

### DIFF
--- a/.changeset/eighty-jars-attack.md
+++ b/.changeset/eighty-jars-attack.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Stop command groups, function bodies and `eval` from rewinding stdin they never replaced, so `{ { read a; }; read b; }` gives `b` the second line instead of replaying the first.

--- a/packages/just-bash/src/comparison-tests/fixtures/group-stdin.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/group-stdin.comparison.fixtures.json
@@ -1,0 +1,234 @@
+{
+  "07b73d845debc1bd": {
+    "command": "{ { { read a; }; }; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "0c9e0ea31e2c8880": {
+    "command": "{ read a; while read x; do echo \"X:$x\"; done < other.txt; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "other.txt": "O1\nO2\nO3\n"
+    },
+    "stdout": "X:O1\nX:O2\nX:O3\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "124dbc51aae2bf1d": {
+    "command": "{ eval 'read a; echo \"a=[$a]\"' < other.txt; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "other.txt": "O1\nO2\nO3\n"
+    },
+    "stdout": "a=[O1]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "28a816d2d3632e61": {
+    "command": "f() { read x; echo \"x=[$x]\"; } < empty.txt; { read a; f; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "empty.txt": ""
+    },
+    "stdout": "x=[]\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2ccccd0e98d641dd": {
+    "command": "{ eval 'while read l; do echo \"E:$l\"; done'; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "E:L1\nE:L2\nE:L3\nE:L4\nE:L5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3a0c611cda10a437": {
+    "command": "{ eval 'read a; read c'; read b; echo \"a=[$a] c=[$c] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1] c=[L2] b=[L3]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "583d99b0e8a38d6f": {
+    "command": "{ read a; { read x; echo \"x=[$x]\"; } < empty.txt; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "empty.txt": ""
+    },
+    "stdout": "x=[]\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5b9b4e1d1a1ebc39": {
+    "command": "{ { read a; echo \"a=[$a]\"; } <<< \"S1\"; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[S1]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5bb969bda6c97a80": {
+    "command": "{ { read a; echo \"a=[$a]\"; } <<EOT\nH1\nEOT\nread b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[H1]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "6723871c6848c7a5": {
+    "command": "n=0; while read a; do n=$((n+1)); { echo x | cat; } >/dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "6b84ec4bde6c8e9a": {
+    "command": "{ read a; { read x; echo \"x=[$x]\"; } < other.txt; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "other.txt": "O1\nO2\nO3\n"
+    },
+    "stdout": "x=[O1]\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "731214683b5fc3a6": {
+    "command": "{ { read a; }; cat; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "L2\nL3\nL4\nL5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "760a355a7212adc4": {
+    "command": "{ read a; eval 'read x; echo \"x=[$x]\"' < empty.txt; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "empty.txt": ""
+    },
+    "stdout": "x=[]\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "7a0dda5553691c92": {
+    "command": "{ { read a; } >/dev/null; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "9521f508de0a5238": {
+    "command": "f() { read a; echo \"in=[$a]\"; }; { f < other.txt; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "other.txt": "O1\nO2\nO3\n"
+    },
+    "stdout": "in=[O1]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "97e5ad35e4af1b3d": {
+    "command": "{ { read a; read c; read d; read e; read f; }; read b; rc=$?; echo \"b=[$b] rc=$rc\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "b=[] rc=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "a231c0764f0775ef": {
+    "command": "while read a; do { read b; }; echo \"pair=[$a][$b]\"; done < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "pair=[L1][L2]\npair=[L3][L4]\npair=[L5][]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ab20cba35b9c7797": {
+    "command": "{ { read a; }; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b47daf8cad1ca4be": {
+    "command": "f() { read q; }; n=0; while read x; do n=$((n+1)); f < /dev/null; done < loop.txt; echo \"iterations: $n\"",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "iterations: 5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "c3fae8a5b19f99bf": {
+    "command": "f() { read b; echo \"f got [$b]\"; }; while read a; do echo \"a=[$a]\"; f; done < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1]\nf got [L2]\na=[L3]\nf got [L4]\na=[L5]\nf got []\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "d924d9289c2082ed": {
+    "command": "{ { { read a; }; read c; }; read b; echo \"a=[$a] c=[$c] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "a=[L1] c=[L2] b=[L3]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f0af781cec488a1b": {
+    "command": "f() { read a; echo \"in=[$a]\"; }; { f; f; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n"
+    },
+    "stdout": "in=[L1]\nin=[L2]\nb=[L3]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f4df2257ae8b19cc": {
+    "command": "f() { read a; echo \"in=[$a]\"; } < other.txt; { f; read b; echo \"b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "other.txt": "O1\nO2\nO3\n"
+    },
+    "stdout": "in=[O1]\nb=[L1]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f982dfb1f4639a74": {
+    "command": "{ { read a; }; read b; echo \"a=[$a] b=[$b]\"; } <<EOT\nH1\nH2\nEOT",
+    "files": {},
+    "stdout": "a=[H1] b=[H2]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "fa64576a9465b0df": {
+    "command": "f() { read x; echo \"x=[$x]\"; }; { read a; f < empty.txt; read b; echo \"a=[$a] b=[$b]\"; } < loop.txt",
+    "files": {
+      "loop.txt": "L1\nL2\nL3\nL4\nL5\n",
+      "empty.txt": ""
+    },
+    "stdout": "x=[]\na=[L1] b=[L2]\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/group-stdin.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/group-stdin.comparison.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Groups, functions and `eval` restore only the stdin they actually replaced.
+ * Recorded against GNU bash 3.2.57. Every command redirects stdin at its
+ * outermost level so recording never blocks on the recorder's own stdin.
+ */
+
+const FIVE_LINES = { "loop.txt": "L1\nL2\nL3\nL4\nL5\n" };
+const TWO_FILES = { ...FIVE_LINES, "other.txt": "O1\nO2\nO3\n" };
+
+describe("group/function/eval stdin - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  it("an inner group's read advances the shared position", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { read a; }; read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("three nested groups still share one position", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { { read a; }; }; read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("reads inside and outside an inner group interleave", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { { read a; }; read c; }; read b; echo "a=[$a] c=[$c] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a group that read to EOF leaves the next read at EOF", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      "{ { read a; read c; read d; read e; read f; }; " +
+        'read b; rc=$?; echo "b=[$b] rc=$rc"; } < loop.txt',
+    );
+  });
+
+  it("an output redirection does not give the group its own stdin", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { read a; } >/dev/null; read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("cat after an inner group starts where the group stopped", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(env, testDir, "{ { read a; }; cat; } < loop.txt");
+  });
+
+  it("`< file` on the inner group leaves the outer position untouched", async () => {
+    const env = await setupFiles(testDir, TWO_FILES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ read a; { read x; echo "x=[$x]"; } < other.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("an empty file on the inner group means EOF inside", async () => {
+    const env = await setupFiles(testDir, { ...FIVE_LINES, "empty.txt": "" });
+    await compareOutputs(
+      env,
+      testDir,
+      '{ read a; { read x; echo "x=[$x]"; } < empty.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a heredoc on the inner group leaves the outer position untouched", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { read a; echo "a=[$a]"; } <<EOT\nH1\nEOT\n' +
+        'read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a here-string on the inner group leaves the outer position untouched", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { read a; echo "a=[$a]"; } <<< "S1"; read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a heredoc on the outer group is the shared position", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(
+      env,
+      testDir,
+      '{ { read a; }; read b; echo "a=[$a] b=[$b]"; } <<EOT\nH1\nH2\nEOT',
+    );
+  });
+
+  it("a function that reads leaves the caller at the next line", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read a; echo "in=[$a]"; }; ' +
+        '{ f; f; read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a redirection on the function definition gives it its own stdin", async () => {
+    const env = await setupFiles(testDir, TWO_FILES);
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read a; echo "in=[$a]"; } < other.txt; ' +
+        '{ f; read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a redirection on the call gives the function its own stdin", async () => {
+    const env = await setupFiles(testDir, TWO_FILES);
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read a; echo "in=[$a]"; }; ' +
+        '{ f < other.txt; read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a loop body calling a reading function consumes two lines per turn", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read b; echo "f got [$b]"; }; ' +
+        'while read a; do echo "a=[$a]"; f; done < loop.txt',
+    );
+  });
+
+  it("a read inside eval advances the shared position", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      "{ eval 'read a; read c'; read b; " +
+        'echo "a=[$a] c=[$c] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a read loop inside eval sees every line", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      "{ eval 'while read l; do echo \"E:$l\"; done'; } < loop.txt",
+    );
+  });
+
+  it("a redirection on eval gives it its own stdin", async () => {
+    const env = await setupFiles(testDir, TWO_FILES);
+    await compareOutputs(
+      env,
+      testDir,
+      "{ eval 'read a; echo \"a=[$a]\"' < other.txt; " +
+        'read b; echo "b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("an empty file on the call means EOF inside the function", async () => {
+    const env = await setupFiles(testDir, { ...FIVE_LINES, "empty.txt": "" });
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read x; echo "x=[$x]"; }; { read a; f < empty.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("an empty file on the definition means EOF inside the function", async () => {
+    const env = await setupFiles(testDir, { ...FIVE_LINES, "empty.txt": "" });
+    await compareOutputs(
+      env,
+      testDir,
+      'f() { read x; echo "x=[$x]"; } < empty.txt; { read a; f; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("an empty file on eval means EOF inside eval", async () => {
+    const env = await setupFiles(testDir, { ...FIVE_LINES, "empty.txt": "" });
+    await compareOutputs(
+      env,
+      testDir,
+      "{ read a; eval 'read x; echo \"x=[$x]\"' < empty.txt; " +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+
+  it("a loop body shielded with /dev/null still runs once per line", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      "f() { read q; }; n=0; while read x; do n=$((n+1)); f < /dev/null; " +
+        'done < loop.txt; echo "iterations: $n"',
+    );
+  });
+
+  it("a group in the loop body pairs the lines two at a time", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      'while read a; do { read b; }; echo "pair=[$a][$b]"; done < loop.txt',
+    );
+  });
+
+  it("a pipeline inside a group body keeps the loop running per line", async () => {
+    const env = await setupFiles(testDir, FIVE_LINES);
+    await compareOutputs(
+      env,
+      testDir,
+      "n=0; while read a; do n=$((n+1)); { echo x | cat; } >/dev/null; " +
+        'done < loop.txt; echo "iterations: $n"',
+    );
+  });
+
+  it("a loop with its own stdin leaves the enclosing position alone", async () => {
+    const env = await setupFiles(testDir, TWO_FILES);
+    await compareOutputs(
+      env,
+      testDir,
+      '{ read a; while read x; do echo "X:$x"; done < other.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < loop.txt',
+    );
+  });
+});

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -87,6 +87,7 @@ export type RunCommandFn = (
   skipFunctions?: boolean,
   useDefaultPath?: boolean,
   stdinSourceFd?: number,
+  stdinRedirected?: boolean,
 ) => Promise<ExecResult>;
 
 interface RevocableCommandContext {
@@ -417,6 +418,13 @@ export async function dispatchBuiltin(
   skipFunctions: boolean,
   _useDefaultPath: boolean,
   stdinSourceFd: number,
+  /**
+   * True when a redirection gave this command its own fd 0. `stdin` alone
+   * cannot express it: `cmd < empty-file` and an unredirected command both
+   * arrive as `""`, but only the first means EOF rather than "inherit the
+   * shell's stdin".
+   */
+  stdinRedirected = false,
 ): Promise<ExecResult | null> {
   const { ctx, runCommand } = dispatchCtx;
 
@@ -453,7 +461,7 @@ export async function dispatchBuiltin(
   // In POSIX mode, eval is a special builtin that cannot be overridden by functions
   // In non-POSIX mode (bash default), functions can override eval
   if (commandName === "eval" && ctx.state.options.posix) {
-    return handleEval(ctx, args, stdin);
+    return handleEval(ctx, args, stdin, stdinRedirected);
   }
   if (commandName === "shift") {
     return handleShift(ctx, args);
@@ -499,7 +507,7 @@ export async function dispatchBuiltin(
   if (!skipFunctions) {
     const func = ctx.state.functions.get(commandName);
     if (func) {
-      return callFunction(ctx, func, args, stdin);
+      return callFunction(ctx, func, args, stdin, undefined, stdinRedirected);
     }
   }
   // Internal transform primitive, reached through `builtin` so a user-defined
@@ -532,7 +540,7 @@ export async function dispatchBuiltin(
   // Simple builtins (can be overridden by functions)
   // eval: In non-POSIX mode, functions can override eval (handled above for POSIX mode)
   if (commandName === "eval") {
-    return handleEval(ctx, args, stdin);
+    return handleEval(ctx, args, stdin, stdinRedirected);
   }
   if (commandName === "cd") {
     return await handleCd(ctx, args);
@@ -547,10 +555,10 @@ export async function dispatchBuiltin(
     return handleLet(ctx, args);
   }
   if (commandName === "command") {
-    return handleCommandBuiltin(dispatchCtx, args, stdin);
+    return handleCommandBuiltin(dispatchCtx, args, stdin, stdinRedirected);
   }
   if (commandName === "builtin") {
-    return handleBuiltinBuiltin(dispatchCtx, args, stdin);
+    return handleBuiltinBuiltin(dispatchCtx, args, stdin, stdinRedirected);
   }
   if (commandName === "shopt") {
     return handleShopt(ctx, args);
@@ -561,7 +569,9 @@ export async function dispatchBuiltin(
       return OK;
     }
     const [cmd, ...rest] = args;
-    return runCommand(cmd, rest, [], stdin, false, false, -1);
+    // Re-dispatch with the same stdin, so the wrapped command inherits fd-0
+    // ownership too (`exec cmd < empty-file` is EOF, not "no redirection").
+    return runCommand(cmd, rest, [], stdin, false, false, -1, stdinRedirected);
   }
   if (commandName === "wait") {
     // wait - wait for background jobs (stub: no-op in this context)
@@ -605,6 +615,8 @@ async function handleCommandBuiltin(
   dispatchCtx: BuiltinDispatchContext,
   args: string[],
   stdin: string,
+  /** Forwarded to the wrapped command: it runs on this command's fd 0. */
+  stdinRedirected = false,
 ): Promise<ExecResult> {
   const { ctx, runCommand } = dispatchCtx;
 
@@ -649,7 +661,16 @@ async function handleCommandBuiltin(
   // Run command without checking functions, but builtins are still available
   // Pass useDefaultPath to use /usr/bin:/bin instead of $PATH
   const [cmd, ...rest] = cmdArgs;
-  return runCommand(cmd, rest, [], stdin, true, useDefaultPath, -1);
+  return runCommand(
+    cmd,
+    rest,
+    [],
+    stdin,
+    true,
+    useDefaultPath,
+    -1,
+    stdinRedirected,
+  );
 }
 
 /**
@@ -659,6 +680,8 @@ async function handleBuiltinBuiltin(
   dispatchCtx: BuiltinDispatchContext,
   args: string[],
   stdin: string,
+  /** Forwarded to the wrapped builtin: it runs on this command's fd 0. */
+  stdinRedirected = false,
 ): Promise<ExecResult> {
   const { runCommand } = dispatchCtx;
 
@@ -682,7 +705,7 @@ async function handleBuiltinBuiltin(
   }
   const [, ...rest] = cmdArgs;
   // Run as builtin (recursive call, skip function lookup)
-  return runCommand(cmd, rest, [], stdin, true, false, -1);
+  return runCommand(cmd, rest, [], stdin, true, false, -1, stdinRedirected);
 }
 
 /**

--- a/packages/just-bash/src/interpreter/builtins/eval.ts
+++ b/packages/just-bash/src/interpreter/builtins/eval.ts
@@ -20,6 +20,12 @@ export async function handleEval(
   ctx: InterpreterContext,
   args: string[],
   stdin?: string,
+  /**
+   * A redirection gave this `eval` its own fd 0. Empty content is still
+   * ownership: `eval '…' < empty-file` means EOF inside, where an
+   * unredirected `eval` shares the shell's stdin.
+   */
+  stdinRedirected = false,
 ): Promise<ExecResult> {
   // Handle options like bash does:
   // -- ends option processing
@@ -50,12 +56,16 @@ export async function handleEval(
     return OK;
   }
 
-  // Save and set groupStdin for piped eval commands
-  // This allows stdin from the pipeline to flow to commands within eval
+  // `eval` runs in the current shell, so it restores only the stdin it
+  // actually replaced. A pipeline or a redirection gives it its own fd 0
+  // (`printf … | eval '…'`, `eval '…' < file`) and that has to be undone
+  // afterwards. Without one, eval shares the shell's fd 0: reads inside it
+  // move the one shared position, so `{ eval 'read a'; read b; }` must give
+  // `b` the second line rather than replay the first.
   const savedGroupStdin = ctx.state.groupStdin;
-  const effectiveStdin = stdin ?? ctx.state.groupStdin;
-  if (effectiveStdin !== undefined) {
-    ctx.state.groupStdin = effectiveStdin;
+  const ownsStdin = stdinRedirected || (stdin !== undefined && stdin !== "");
+  if (ownsStdin) {
+    ctx.state.groupStdin = stdin ?? "";
   }
 
   try {
@@ -77,7 +87,15 @@ export async function handleEval(
     }
     throw error;
   } finally {
-    // Restore groupStdin
-    ctx.state.groupStdin = savedGroupStdin;
+    // Same rule as command groups: hand the shared position back untouched
+    // only when eval owned fd 0. `undefined` is not a read position, so a body
+    // that cleared shared stdin it does not own (pipeline stages on main, see
+    // #328) gets the inherited position restored rather than propagated.
+    if (
+      ownsStdin ||
+      (savedGroupStdin !== undefined && ctx.state.groupStdin === undefined)
+    ) {
+      ctx.state.groupStdin = savedGroupStdin;
+    }
   }
 }

--- a/packages/just-bash/src/interpreter/functions.ts
+++ b/packages/just-bash/src/interpreter/functions.ts
@@ -49,12 +49,17 @@ export function executeFunctionDef(
 /**
  * Process input redirections to get stdin content for function calls.
  * Handles heredocs (<<, <<-), here-strings (<<<), and file input (<).
+ *
+ * `redirected` is reported separately from the content: `f() { …; } < empty`
+ * yields the same empty string as a definition with no redirection, but it
+ * means EOF inside the function rather than "inherit the shell's stdin".
  */
 async function processInputRedirections(
   ctx: InterpreterContext,
   redirections: RedirectionNode[],
-): Promise<string> {
+): Promise<{ stdin: string; redirected: boolean }> {
   let stdin = "";
+  let redirected = false;
 
   for (const redir of redirections) {
     if (
@@ -74,21 +79,24 @@ async function processInputRedirections(
       const fd = redir.fd ?? 0;
       if (fd === 0) {
         stdin = content;
+        redirected = true;
       }
     } else if (redir.operator === "<<<" && redir.target.type === "Word") {
       stdin = `${await expandWord(ctx, redir.target as WordNode)}\n`;
+      redirected = true;
     } else if (redir.operator === "<" && redir.target.type === "Word") {
       const target = await expandWord(ctx, redir.target as WordNode);
       const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
       try {
         stdin = await ctx.fs.readFile(filePath);
+        redirected = true;
       } catch {
         // File not found - stdin remains unchanged
       }
     }
   }
 
-  return stdin;
+  return { stdin, redirected };
 }
 
 export async function callFunction(
@@ -97,6 +105,8 @@ export async function callFunction(
   args: string[],
   stdin = "",
   callLine?: number,
+  /** A redirection on the call site (`f < file`) gave the function its own fd 0. */
+  stdinRedirected = false,
 ): Promise<ExecResult> {
   ctx.state.callDepth++;
   if (ctx.state.callDepth > ctx.limits.maxCallDepth) {
@@ -243,8 +253,18 @@ export async function callFunction(
       ctx,
       func.redirections,
     );
-    const effectiveStdin = stdin || redirectionStdin;
-    const execResult = await ctx.executeCommand(func.body, effectiveStdin);
+    const effectiveStdin = stdin || redirectionStdin.stdin;
+    // The body owns fd 0 when anything gave the function one: a pipe or a
+    // redirection on the call (`f < file`), or one on the definition
+    // (`f() { …; } < file`). Empty content is still ownership — it means EOF,
+    // not "read the enclosing shell's stdin".
+    const stdinOwned =
+      stdinRedirected || redirectionStdin.redirected || stdin !== "";
+    const execResult = await ctx.executeCommand(
+      func.body,
+      effectiveStdin,
+      stdinOwned,
+    );
     // Apply output redirections from the function definition using pre-expanded targets
     // e.g., fun() { echo hi; } 1>&2 should redirect output to stderr when called
     return applyRedirections(

--- a/packages/just-bash/src/interpreter/group-stdin.constructs.test.ts
+++ b/packages/just-bash/src/interpreter/group-stdin.constructs.test.ts
@@ -1,0 +1,264 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * The "restore only what you replaced" rule for stdin, as it shows up in the
+ * constructs that run their body through a command group: function bodies and
+ * `eval`. Both share the enclosing shell's fd 0 unless a redirection or a
+ * pipeline gives them their own, so reads inside them move the one shared
+ * position instead of being replayed afterwards.
+ *
+ * The read-loop idioms at the bottom are guards: a loop *does* own the stdin
+ * its `done < file` opened, so those must keep running once per line.
+ *
+ * Every expectation below was checked against GNU bash 3.2.57.
+ */
+
+const FIVE_LINES = "L1\nL2\nL3\nL4\nL5\n";
+const OTHER = "O1\nO2\nO3\n";
+
+function makeBash(content = FIVE_LINES): Bash {
+  return new Bash({
+    files: { "/loop.txt": content, "/other.txt": OTHER, "/empty.txt": "" },
+    cwd: "/",
+  });
+}
+
+describe("function bodies share the shell's stdin position", () => {
+  it("a function that reads leaves the caller at the next line", async () => {
+    const result = await makeBash().exec(
+      'f() { read a; echo "in=[$a]"; }; ' +
+        '{ f; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("in=[L1]\nb=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("two calls read two different lines", async () => {
+    const result = await makeBash().exec(
+      'f() { read a; echo "in=[$a]"; }; ' +
+        '{ f; f; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("in=[L1]\nin=[L2]\nb=[L3]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a group nested in the function body shares the same position", async () => {
+    const result = await makeBash().exec(
+      'f() { { read a; }; read c; echo "a=[$a] c=[$c]"; }; ' +
+        '{ f; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] c=[L2]\nb=[L3]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("`return` from inside a group does not rewind the position", async () => {
+    const result = await makeBash().exec(
+      "f() { { read a; return 0; }; }; " +
+        '{ f; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a redirection on the definition gives the function its own stdin", async () => {
+    const result = await makeBash().exec(
+      'f() { read a; echo "in=[$a]"; } < /other.txt; ' +
+        '{ f; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("in=[O1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a redirection on the call gives the function its own stdin", async () => {
+    const result = await makeBash().exec(
+      'f() { read a; echo "in=[$a]"; }; ' +
+        '{ f < /other.txt; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("in=[O1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a loop body calling a reading function consumes two lines per turn", async () => {
+    const result = await makeBash().exec(
+      'f() { read b; echo "f got [$b]"; }; ' +
+        'while read a; do echo "a=[$a]"; f; done < /loop.txt',
+    );
+    expect(result.stdout).toBe(
+      "a=[L1]\nf got [L2]\na=[L3]\nf got [L4]\na=[L5]\nf got []\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("eval shares the shell's stdin position", () => {
+  it("a read inside eval advances the position the next read sees", async () => {
+    const result = await makeBash().exec(
+      '{ eval \'read a\'; echo "a=[$a]"; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1]\nb=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("two reads inside eval consume two lines", async () => {
+    const result = await makeBash().exec(
+      "{ eval 'read a; read c'; read b; " +
+        'echo "a=[$a] c=[$c] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] c=[L2] b=[L3]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a read loop inside eval sees every line of the shell's stdin", async () => {
+    const result = await makeBash().exec(
+      "{ eval 'while read l; do echo \"E:$l\"; done'; } < /loop.txt",
+    );
+    expect(result.stdout).toBe("E:L1\nE:L2\nE:L3\nE:L4\nE:L5\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a redirection on eval gives it its own stdin", async () => {
+    const result = await makeBash().exec(
+      "{ eval 'read a; echo \"a=[$a]\"' < /other.txt; " +
+        'read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[O1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a heredoc on eval gives it its own stdin", async () => {
+    const result = await makeBash().exec(
+      "{ eval 'read a; echo \"a=[$a]\"' <<EOT\nH1\nEOT\n" +
+        'read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[H1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("an empty redirection is still an owned fd 0", () => {
+  // `f < empty-file` hands the body an empty stdin, which is EOF — not "no
+  // redirection, inherit the shell's". The two are the same empty string at
+  // the builtin boundary, so ownership travels beside it as its own flag.
+  const shields: Array<[label: string, script: string]> = [
+    [
+      "a redirection on the call",
+      'f() { read x; echo "x=[$x]"; }; { read a; f < /empty.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+    [
+      "a redirection on the definition",
+      'f() { read x; echo "x=[$x]"; } < /empty.txt; { read a; f; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+    [
+      "/dev/null on the call",
+      'f() { read x; echo "x=[$x]"; }; { read a; f < /dev/null; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+    [
+      "a redirection on eval",
+      "{ read a; eval 'read x; echo \"x=[$x]\"' < /empty.txt; " +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+    [
+      "/dev/null on eval",
+      "{ read a; eval 'read x; echo \"x=[$x]\"' < /dev/null; " +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+    [
+      "an empty file on a group",
+      '{ read a; { read x; echo "x=[$x]"; } < /empty.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    ],
+  ];
+
+  for (const [label, script] of shields) {
+    it(`reads EOF, not the shell's stdin, with ${label}`, async () => {
+      const result = await makeBash().exec(script);
+      expect(result.stdout).toBe("x=[]\na=[L1] b=[L2]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  }
+
+  // The idiom this protects: shielding a loop body from the loop's own stdin.
+  const loopShields: Array<[label: string, body: string]> = [
+    ["a function call", "f < /dev/null"],
+    ["a function call from an empty file", "f < /empty.txt"],
+    ["eval", "eval 'read q' < /dev/null"],
+    ["a group", "{ read q; } < /dev/null"],
+    ["a subshell", "(read q) < /dev/null"],
+  ];
+
+  for (const [label, body] of loopShields) {
+    it(`a loop whose body is ${label} still runs once per line`, async () => {
+      const result = await makeBash().exec(
+        "f() { read q; }; n=0\n" +
+          `while read x; do n=$((n+1)); ${body}; done < /loop.txt\n` +
+          'echo "iterations: $n"',
+      );
+      expect(result.stdout).toBe("iterations: 5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  }
+});
+
+describe("read-loop idioms keep their own stdin", () => {
+  const bodies: Array<[label: string, body: string]> = [
+    ["empty body", ":"],
+    ["command group", "{ echo x; } >/dev/null"],
+    ["subshell", "(echo x) >/dev/null"],
+    ["function call", "f >/dev/null"],
+    ["eval", "eval 'echo x' >/dev/null"],
+    ["pipeline inside a command group", "{ echo x | cat; } >/dev/null"],
+    ["pipeline inside a function", "g >/dev/null"],
+    ["pipeline inside eval", "eval 'echo x | cat' >/dev/null"],
+    ["pipeline inside a subshell", "(echo x | cat) >/dev/null"],
+  ];
+
+  for (const [label, body] of bodies) {
+    it(`runs once per line with ${label} in the body`, async () => {
+      const result = await makeBash().exec(
+        "f() { echo x; }; g() { echo x | cat; }; n=0\n" +
+          `while read a; do n=$((n+1)); ${body}; done < /loop.txt\n` +
+          'echo "iterations: $n"',
+      );
+      expect(result.stdout).toBe("iterations: 5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  }
+
+  it("a group in the loop body pairs the lines two at a time", async () => {
+    const result = await makeBash().exec(
+      'while read a; do { read b; }; echo "pair=[$a][$b]"; done < /loop.txt',
+    );
+    expect(result.stdout).toBe("pair=[L1][L2]\npair=[L3][L4]\npair=[L5][]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a loop with its own stdin leaves the enclosing position alone", async () => {
+    const result = await makeBash().exec(
+      '{ read a; while read x; do echo "X:$x"; done < /other.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("X:O1\nX:O2\nX:O3\na=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/interpreter/group-stdin.test.ts
+++ b/packages/just-bash/src/interpreter/group-stdin.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * A command group restores only the stdin it actually replaced.
+ *
+ * `{ …; } < file` (or a heredoc/here-string on the group) gives the group its
+ * own fd 0, so the enclosing shell's read position survives the group intact.
+ * A group without one shares the shell's fd 0: reads inside it move the single
+ * shared position, and the command after the group must see the line the group
+ * left off at — `{ { read a; }; read b; }` gives `b` the *second* line.
+ *
+ * Found while verifying the pipeline half of the same rule (PR #328): the
+ * inner group used to put the pre-group position back unconditionally, which
+ * replayed every line its body had consumed.
+ *
+ * Every expectation below was checked against GNU bash 3.2.57.
+ */
+
+const FIVE_LINES = "L1\nL2\nL3\nL4\nL5\n";
+const TWO_LINES = "L1\nL2\n";
+const OTHER = "O1\nO2\nO3\n";
+
+function makeBash(content = FIVE_LINES): Bash {
+  return new Bash({
+    files: { "/loop.txt": content, "/other.txt": OTHER, "/empty.txt": "" },
+    cwd: "/",
+  });
+}
+
+describe("group stdin — the repro", () => {
+  it("an inner group's read advances the position the next read sees", async () => {
+    const result = await makeBash(TWO_LINES).exec(
+      '{ { read a; }; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports both variables from the shared position", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; }; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("group stdin — a group without its own fd 0 shares the position", () => {
+  it("nesting three groups deep still advances one position", async () => {
+    const result = await makeBash().exec(
+      '{ { { read a; }; }; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reads inside and outside an inner group interleave", async () => {
+    const result = await makeBash().exec(
+      '{ { { read a; }; read c; }; read b; echo "a=[$a] c=[$c] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] c=[L2] b=[L3]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a group that read to EOF leaves the next read at EOF", async () => {
+    const result = await makeBash().exec(
+      "{ { read a; read c; read d; read e; read f; }; " +
+        'read b; rc=$?; echo "b=[$b] rc=$rc"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("b=[] rc=1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("an output redirection on the group does not make it own stdin", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; } >/dev/null; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("cat after an inner group starts at the line the group left", async () => {
+    const result = await makeBash().exec("{ { read a; }; cat; } < /loop.txt");
+    expect(result.stdout).toBe("L2\nL3\nL4\nL5\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a failing command in the group does not rewind the position", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; grep -q zzz /dev/null; }; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("errexit aborting inside the group leaves no output", async () => {
+    const result = await makeBash().exec(
+      'set -e; { { read a; false; }; read b; echo "b=[$b]"; } < /loop.txt; echo "after"',
+    );
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("break out of a group inside a loop keeps both reads", async () => {
+    const result = await makeBash().exec(
+      'while read a; do { read b; break; }; done < /loop.txt; echo "a=[$a] b=[$b]"',
+    );
+    expect(result.stdout).toBe("a=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("group stdin — a pipeline in the body is not a read", () => {
+  // A pipeline stage clears the shared stdin while it runs (issue #323, fixed
+  // for the pipeline itself in PR #328). `undefined` is not a read position, so
+  // a group that only shared the shell's stdin hands back the position it
+  // inherited rather than propagating the clear.
+  it("a pipeline inside an inner group leaves the position alone", async () => {
+    const result = await makeBash().exec(
+      '{ { echo x | cat; }; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a pipeline that reads nothing consumes nothing", async () => {
+    const result = await makeBash().exec(
+      '{ { true | true; }; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("b=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a pipeline inside eval leaves the position alone", async () => {
+    const result = await makeBash().exec(
+      "{ eval 'echo x | cat'; read b; echo \"b=[$b]\"; } < /loop.txt",
+    );
+    expect(result.stdout).toBe("x\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a read before a pipeline group still advances by one line", async () => {
+    const result = await makeBash().exec(
+      '{ read a; { echo x | cat; }; read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x\na=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("group stdin — a group with its own fd 0 restores the outer position", () => {
+  it("`< file` on the inner group leaves the outer position untouched", async () => {
+    const result = await makeBash().exec(
+      '{ read a; { read x; echo "x=[$x]"; } < /other.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x=[O1]\na=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a heredoc on the inner group leaves the outer position untouched", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; echo "a=[$a]"; } <<EOT\nH1\nEOT\n' +
+        'read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[H1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a here-string on the inner group leaves the outer position untouched", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; echo "a=[$a]"; } <<< "S1"; read b; echo "b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[S1]\nb=[L1]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("an empty file on the inner group means EOF inside, not the outer stdin", async () => {
+    const result = await makeBash().exec(
+      '{ read a; { read x; echo "x=[$x]"; } < /empty.txt; ' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x=[]\na=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("an empty heredoc on the inner group means EOF inside", async () => {
+    const result = await makeBash().exec(
+      '{ read a; { read x; echo "x=[$x]"; } <<EOT\nEOT\n' +
+        'read b; echo "a=[$a] b=[$b]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x=[]\na=[L1] b=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a redirected inner group followed by a loop over the outer stdin", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; echo "a=[$a]"; } < /other.txt; ' +
+        'while read l; do echo "L:$l"; done; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("a=[O1]\nL:L1\nL:L2\nL:L3\nL:L4\nL:L5\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a heredoc on the outer group is the position the inner group shares", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; }; read b; echo "a=[$a] b=[$b]"; } <<EOT\nH1\nH2\nEOT\n',
+    );
+    expect(result.stdout).toBe("a=[H1] b=[H2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("a here-string on the outer group runs out after its single line", async () => {
+    const result = await makeBash().exec(
+      '{ { read a; }; read b; echo "a=[$a] b=[$b]"; } <<< "S1"',
+    );
+    expect(result.stdout).toBe("a=[S1] b=[]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/interpreter/group-stdin.wrappers.test.ts
+++ b/packages/just-bash/src/interpreter/group-stdin.wrappers.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * `command` and `builtin` re-enter dispatch with the *same* stdin, so fd-0
+ * ownership has to travel with it. Without the forward, `command eval '…' <
+ * empty-file` looked unredirected to the wrapped `eval`, which then read the
+ * enclosing shell's stdin instead of seeing EOF — and a loop body shielded
+ * that way lost a line per turn.
+ *
+ * Every expectation below was checked against GNU bash 3.2.57.
+ */
+
+const FIVE_LINES = "L1\nL2\nL3\nL4\nL5\n";
+const OTHER = "O1\nO2\nO3\n";
+const READ_X = "'read x; echo \"x=[$x]\"'";
+
+function makeBash(): Bash {
+  return new Bash({
+    files: { "/loop.txt": FIVE_LINES, "/other.txt": OTHER, "/empty.txt": "" },
+    cwd: "/",
+  });
+}
+
+describe("stdin ownership survives the command/builtin wrappers", () => {
+  const wrappers = ["command", "builtin"] as const;
+
+  for (const wrapper of wrappers) {
+    it(`\`${wrapper} eval\` with an empty file reads EOF, not the shell's stdin`, async () => {
+      const result = await makeBash().exec(
+        `{ ${wrapper} eval ${READ_X} < /empty.txt; ` +
+          'read y; echo "y=[$y]"; } < /loop.txt',
+      );
+      expect(result.stdout).toBe("x=[]\ny=[L1]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(`\`${wrapper} eval\` with /dev/null reads EOF, not the shell's stdin`, async () => {
+      const result = await makeBash().exec(
+        `{ ${wrapper} eval ${READ_X} < /dev/null; ` +
+          'read y; echo "y=[$y]"; } < /loop.txt',
+      );
+      expect(result.stdout).toBe("x=[]\ny=[L1]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(`\`${wrapper} eval\` with a file of its own leaves the shell's position`, async () => {
+      const result = await makeBash().exec(
+        `{ ${wrapper} eval ${READ_X} < /other.txt; ` +
+          'read y; echo "y=[$y]"; } < /loop.txt',
+      );
+      expect(result.stdout).toBe("x=[O1]\ny=[L1]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(`\`${wrapper} eval\` without a redirection shares the shell's position`, async () => {
+      const result = await makeBash().exec(
+        `{ ${wrapper} eval ${READ_X}; read y; echo "y=[$y]"; } < /loop.txt`,
+      );
+      expect(result.stdout).toBe("x=[L1]\ny=[L2]\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it(`a loop body shielded with \`${wrapper} eval … < /dev/null\` runs once per line`, async () => {
+      const result = await makeBash().exec(
+        `n=0; while read q; do n=$((n+1)); ${wrapper} eval 'read x' < /dev/null; ` +
+          'done < /loop.txt; echo "iterations: $n"',
+      );
+      expect(result.stdout).toBe("iterations: 5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  }
+
+  it("`command read` without a redirection still reads the shell's stdin", async () => {
+    const result = await makeBash().exec(
+      '{ command read x; echo "x=[$x]"; read y; echo "y=[$y]"; } < /loop.txt',
+    );
+    expect(result.stdout).toBe("x=[L1]\ny=[L2]\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -531,6 +531,7 @@ export class Interpreter {
   private async executeCommand(
     node: CommandNode,
     stdin: string,
+    stdinOwned = false,
   ): Promise<ExecResult> {
     this.assertDefenseContext("command");
 
@@ -551,9 +552,9 @@ export class Interpreter {
       case "Case":
         return executeCase(this.ctx, node);
       case "Subshell":
-        return this.executeSubshell(node, stdin);
+        return this.executeSubshell(node, stdin, stdinOwned);
       case "Group":
-        return this.executeGroup(node, stdin);
+        return this.executeGroup(node, stdin, stdinOwned);
       case "FunctionDef":
         return executeFunctionDef(this.ctx, node);
       case "ArithmeticCommand":
@@ -710,6 +711,12 @@ export class Interpreter {
     // This allows the read builtin to update the FD's position after reading
     let stdinSourceFd = -1;
 
+    // Whether one of the redirections below gave this command its own fd 0.
+    // The content alone cannot say: `cmd < empty-file` produces the same empty
+    // string as no redirection at all, and the two mean opposite things —
+    // EOF versus "inherit the shell's stdin".
+    let stdinRedirected = false;
+
     for (const redir of node.redirections) {
       if (
         (redir.operator === "<<" || redir.operator === "<<-") &&
@@ -740,6 +747,7 @@ export class Interpreter {
           this.ctx.state.fileDescriptors.set(fd, content);
         } else {
           stdin = content;
+          stdinRedirected = true;
         }
         continue;
       }
@@ -752,6 +760,7 @@ export class Interpreter {
             `${await expandWord(this.ctx, redir.target as WordNode)}\n`,
           ),
         );
+        stdinRedirected = true;
         continue;
       }
 
@@ -763,6 +772,7 @@ export class Interpreter {
           // pipe and we don't want the smart-utf8 read path turning
           // valid bytes into U+FFFD replacement chars.
           stdin = latin1FromBytes(await readBytesFrom(this.ctx.fs, filePath));
+          stdinRedirected = true;
         } catch {
           const target = await expandWord(this.ctx, redir.target as WordNode);
           for (const [name, value] of tempAssignments) {
@@ -788,6 +798,7 @@ export class Interpreter {
                 // Return content starting from current position
                 stdin = parsed.content.slice(parsed.position);
                 stdinSourceFd = sourceFd;
+                stdinRedirected = true;
               }
             } else if (
               fdContent.startsWith("__file__:") ||
@@ -797,6 +808,7 @@ export class Interpreter {
             } else {
               // Plain content (from exec N< file or here-docs)
               stdin = fdContent;
+              stdinRedirected = true;
             }
           }
         }
@@ -908,6 +920,7 @@ export class Interpreter {
             false,
             false,
             stdinSourceFd,
+            stdinRedirected,
           );
         }
         // No args - treat as no-op (status 0)
@@ -1131,6 +1144,7 @@ export class Interpreter {
         false,
         false,
         stdinSourceFd,
+        stdinRedirected,
       );
     } catch (error) {
       // For break/continue, we still need to apply redirections before propagating
@@ -1239,11 +1253,12 @@ export class Interpreter {
     skipFunctions = false,
     useDefaultPath = false,
     stdinSourceFd = -1,
+    stdinRedirected = false,
   ): Promise<ExecResult> {
     const dispatchCtx: BuiltinDispatchContext = {
       ctx: this.ctx,
-      runCommand: (name, a, qa, s, sf, udp, ssf) =>
-        this.runCommand(name, a, qa, s, sf, udp, ssf),
+      runCommand: (name, a, qa, s, sf, udp, ssf, sr) =>
+        this.runCommand(name, a, qa, s, sf, udp, ssf, sr),
       buildExportedEnv: () => this.buildExportedEnv(),
       executeUserScript: (path, a, s) => this.executeUserScript(path, a, s),
     };
@@ -1258,6 +1273,7 @@ export class Interpreter {
       skipFunctions,
       useDefaultPath,
       stdinSourceFd,
+      stdinRedirected,
     );
 
     if (builtinResult !== null) {
@@ -1292,15 +1308,28 @@ export class Interpreter {
   private async executeSubshell(
     node: SubshellNode,
     stdin = "",
+    stdinOwned = false,
   ): Promise<ExecResult> {
-    return executeSubshellHelper(this.ctx, node, stdin, (stmt) =>
-      this.executeStatement(stmt),
+    return executeSubshellHelper(
+      this.ctx,
+      node,
+      stdin,
+      (stmt) => this.executeStatement(stmt),
+      stdinOwned,
     );
   }
 
-  private async executeGroup(node: GroupNode, stdin = ""): Promise<ExecResult> {
-    return executeGroupHelper(this.ctx, node, stdin, (stmt) =>
-      this.executeStatement(stmt),
+  private async executeGroup(
+    node: GroupNode,
+    stdin = "",
+    stdinOwned = false,
+  ): Promise<ExecResult> {
+    return executeGroupHelper(
+      this.ctx,
+      node,
+      stdin,
+      (stmt) => this.executeStatement(stmt),
+      stdinOwned,
     );
   }
 

--- a/packages/just-bash/src/interpreter/subshell-group.ts
+++ b/packages/just-bash/src/interpreter/subshell-group.ts
@@ -50,6 +50,8 @@ export async function executeSubshell(
   node: SubshellNode,
   stdin: string,
   executeStatement: ExecuteStatementFn,
+  /** See `executeGroup`: empty content can still be an owned, empty fd 0. */
+  stdinOwned = false,
 ): Promise<ExecResult> {
   // Pre-open output redirects to truncate files BEFORE executing body
   // This matches bash behavior where redirect files are opened before
@@ -72,7 +74,7 @@ export async function executeSubshell(
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
 
   // Save any existing groupStdin and set new one from pipeline
-  if (stdin) {
+  if (stdinOwned || stdin) {
     ctx.state.groupStdin = stdin;
   }
 
@@ -232,6 +234,12 @@ export async function executeGroup(
   node: GroupNode,
   stdin: string,
   executeStatement: ExecuteStatementFn,
+  /**
+   * The caller already gave this group its own fd 0 — a function body whose
+   * definition or call was redirected. Needed because an empty `stdin` cannot
+   * say whether it came from `< empty-file` or from no redirection at all.
+   */
+  stdinOwned = false,
 ): Promise<ExecResult> {
   const output = new ExecutionOutputAccumulator(ctx.executionScope, "group");
   let exitCode = 0;
@@ -252,8 +260,13 @@ export async function executeGroup(
     return fdVarError;
   }
 
-  // Process heredoc and input redirections to get stdin content
+  // Process heredoc and input redirections to get stdin content.
+  // `ownsStdin` records whether the group gets its *own* fd 0 — from a
+  // pipeline (`… | { …; }`) or from a redirection on the group itself
+  // (`{ …; } < file`, `<<EOT`, `<<<`). A group without one shares the
+  // enclosing shell's stdin, which decides what has to be restored below.
   let effectiveStdin = stdin;
+  let ownsStdin = stdinOwned || stdin !== "";
   for (const redir of node.redirections) {
     if (
       (redir.operator === "<<" || redir.operator === "<<-") &&
@@ -277,17 +290,20 @@ export async function executeGroup(
         ctx.state.fileDescriptors.set(fd, content);
       } else {
         effectiveStdin = content;
+        ownsStdin = true;
       }
     } else if (redir.operator === "<<<" && redir.target.type === "Word") {
       effectiveStdin = `${
         preparedRedirects.targets.get(node.redirections.indexOf(redir)) ?? ""
       }\n`;
+      ownsStdin = true;
     } else if (redir.operator === "<" && redir.target.type === "Word") {
       try {
         const target =
           preparedRedirects.targets.get(node.redirections.indexOf(redir)) ?? "";
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
         effectiveStdin = await ctx.fs.readFile(filePath);
+        ownsStdin = true;
       } catch {
         const target =
           preparedRedirects.targets.get(node.redirections.indexOf(redir)) ?? "";
@@ -296,11 +312,33 @@ export async function executeGroup(
     }
   }
 
-  // Save any existing groupStdin and set new one from pipeline
+  // A group restores only the stdin it actually replaced.
+  //
+  // `{ …; } < file` (or a heredoc/here-string on the group, or a pipe into it)
+  // gives the group its own fd 0, so the enclosing shell's read position has to
+  // come back untouched by whatever the body read.
+  //
+  // A group without one shares the shell's fd 0. Reads inside it move the one
+  // shared position, and `{ { read a; }; read b; }` must therefore give `b` the
+  // *second* line: putting the saved position back would replay a line the
+  // inner group already consumed.
   const savedGroupStdin = ctx.state.groupStdin;
-  if (effectiveStdin) {
+  if (ownsStdin) {
     ctx.state.groupStdin = effectiveStdin;
   }
+  const restoreGroupStdin = (): void => {
+    // A shared stdin can be consumed down to "" but never taken away:
+    // `undefined` means "this scope has no stdin at all", which is not a read
+    // position. If the body left `undefined` where the group inherited a
+    // stream, something inside cleared shared state it does not own (pipeline
+    // stages do on main — see #328) and there is no position to hand back.
+    if (
+      ownsStdin ||
+      (savedGroupStdin !== undefined && ctx.state.groupStdin === undefined)
+    ) {
+      ctx.state.groupStdin = savedGroupStdin;
+    }
+  };
 
   try {
     for (const stmt of node.body) {
@@ -310,7 +348,7 @@ export async function executeGroup(
     }
   } catch (error) {
     // Restore groupStdin before handling error
-    ctx.state.groupStdin = savedGroupStdin;
+    restoreGroupStdin();
     // ExecutionLimitError must always propagate - these are safety limits
     if (error instanceof ExecutionLimitError) {
       output.prependTo(error);
@@ -329,7 +367,7 @@ export async function executeGroup(
   }
 
   // Restore groupStdin
-  ctx.state.groupStdin = savedGroupStdin;
+  restoreGroupStdin();
 
   // Apply output redirections
   const bodyResult = output.build(exitCode);

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -443,7 +443,17 @@ export interface InterpreterContext {
   ) => Promise<ExecResult>;
   executeScript: (node: ScriptNode) => Promise<ExecResult>;
   executeStatement: (node: StatementNode) => Promise<ExecResult>;
-  executeCommand: (node: CommandNode, stdin: string) => Promise<ExecResult>;
+  /**
+   * `stdinOwned` says the caller gave this command its own fd 0, even when the
+   * content is the empty string (`f < empty-file`). Without it an empty stdin
+   * is indistinguishable from "no redirection", and the command would fall
+   * back to the enclosing shell's stdin instead of seeing EOF.
+   */
+  executeCommand: (
+    node: CommandNode,
+    stdin: string,
+    stdinOwned?: boolean,
+  ) => Promise<ExecResult>;
   /** Optional secure fetch function for network-enabled commands */
   fetch?: SecureFetch;
   /** Optional sleep function for testing with mock clocks */


### PR DESCRIPTION
## Summary

A command group put the shell's stdin read position back even when it never replaced it, throwing away everything its body had read. With a two-line file:

```bash
{ { read a; }; read b; echo "b=[$b]"; } < file
# bash:      b=[L2]
# just-bash: b=[L1]
```

The inner group has no redirection of its own, so it shares the shell's fd 0 — the `read` inside it consumes the first line and the next `read` must get the second. just-bash restored the pre-group position instead, so the line came back and every read after a group replayed input. The same restore sits on the path that runs function bodies (a function body *is* a group) and on `eval`, where it was worse: `{ eval 'while read l; do echo "E:$l"; done'; } < file` printed **nothing at all**, because `eval` also installed an empty stdin over the shell's before running its body.

No issue is filed for this. It was found while verifying **#328**, which fixes the pipeline half of the same root pattern: a construct writing to the shared `state.groupStdin` that it does not own. #328 fixes `executePipeline` (a pipeline drained stdin to EOF); this PR fixes the group/function/`eval` side (they rewound it). Different constructs, different files — `pipeline-execution.ts` there, `subshell-group.ts` + `builtins/eval.ts` + the ownership plumbing here — so the two compose. This branch is cut from `upstream/main`, which does **not** contain #328 yet.

Two cases need both patches and are still wrong on this branch alone: `{ { read a; echo "a=[$a]"; } | cat; read b; }` and `printf … | eval '…'` inside a redirected group. With #328's `finally` hand-back in place they resolve — #328 makes the pipeline give the position back, this PR makes the group inside the stage stop rewinding it.

## Details

### Root cause

`executeGroup` saved and restored unconditionally, but installed conditionally:

```ts
const savedGroupStdin = ctx.state.groupStdin;
if (effectiveStdin) {                        // only when the group had its own stdin
  ctx.state.groupStdin = effectiveStdin;
}
…
ctx.state.groupStdin = savedGroupStdin;      // always
```

`eval` had the same shape plus a second defect: `const effectiveStdin = stdin ?? ctx.state.groupStdin` — the builtin dispatcher hands `eval` a plain string, so a command with no redirection arrives as `""`, not `undefined`. `"" ?? …` is `""`, so `eval` installed an empty stdin (immediate EOF) over the shell's position on *every* call, then rewound it on the way out.

### The rule

A construct restores only what it actually replaced.

- **It owns fd 0** — `{ …; } < file`, a heredoc or here-string on the group, a pipe into it, a redirection on a function definition or call, `eval '…' < file`. The enclosing shell's position must come back untouched by whatever the body read.
- **It shares fd 0** — no redirection, no pipe. Reads inside move the one shared position and the command after the construct must see where the body left off.

`executeGroup` now tracks that as an explicit `ownsStdin` flag and routes both the normal and the error path through one `restoreGroupStdin()`. `eval` uses the same rule.

### Ownership is a fact, not an inference from the content

An empty stdin is ambiguous: `f < empty-file` and an unredirected `f` both reach the callee as `""`, and they mean opposite things — EOF versus "inherit the shell's stdin". Inferring ownership from `stdin !== ""` gets the second right and the first wrong, for a whole class of constructs, with a loop-count failure mode:

```bash
f() { read a; }; while read x; do f < /dev/null; done < five-line-file
# shielding the body from the loop's stdin is the idiom; inferring gives 3 turns, not 5
```

So the fact travels beside the string instead. `executeSimpleCommandInner` already knows it — it is the branch that assigned `stdin` — and passes `stdinRedirected` through `runCommand` → `dispatchBuiltin` to `handleEval` and `callFunction`, alongside the existing `stdinSourceFd`. `callFunction` combines it with its own definition-level redirections (`processInputRedirections` now reports `{ stdin, redirected }` rather than a bare string) and hands the result to `executeCommand(func.body, stdin, stdinOwned)`, which reaches `executeGroup` / `executeSubshell`. Every new parameter is optional and defaults to `false`, so no caller that does not pass one changes behavior.

That closes the class: `f < empty.txt`, `f() { …; } < empty.txt`, `f < /dev/null`, `eval '…' < empty.txt`, `eval '…' < /dev/null` and `{ …; } < empty.txt` all mean EOF inside now, and all five loop-shield idioms run once per line.

The wrapper builtins re-enter dispatch with the *same* stdin, so they forward the flag as well: `command`, `builtin` and `exec` each pass it to the command they wrap. Without that, `command eval '…' < empty-file` looked unredirected to the wrapped `eval` — it read the enclosing shell's line instead of EOF, and `while read q; do command eval 'read x' < /dev/null; done < file` ran three times instead of five. `command`/`builtin` still drop `stdinSourceFd` when they re-dispatch, which is the pre-existing `<&N`-through-a-wrapper gap and belongs with #326's descriptor work.

### Why `undefined` is not a position

Both restore points keep one guard: if the body left `ctx.state.groupStdin === undefined` where the construct inherited a defined stream, the inherited position is restored rather than propagated.

A shared stdin can be consumed down to `""` — that is EOF, and it *must* propagate — but it can never be taken away; `undefined` means "this scope has no stdin at all", which is not a read position. Today the only thing that produces it is a pipeline stage clearing shared state it does not own, i.e. exactly the bug #328 fixes. Without the guard, `while read a; do { echo x | cat; }; done < file` — a pipeline nested in a group in a loop body — would run once instead of five times on a branch without #328, because the group would faithfully propagate the pipeline's `undefined`. With #328 merged the guard never fires; four unit tests pin the behavior from the outside so it stays correct either way.

### Bash matrix

90 shapes, each run in `/bin/bash` 3.2.57 and in just-bash, before and after. **45 → 71 matching: 26 fixed, 0 regressed**, 64 unchanged.

| Case | bash | before | after |
|---|---|---|---|
| `{ { read a; }; read b; }` | `L1`,`L2` | `L1`,**`L1`** | `L1`,`L2` |
| `{ { { read a; }; }; read b; }` | `L1`,`L2` | `L1`,**`L1`** | `L1`,`L2` |
| `{ { { read a; }; read c; }; read b; }` | `L1`,`L2`,`L3` | `L1`,`L2`,**`L1`** | `L1`,`L2`,`L3` |
| `{ { 5×read }; read b; echo $? }` | `""`, 1 | **`L1`**, **0** | `""`, 1 |
| `{ { read a; } >/dev/null; read b; }` | `L1`,`L2` | `L1`,**`L1`** | `L1`,`L2` |
| `{ { read a; }; cat; }` | `L2…L5` | **`L1…L5`** | `L2…L5` |
| `{ { read a; }; read b; } <<EOT` / `<<<` | `H1`,`H2` / `S1`,`""` | **replayed** | `H1`,`H2` / `S1`,`""` |
| `{ read a; { read x; } < other; read b; }` | `O1`, `L1`,`L2` | `O1`, `L1`,`L2` | unchanged |
| `{ read a; { read x; } < empty; read b; }` | `""`, `L1`,`L2` | **`L2`**, `L1`,`L2` | `""`, `L1`,`L2` |
| `f() { read a; }; { f; f; read b; }` | `L1`,`L2`,`L3` | `L1`,**`L1`**,**`L1`** | `L1`,`L2`,`L3` |
| `f() { read a; } < other; { f; read b; }` | `O1`,`L1` | `O1`,`L1` | unchanged |
| `{ f < other; read b; }` | `O1`,`L1` | `O1`,`L1` | unchanged |
| `{ read a; f < empty; read b; }` | `""`, `L1`,`L2` | **`L2`**, `L1`,`L2` | `""`, `L1`,`L2` |
| `f() { …; } < empty; { read a; f; read b; }` | `""`, `L1`,`L2` | **`L2`**, `L1`,`L2` | `""`, `L1`,`L2` |
| `{ read a; f < /dev/null; read b; }` | `""`, `L1`,`L2` | **`L2`**, `L1`,`L2` | `""`, `L1`,`L2` |
| `while read a; do …; f; done` (f reads) | 3 turns | **5 turns, replayed** | 3 turns |
| `while read x; do f < /dev/null; done` | 5 turns | 5 turns | 5 turns |
| `while read x; do f < empty; done` | 5 turns | 5 turns | 5 turns |
| `while read x; do eval 'read q' < /dev/null; done` | 5 turns | 5 turns | 5 turns |
| `while read x; do { read q; } < /dev/null; done` | 5 turns | 5 turns | 5 turns |
| `{ eval 'read a'; read b; }` | `L1`,`L2` | **`""`**,**`L1`** | `L1`,`L2` |
| `{ eval 'read a; read c'; read b; }` | `L1`,`L2`,`L3` | **`""`,`""`,`L1`** | `L1`,`L2`,`L3` |
| `{ eval 'while read l; …'; } < file` | `L1…L5` | **(nothing)** | `L1…L5` |
| `{ eval '…' < other; read b; }` | `O1`,`L1` | `O1`,`L1` | unchanged |
| `{ read a; eval 'read x' < empty; read b; }` | `""`, `L1`,`L2` | `""`, `L1`,`L2` | unchanged |
| `{ command eval 'read x' < empty; read y; }` | `""`,`L1` | `""`,`L1` | unchanged |
| `{ command eval 'read x'; read y; }` | `L1`,`L2` | **`""`**,**`L1`** | `L1`,`L2` |
| `{ builtin eval 'read x'; read y; }` | `L1`,`L2` | **`""`**,**`L1`** | `L1`,`L2` |
| `while read q; do command eval 'read x' < /dev/null; done` | 5 turns | 5 turns | 5 turns |
| `while read a; do { read b; }; done` | 3 turns | **5 turns, replayed** | 3 turns |
| `while read a; do …; done < file` (bare) | 5 turns | 5 | 5 |
| loop body: group / subshell / function / eval | 5 turns | 5 | 5 |
| loop body: pipeline in group / function / eval / subshell | 5 turns | 5 | 5 |
| `{ { echo x \| cat; }; read b; }` | `L1` | `L1` | `L1` |
| `{ { true \| true; }; read b; }` | `L1` | `L1` | `L1` |
| `for` / `until` / `case` / `if` body reads | advance | advance | unchanged |

Two rows still differ from bash on both sides but changed value, both for the better:

- `{ eval 'while read l; …'; read b; } < file` — the loop body now prints all five lines instead of nothing. The row stays DIFF only because of the `while` residual below (`b=[L1]` where bash has `b=[]`).
- `{ { mapfile -t arr; }; echo ${#arr[@]}; read b; }` — `b` went from `L1` to `""`, which is what bash 5 prints. The recorded reference is bash 3.2.57, which has no `mapfile` at all, so this row cannot be judged against it; it is not covered by a test.

### Subshells: deliberately not touched

`( read a )` in bash advances the parent's offset for a seekable stdin (`{ ( read a ); read b; }` gives `b` the second line); just-bash gives it the first, because `executeSubshell` runs the body under `beginIsolatedShellState`, which snapshots and restores `groupStdin` along with the rest of the namespace. That is the model, not this bug: #326's *Deferred* section states it for descriptors — "subshells copy the descriptor table rather than sharing the open file description … just-bash already copies stdin the same way, so this stays consistent with the existing model. Not covered by a test, to avoid pinning behavior we intend to change." Changing it here would mean making subshell state selectively non-isolated, which is a model change, not a restore-rule fix. No test in this PR pins subshell stdin behavior in either direction.

### Known residual divergences — all measured, none introduced or changed by this PR

Each was run on `upstream/main` and on this branch and produced byte-identical just-bash output on both.

- **`while`/`until` loops have the same unconditional restore** in `control-flow.ts`: `{ while read a; do …; done; read b; }` gives `b` the first line where bash gives EOF. It is the same two-line rule, but `control-flow.ts` is being rewritten by a sibling PR for loop *output* redirections; applying it here would guarantee a conflict for a case that only shows up when a loop shares stdin with a following command. Left for a follow-up. The core `done < file` idiom is unaffected and covered by tests here.
- **Non-`read` commands do not advance the shared position**: `{ read a; cat; read b; }` — `cat` prints the rest but leaves the position, so the following `read` gets a line bash does not. #326 documents the same gap for `<&N`.
- **`read` is the one member of the empty-fd-0 class left open.** `{ read a; read x < empty.txt; read b; }` gives `x=[L2]`, `b=[L3]` where bash gives `x=[]`, `b=[L2]`: `handleRead` falls back to `groupStdin` whenever its own stdin is empty. The `stdinRedirected` fact now reaches `dispatchBuiltin`, so closing it is a small follow-up, but `read` is the most heavily exercised builtin in the suite and the change deserves its own PR and its own matrix.
- **`( … ) < file` never installs the file as stdin.** `executeSubshell` ignores input redirections entirely, so `( read x ) < other.txt` reads the *outer* stdin and `( { read a; }; read b; ) < loop.txt` reads nothing at all.
- **`exec < file` never installs stdin.** `{ exec < other.txt; read a; }` reads `L1` from the enclosing redirect and bare `exec < other.txt; read a` reads nothing, where bash gives `O1` for both. `exec`'s redirection handling only populates `fileDescriptors`; fd 0 is not routed to `groupStdin`.
- **`exec` runs builtins that bash refuses to exec.** `exec eval '…'` reports `exec: eval: not found` (status 127) in bash — `exec` only replaces the shell with an external program — where just-bash's `exec` stub runs it. Unrelated to stdin; the ownership flag is forwarded through `exec` anyway so the wrapped command is correct on the day that stub is replaced.
- **A group's `<` branch ignores the descriptor number.** `{ read x; } 3< other.txt` feeds `other.txt` to *stdin*: `{ read a; { read x; } 3< other.txt; read b; }` gives `x=[O1]`, `b=[L2]` where bash gives `x=[L2]`, `b=[L3]`. The heredoc branch beside it checks `redir.fd ?? 0`; the `<` and `<<<` branches do not. This overlaps open PR **#326**, which routes every fd ≥ 3 construct through a typed descriptor table, so the fix belongs there rather than in a conflicting parallel edit.

## Tests

| File | Tests | Lines |
| --- | --- | --- |
| `packages/just-bash/src/interpreter/group-stdin.test.ts` | 22 | 243 |
| `packages/just-bash/src/interpreter/group-stdin.constructs.test.ts` | 34 | 264 |
| `packages/just-bash/src/interpreter/group-stdin.wrappers.test.ts` | 11 | 87 |
| `packages/just-bash/src/comparison-tests/group-stdin.comparison.test.ts` | 25 | 265 |

92 new tests. `group-stdin.test.ts` opens with the exact repro. All assertions compare full stdout and stderr strings plus the exit code; every file is under the 300-line limit. **27 of the 67 unit tests fail on `upstream/main`**; the other 40 are guards that must keep passing (read-loop idioms, loop-body shields, redirections that *do* own stdin, pipelines in a shared-stdin body, and the wrapper cases `upstream/main` happens to get right).

Comparison fixtures were recorded against **GNU bash 3.2.57(1)-release**, `/bin/bash` on macOS (`RECORD_FIXTURES=1`). None are locked: every command is plain POSIX `read`/`echo`/`cat` with no diagnostics on stderr, so a re-record on the CI runner's bash 5 produces byte-identical entries. Re-recording on this machine produces no diff.

Verification on this branch, measured against `upstream/main` in the same checkout with `pnpm build` run first in both cases:

| Suite | `upstream/main` | this branch |
| --- | --- | --- |
| `pnpm test:run` | 6 failed, 14287 passed, 97 skipped (14390) | 6 failed, **14379** passed, 97 skipped (14482) |
| `pnpm test:comparison` | 567 passed (35 files) | **592** passed (36 files) |
| `src/spec-tests` | 3825 passed, 1 skipped | 3825 passed, 1 skipped |

Zero new failures. The 6 failures are identical on both sides and are the CPython-WASM suite: `vendor/cpython-emscripten/python.wasm` is an unmaterialized git-LFS pointer in this checkout (132 bytes), so `python: true` tests time out loading the worker (`just-bash.bundle`, `code-exec-exploit-regression`, `defense-in-depth-independence`, `python-sqlite-information-disclosure` ×2, `worker-protocol-runtime-desync`). They fail in isolation here too, on main and on the branch, for the same reason. No existing test asserted the old behavior, so none was changed.

`pnpm typecheck`, `pnpm lint:fix` (biome), `pnpm lint:banned` and `pnpm knip` are clean.

One CI run of this branch failed `packages/just-bash-executor` › "should list all items from a discovered tool" — a js-exec worker returning truncated stdout with status 0 and empty stderr — on the Node 24 job while the **same commit passed the Node 22 job**, which runs that suite too. The failure is in `commands/js-exec` + `commands/worker-bridge`, both byte-identical to `upstream/main` here (this PR touches only `src/interpreter/`), and the signature is only reachable inside `BridgeHandler`. 180 repeat runs of that suite on this branch (including 70 on Node 24, under CPU saturation and against a concurrently running just-bash unit suite) and 80 on `upstream/main` produced 0 failures on either side, so it looks like a pre-existing worker-output race rather than anything this PR introduces.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
