### PR TITLE
feat(grep): treat - operand as standard input

### DIFF
--- a/.changeset/olive-donkeys-search.md
+++ b/.changeset/olive-donkeys-search.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Treat a `-` FILE operand in `grep` as standard input, matching GNU. `grep PATTERN -` now reads stdin instead of failing with "No such file or directory", stdin is labelled `(standard input)` in the multi-file prefix and in `-l`/`-L`/`-c` output, repeated `-` operands see the stream drained by the first one, and `-` is exempt from `-r` recursion and `--include`/`--exclude` filtering.

--- a/packages/just-bash/src/commands/grep/grep.stdin-operand.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.stdin-operand.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * `-` as a FILE operand means standard input. GNU labels it
+ * `(standard input)` wherever a file name would appear, and treats it as a
+ * stream: only the first `-` of an invocation sees any content.
+ *
+ * Expectations verified against GNU grep 3.12.
+ */
+const files = {
+  "/f1.txt": "apple\nbanana\n",
+  "/f2.txt": "cherry\napple pie\n",
+};
+
+describe("grep - (stdin operand)", () => {
+  it("reads standard input for a lone - operand", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep apple -");
+    expect(result.stdout).toBe("apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("prints no file-name prefix for a lone - operand", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'x\\napple pie\\n' | grep -n apple -",
+    );
+    expect(result.stdout).toBe("2:apple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 when standard input has no match", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'zzz\\n' | grep apple -");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 1 for empty standard input", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf '' | grep apple -");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("treats absent standard input as empty", async () => {
+    const env = new Bash();
+    const result = await env.exec("grep apple -");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("still accepts - as the PATTERN operand", async () => {
+    const env = new Bash({ files: { "/dash.txt": "a-b\nxy\n" } });
+    const result = await env.exec("grep - /dash.txt");
+    expect(result.stdout).toBe("a-b\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts - after the -- option terminator", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -- apple -");
+    expect(result.stdout).toBe("apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accepts - alongside -e", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -e apple -");
+    expect(result.stdout).toBe("apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep - (stdin operand) mixed with files", () => {
+  it("labels standard input in the multi-file prefix", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe(
+      "/f1.txt:apple\n(standard input):apple stdin\n/f2.txt:apple pie\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps operand order when - comes first", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep apple - /f1.txt",
+    );
+    expect(result.stdout).toBe("(standard input):apple stdin\n/f1.txt:apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("labels standard input in -l output", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep -l apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe("/f1.txt\n(standard input)\n/f2.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("labels standard input in -L output", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'zzz\\n' | grep -L apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe("(standard input)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("labels standard input in -c output", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep -c apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe("/f1.txt:1\n(standard input):1\n/f2.txt:1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("numbers standard input lines independently with -n", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'x\\napple stdin\\n' | grep -n apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe(
+      "/f1.txt:1:apple\n(standard input):2:apple stdin\n/f2.txt:2:apple pie\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("suppresses the (standard input) label with -h", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep -h apple /f1.txt - /f2.txt",
+    );
+    expect(result.stdout).toBe("apple\napple stdin\napple pie\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("keeps the -l listing unprefixed by -h", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep -h -l apple /f1.txt -",
+    );
+    expect(result.stdout).toBe("/f1.txt\n(standard input)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("reports a missing file but still searches standard input", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec("printf 'apple\\n' | grep apple /nope.txt -");
+    expect(result.stdout).toBe("(standard input):apple\n");
+    expect(result.stderr).toBe("grep: /nope.txt: No such file or directory\n");
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("exits 0 for -q even when another operand is missing", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple\\n' | grep -q apple - /nope.txt",
+    );
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("ignores --include and --exclude for standard input", async () => {
+    const env = new Bash({ files });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep --include='*.txt' apple - /f1.txt",
+    );
+    expect(result.stdout).toBe("(standard input):apple stdin\n/f1.txt:apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep - (stdin operand) repeated", () => {
+  it("gives the second - an empty stream", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'apple\\napple2\\n' | grep apple - -",
+    );
+    expect(result.stdout).toBe(
+      "(standard input):apple\n(standard input):apple2\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("counts the second - as zero", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'apple\\napple2\\n' | grep -c apple - -",
+    );
+    expect(result.stdout).toBe("(standard input):2\n(standard input):0\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("counts every - after the first as zero", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -c apple - - -");
+    expect(result.stdout).toBe(
+      "(standard input):1\n(standard input):0\n(standard input):0\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("lists the drained - under -L", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -L apple - -");
+    expect(result.stdout).toBe("(standard input)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("stops the first - at -m and leaves the second empty", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      "printf 'apple s1\\napple s2\\n' | grep -m1 apple - -",
+    );
+    expect(result.stdout).toBe("(standard input):apple s1\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep - (stdin operand) with -r", () => {
+  it("prints no prefix for a lone - under -r", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple stdin\\n' | grep -r apple -");
+    expect(result.stdout).toBe("apple stdin\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("prefixes when -r is given a directory alongside -", async () => {
+    const env = new Bash({ files: { "/sub/a.txt": "apple tree\n" } });
+    const result = await env.exec(
+      "printf 'apple stdin\\n' | grep -r apple - /sub",
+    );
+    expect(result.stdout).toBe(
+      "(standard input):apple stdin\n/sub/a.txt:apple tree\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("lists both sources with -lr", async () => {
+    const env = new Bash({ files: { "/sub/a.txt": "apple tree\n" } });
+    const result = await env.exec("printf 'apple\\n' | grep -lr apple - /sub");
+    expect(result.stdout).toBe("(standard input)\n/sub/a.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("prefixes repeated - under -r", async () => {
+    const env = new Bash();
+    const result = await env.exec("printf 'apple\\n' | grep -r apple - -");
+    expect(result.stdout).toBe("(standard input):apple\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -11,10 +11,24 @@ import { matchGlob } from "../../utils/glob.js";
 import { showHelp, unknownOption } from "../help.js";
 import { buildRegex, searchContent } from "../search-engine/index.js";
 
+/**
+ * The name GNU grep prints for the `-` operand. It appears wherever a real
+ * file name would: the multi-file `file:line` prefix, `-l`/`-L` listings and
+ * `-c` counts.
+ */
+const STDIN_FILENAME = "(standard input)";
+
 /** File entry with optional type info from glob expansion */
 interface FileEntry {
   path: string;
   isFile?: boolean; // undefined means we need to stat
+  /** True for the `-` operand, which names standard input instead of a file. */
+  isStdin?: boolean;
+  /**
+   * True when an earlier `-` already drained stdin. stdin is a stream, so the
+   * second `-` of `grep pat - -` reads EOF and contributes nothing.
+   */
+  stdinAtEof?: boolean;
 }
 
 interface GrepTraversalBudget {
@@ -53,6 +67,10 @@ const grepHelp = {
   name: "grep",
   summary: "print lines that match patterns",
   usage: "grep [OPTION]... PATTERN [FILE]...",
+  description: [
+    "Search for PATTERN in each FILE.",
+    "With no FILE, or when FILE is -, read standard input.",
+  ],
   options: [
     "-E, --extended-regexp    PATTERN is an extended regular expression",
     "-P, --perl-regexp        PATTERN is a Perl regular expression",
@@ -334,7 +352,38 @@ export const grepCommand: RuntimeCommand = {
       }
       filesToSearch.push(...entries);
     };
+    /**
+     * True once a `-` operand has claimed stdin. stdin is a stream, so only the
+     * first reader sees its contents.
+     */
+    let stdinConsumed = false;
+    /**
+     * True once a real path is queued. GNU only forces the file-name prefix
+     * under -r when recursion can actually descend into a directory, and `-` is
+     * never a directory: `grep -r pat -` prints bare lines.
+     */
+    let hasFileTarget = false;
     for (const file of files) {
+      if (file === "-") {
+        // GNU treats `-` as an operand naming standard input. It bypasses glob
+        // expansion, recursion and --include/--exclude entirely: those all
+        // filter on a file name, and stdin has none.
+        if (filesToSearch.length >= traversalBudget.maxResults) {
+          throw new ExecutionLimitError(
+            `grep: array element limit exceeded (${traversalBudget.maxResults})`,
+            "array_elements",
+          );
+        }
+        filesToSearch.push({
+          path: STDIN_FILENAME,
+          isFile: true,
+          isStdin: true,
+          stdinAtEof: stdinConsumed,
+        });
+        stdinConsumed = true;
+        continue;
+      }
+      hasFileTarget = true;
       // Check if this is a glob pattern
       if (file.includes("*") || file.includes("?") || file.includes("[")) {
         const expanded = await expandGlobPatternWithTypes(
@@ -381,7 +430,8 @@ export const grepCommand: RuntimeCommand = {
     }
 
     // Determine if we should show filename (after glob expansion)
-    const showFilename = (filesToSearch.length > 1 || recursive) && !noFilename;
+    const showFilename =
+      (filesToSearch.length > 1 || (recursive && hasFileTarget)) && !noFilename;
 
     // Process files in parallel batches for better performance
     const BATCH_SIZE = 50;
@@ -395,7 +445,7 @@ export const grepCommand: RuntimeCommand = {
           const basename = file.split("/").pop() || file;
 
           // Check exclude patterns for non-recursive case
-          if (excludePatterns.length > 0 && !recursive) {
+          if (excludePatterns.length > 0 && !recursive && !fileEntry.isStdin) {
             if (
               excludePatterns.some((p) =>
                 matchGlob(basename, p, { stripQuotes: true }),
@@ -406,7 +456,7 @@ export const grepCommand: RuntimeCommand = {
           }
 
           // Check include patterns for non-recursive case
-          if (includePatterns.length > 0 && !recursive) {
+          if (includePatterns.length > 0 && !recursive && !fileEntry.isStdin) {
             if (
               !includePatterns.some((p) =>
                 matchGlob(basename, p, { stripQuotes: true }),
@@ -417,25 +467,36 @@ export const grepCommand: RuntimeCommand = {
           }
 
           try {
-            const filePath = ctx.fs.resolvePath(ctx.cwd, file);
-
-            // Skip stat if we already know it's a file from glob expansion
-            let isDirectory = false;
-            if (fileEntry.isFile === undefined) {
-              const stat = await ctx.fs.stat(filePath);
-              isDirectory = stat.isDirectory;
+            let content: string;
+            if (fileEntry.isStdin) {
+              // grep runs regex over text — decode bytes to UTF-8 so multibyte
+              // codepoints match `.` / character classes correctly. A `-` that
+              // arrives after stdin was already drained reads EOF.
+              content =
+                fileEntry.stdinAtEof || ctx.stdin === undefined
+                  ? ""
+                  : decodeBytesToUtf8(ctx.stdin);
             } else {
-              isDirectory = !fileEntry.isFile;
-            }
+              const filePath = ctx.fs.resolvePath(ctx.cwd, file);
 
-            if (isDirectory) {
-              if (!recursive) {
-                return { error: `grep: ${file}: Is a directory\n` };
+              // Skip stat if we already know it's a file from glob expansion
+              let isDirectory = false;
+              if (fileEntry.isFile === undefined) {
+                const stat = await ctx.fs.stat(filePath);
+                isDirectory = stat.isDirectory;
+              } else {
+                isDirectory = !fileEntry.isFile;
               }
-              return null;
-            }
 
-            const content = await ctx.fs.readFile(filePath);
+              if (isDirectory) {
+                if (!recursive) {
+                  return { error: `grep: ${file}: Is a directory\n` };
+                }
+                return null;
+              }
+
+              content = await ctx.fs.readFile(filePath);
+            }
 
             // File-level preFilter: skip searchContent entirely when no needle exists in file.
             // Avoids content.split("\n") and all per-line work for the common zero-match case.

--- a/packages/just-bash/src/comparison-tests/fixtures/grep-stdin-operand.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/grep-stdin-operand.comparison.fixtures.json
@@ -1,0 +1,303 @@
+{
+  "022e1902083fde97": {
+    "command": "printf 'zzz\\n' | grep -v apple f1.txt -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:banana\n(standard input):zzz\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "024aae49b28542a2": {
+    "command": "printf 'apple stdin\\n' | grep -o apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:apple\n(standard input):apple\nf2.txt:apple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "10d4777f4f350109": {
+    "command": "printf '' | grep -c apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "0\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "127fb1418ad3c848": {
+    "command": "printf 'apple stdin\\n' | grep -r apple - sub",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n",
+      "sub/a.txt": "apple tree\n"
+    },
+    "stdout": "(standard input):apple stdin\nsub/a.txt:apple tree\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "16ec8be710a002a2": {
+    "command": "printf 'apple stdin\\n' | grep -r apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n",
+      "sub/a.txt": "apple tree\n"
+    },
+    "stdout": "apple stdin\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "1ba37f2e862a537e": {
+    "command": "printf 'apple\\n' | grep -lr apple - sub",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n",
+      "sub/a.txt": "apple tree\n"
+    },
+    "stdout": "(standard input)\nsub/a.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "2a2be74b890630d2": {
+    "command": "printf 'apple\\n' | grep apple nope.txt - 2>/dev/null",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input):apple\n",
+    "stderr": "",
+    "exitCode": 2,
+    "locked": true
+  },
+  "348a41a560c1971f": {
+    "command": "printf 'apple\\n' | grep -q apple - nope.txt 2>/dev/null",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "43fcf752b8632021": {
+    "command": "printf 'apple stdin\\n' | grep -h apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "apple\napple stdin\napple pie\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "456faf8ab0cd88f7": {
+    "command": "printf 'zzz\\n' | grep apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "52bb737421b16e6a": {
+    "command": "printf 'apple stdin\\n' | grep -h -l apple f1.txt -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt\n(standard input)\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "57e55a14addf4f6b": {
+    "command": "printf 'apple\\n' | grep -L apple - -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input)\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "5f4bc36dba55d12c": {
+    "command": "printf 'apple stdin\\n' | grep -- apple - f1.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input):apple stdin\nf1.txt:apple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "9e0d28621247d248": {
+    "command": "printf 'apple s1\\napple s2\\n' | grep -m1 apple f1.txt -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:apple\n(standard input):apple s1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "a2fc79d6f2712e45": {
+    "command": "printf 'apple stdin\\n' | grep apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:apple\n(standard input):apple stdin\nf2.txt:apple pie\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b254cb8d362f5bb3": {
+    "command": "printf 'zzz\\n' | grep -L apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input)\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b5e41b2ca2975077": {
+    "command": "printf 'x\\napple stdin\\n' | grep -n apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:1:apple\n(standard input):2:apple stdin\nf2.txt:2:apple pie\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b9b4678962c5e122": {
+    "command": "printf 'apple\\napple2\\n' | grep -c apple - -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input):2\n(standard input):0\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c15d14bf7188d524": {
+    "command": "printf 'apple\\napple2\\n' | grep apple - -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input):apple\n(standard input):apple2\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d4fb3038630b0e21": {
+    "command": "printf 'apple\\n' | grep -c apple - - -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input):1\n(standard input):0\n(standard input):0\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d546f78360cb8848": {
+    "command": "printf 'apple\\n' | grep --exclude='*' apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "apple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "dc1475ffd8afead2": {
+    "command": "printf 'apple\\n' | grep apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "apple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "df13e82ef09a2594": {
+    "command": "printf 'apple\\n' | grep -l apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "(standard input)\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e6cf1de74078ac7f": {
+    "command": "printf 'apple stdin\\n' | grep -l apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt\n(standard input)\nf2.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ecc36b0a364e9d88": {
+    "command": "printf 'x\\napple pie\\n' | grep -n apple -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "2:apple pie\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "fac7023a58142a20": {
+    "command": "printf 'apple\\n' | grep -r apple - -",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n",
+      "sub/a.txt": "apple tree\n"
+    },
+    "stdout": "(standard input):apple\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "fe3c3b65a44d2b2e": {
+    "command": "printf 'apple stdin\\n' | grep -c apple f1.txt - f2.txt",
+    "files": {
+      "f1.txt": "apple\nbanana\n",
+      "f2.txt": "cherry\napple pie\n"
+    },
+    "stdout": "f1.txt:1\n(standard input):1\nf2.txt:1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/grep-stdin-operand.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/grep-stdin-operand.comparison.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * `grep PATTERN -` comparison tests: `-` as a FILE operand means standard
+ * input, labelled `(standard input)`.
+ *
+ * Fixtures are recorded against GNU grep 3.12, not the BSD grep that ships with
+ * macOS, and are therefore locked. To re-record:
+ *
+ *   PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
+ *     RECORD_FIXTURES=force pnpm test:run \
+ *     src/comparison-tests/grep-stdin-operand.comparison.test.ts
+ */
+describe("grep - (stdin operand) - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const files = {
+    "f1.txt": "apple\nbanana\n",
+    "f2.txt": "cherry\napple pie\n",
+  };
+
+  const treeFiles = {
+    ...files,
+    "sub/a.txt": "apple tree\n",
+  };
+
+  describe("a lone - operand", () => {
+    it("should read standard input", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "printf 'apple\\n' | grep apple -");
+    });
+
+    it("should print no file-name prefix", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'x\\napple pie\\n' | grep -n apple -",
+      );
+    });
+
+    it("should exit 1 when standard input does not match", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "printf 'zzz\\n' | grep apple -");
+    });
+
+    it("should count empty standard input as zero", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "printf '' | grep -c apple -");
+    });
+
+    it("should list (standard input) with -l", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "printf 'apple\\n' | grep -l apple -");
+    });
+
+    it("should ignore --exclude for standard input", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep --exclude='*' apple -",
+      );
+    });
+
+    it("should accept - after the option terminator", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -- apple - f1.txt",
+      );
+    });
+  });
+
+  describe("- mixed with files", () => {
+    it("should label standard input in the multi-file prefix", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should label standard input in -l output", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -l apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should label standard input in -L output", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'zzz\\n' | grep -L apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should label standard input in -c output", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -c apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should number standard input lines independently", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'x\\napple stdin\\n' | grep -n apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should drop the label with -h", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -h apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should keep -l names with -h", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -h -l apple f1.txt -",
+      );
+    });
+
+    it("should label standard input with -o", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -o apple f1.txt - f2.txt",
+      );
+    });
+
+    it("should label standard input with -v", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'zzz\\n' | grep -v apple f1.txt -",
+      );
+    });
+
+    it("should apply -m per source", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple s1\\napple s2\\n' | grep -m1 apple f1.txt -",
+      );
+    });
+
+    it("should still search standard input when another operand is missing", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep apple nope.txt - 2>/dev/null",
+      );
+    });
+
+    it("should exit 0 for -q even when another operand is missing", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep -q apple - nope.txt 2>/dev/null",
+      );
+    });
+  });
+
+  describe("repeated -", () => {
+    it("should give the second - an empty stream", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\napple2\\n' | grep apple - -",
+      );
+    });
+
+    it("should count the second - as zero", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\napple2\\n' | grep -c apple - -",
+      );
+    });
+
+    it("should count every - after the first as zero", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep -c apple - - -",
+      );
+    });
+
+    it("should list the drained - under -L", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep -L apple - -",
+      );
+    });
+  });
+
+  describe("- with -r", () => {
+    it("should print no prefix for a lone - under -r", async () => {
+      const env = await setupFiles(testDir, treeFiles);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -r apple -",
+      );
+    });
+
+    it("should prefix when a directory is searched alongside -", async () => {
+      const env = await setupFiles(testDir, treeFiles);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple stdin\\n' | grep -r apple - sub",
+      );
+    });
+
+    it("should list both sources with -lr", async () => {
+      const env = await setupFiles(testDir, treeFiles);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep -lr apple - sub",
+      );
+    });
+
+    it("should prefix repeated - under -r", async () => {
+      const env = await setupFiles(testDir, treeFiles);
+      await compareOutputs(
+        env,
+        testDir,
+        "printf 'apple\\n' | grep -r apple - -",
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/spec-tests/grep/skips.ts
+++ b/packages/just-bash/src/spec-tests/grep/skips.ts
@@ -102,24 +102,14 @@ const SKIP_TESTS: Map<string, string> = new Map<string, string>([
   ],
 
   // Tests using - for stdin argument position
-  ["busybox-grep.tests:grep - (specify stdin)", "- stdin arg not supported"],
   [
     "busybox-grep.tests:grep - infile (specify stdin and file)",
-    "- stdin arg not supported",
-  ],
-  [
-    "busybox-grep.tests:grep - nofile (specify stdin and nonexisting file)",
-    "- stdin arg not supported",
-  ],
-  [
-    "busybox-grep.tests:grep -q - nofile (specify stdin and nonexisting file, match)",
-    "- stdin arg not supported",
+    "runner rewrites `input` to /tmp/input, so the file-name prefix differs",
   ],
   [
     "busybox-grep.tests:grep -s nofile - (stdin and nonexisting file, match)",
-    "- stdin arg not supported",
+    "-s option not implemented",
   ],
-  ["busybox-grep.tests:grep -L exitcode 0 #2", "- stdin arg not supported"],
 
   // Tests that create external files (>empty, mkdir)
   ["busybox-grep.tests:grep two files", "creates external empty file"],


### PR DESCRIPTION
## Summary

`grep` did not accept `-` as a FILE operand. Found while reviewing #327 (`grep -f`), which added `-f -` for reading *patterns* from stdin and made the neighbouring gap obvious. There is no issue for it.

```
$ printf 'apple\n' | grep apple -
grep: -: No such file or directory     # just-bash, exit 2
apple                                  # GNU grep 3.12, exit 0
```

`-` is a POSIX-documented operand meaning standard input, and the busybox grep spec suite already exercises it — six cases were parked in `spec-tests/grep/skips.ts` with the reason "- stdin arg not supported".

This PR implements the GNU semantics. Every expectation below was verified against GNU grep 3.12 (`/opt/homebrew/opt/grep/libexec/gnubin/grep`), never macOS BSD grep.

## Details

**The label.** GNU prints `(standard input)` wherever a real file name would appear — the multi-file `file:line` prefix, `-l`/`-L` listings, `-c` counts, and the `file-line` form of context lines. (Context output with `-A`/`-B`/`-C` is not exercised in the new tests: just-bash omits GNU's `--` separator between context groups, a pre-existing divergence that predates this PR — `grep -A1 pat f1 f2` on `main` already omits it, `-` or no `-`.)

```
$ printf 'apple stdin\n' | ggrep -n apple f1.txt - f2.txt
f1.txt:1:apple
(standard input):2:apple stdin
f2.txt:2:apple pie
```

A lone `-` gets no prefix (one operand), and `-h` suppresses it exactly as it does for files. `-l`/`-L` still print `(standard input)` under `-h`, since those *are* the output rather than a prefix.

**Stream semantics for repeated `-`.** stdin is a stream, so only the first `-` sees content; every later one reads EOF:

```
$ printf 'apple\n' | ggrep -c apple - - -
(standard input):1
(standard input):0
(standard input):0
```

Implemented by marking each queued `-` entry with `stdinAtEof` at operand-collection time, so the parallel batch executor stays deterministic.

**`-` with `-r`.** GNU only forces the file-name prefix under `-r` when recursion can actually descend into a directory, and stdin is never a directory: `grep -r pat -` prints bare lines, while `grep -r pat - sub` prefixes both sources (two operands). `showFilename` now requires a real path target before `-r` forces the prefix. This deliberately leaves the pre-existing `grep -r pat single-file.txt` divergence (just-bash prefixes, GNU does not) untouched — out of scope here.

**`-` bypasses name-based filtering.** Glob expansion, recursion and `--include`/`--exclude` all filter on a file name; stdin has none, so GNU applies none of them. `printf 'apple\n' | ggrep --exclude='*' apple -` still prints `apple`.

**Empty vs absent stdin.** Empty stdin is a valid empty stream: no output, `-c` prints `0`, exit 1 — same as GNU with `< /dev/null`. When just-bash has no stdin at all, `-` reads empty, consistent with how `cat -` already behaves in this repo.

**Exit codes.** Unchanged rules, now fed by stdin too: 0 on match, 1 on none, 2 when any operand errored. A missing operand alongside `-` still searches stdin and exits 2; `-q` short-circuits to 0 on a match even then, per SUSv3 (busybox spec case at `busybox-grep.tests:55`).

Two adjacent pre-existing divergences are deliberately not addressed (both reproduce on `main` without `-`): `grep pat - dir` exits 0 where GNU exits 2 (directory operands don't set the error flag), and `-q` suppresses the `No such file or directory` diagnostic that GNU still prints to stderr — the new `-q` test asserts just-bash's current (empty) stderr, and the corresponding fixture routes stderr to `/dev/null`, so neither pins the GNU wording.

**`-H` is not implemented in just-bash at all** (it is rejected as an unknown option, on `main` too). Out of scope; `-h` interaction is covered.

**Composition with #327 (`grep -f`).** Both `-f -` and a `-` operand consume stdin, and in GNU the first consumer wins — patterns are read before input, so `-f -` drains the stream and the `-` operand then reads EOF:

```
$ printf 'a\n' | ggrep -f - -
$ echo $?
1
```

The two PRs are independent (this one is based on `upstream/main`, not on #327). #327 renames `files` → `operands` in the arg loop and introduces `stdinUsedForPatterns`; this PR adds a `let stdinConsumed = false` next to the operand-expansion loop. Whichever lands second needs one mechanical edit: initialise `stdinConsumed` from `stdinUsedForPatterns` instead of `false`, which reproduces GNU's first-consumer-wins behaviour for free. No other overlap — #327 touches the pattern-collection half of the function, this PR touches the operand-expansion and per-file-read half.

**Composition with #314 (repeated `-e`).** #314 also renames `files` → `operands` and adds `combinePatterns`; it does not touch operand expansion, `showFilename` or the per-file read. Both PRs delete from `spec-tests/grep/skips.ts`, but from non-adjacent hunks (#314 removes the "Multiple -e patterns" block, this PR the "- for stdin argument position" block). Rebase is mechanical.

## Tests

GNU grep version used for every expectation and every fixture: **GNU grep 3.12** (Homebrew, `/opt/homebrew/opt/grep/libexec/gnubin/grep`).

- `packages/just-bash/src/commands/grep/grep.stdin-operand.test.ts` — **28 unit tests**, 286 lines, full-string stdout/stderr assertions plus exit codes. Covers the exact repro, the `(standard input)` label across `-n`/`-l`/`-L`/`-c`/`-o`/`-v`, `-h`, repeated `-` (2× and 3×), `-m`, `-r` prefixing, `--include`/`--exclude` exemption, `--` terminator, `-e`, `-` as PATTERN, empty stdin, absent stdin, and the missing-operand + `-q` exit codes.
- `packages/just-bash/src/comparison-tests/grep-stdin-operand.comparison.test.ts` + `fixtures/grep-stdin-operand.comparison.fixtures.json` — **27 comparison cases / 27 fixtures, all `"locked": true`** so BSD-grep boxes cannot silently re-record them. The re-record command is documented in the test file header:

  ```
  PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
    RECORD_FIXTURES=force pnpm test:run \
    src/comparison-tests/grep-stdin-operand.comparison.test.ts
  ```

- `packages/just-bash/src/spec-tests/grep/skips.ts` — **4 busybox spec tests unskipped** and now passing: `grep - (specify stdin)`, `grep - nofile (specify stdin and nonexisting file)`, `grep -q - nofile (... match)`, `grep -L exitcode 0 #2`. Two entries stay skipped with corrected reasons: `grep - infile` (the spec runner rewrites `input` to `/tmp/input`, so the file-name prefix differs — a runner artifact, not a grep bug) and `grep -s nofile -` (`-s` is not implemented).

Verification numbers on this branch:

- `pnpm typecheck` — clean; `pnpm lint` (biome + workflow security + `lint:banned`) — clean; `pnpm knip` — clean (2 pre-existing configuration hints only).
- `pnpm test:comparison` — 36 files, **594 passed, 0 failed**.
- grep + rg + search-engine + grep spec suites — 33 files, **1158 passed, 90 skipped, 0 failed** (grep spec alone: 332/332).
- `pnpm test:run` — **14342 passed, 97 skipped, 6 failed**. The 6 failures are pre-existing python3/WASM sandbox tests (`just-bash.bundle`, `code-exec-exploit-regression`, `defense-in-depth-independence`, `python-sqlite-information-disclosure` ×2, `worker-protocol-runtime-desync`); confirmed identical (6 failed / 26 passed across those 5 files) on a stashed, unmodified tree.

Not touched: `-L`'s exit-code inversion (GNU keys `-L`'s exit status off whether a line was *selected*, not off whether anything was printed) is being fixed separately. Every `-L` case here is one where both the current and the corrected rule agree.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
