### PR TITLE
fix(grep): match GNU exit status for -L

### DIFF
--- a/.changeset/cuddly-pugs-repeat.md
+++ b/.changeset/cuddly-pugs-repeat.md
@@ -1,0 +1,8 @@
+---
+"just-bash": patch
+---
+
+Fix `grep -L` exit status to match GNU grep. The status reports whether a line
+was selected, not whether a filename was printed, so `grep -L` now exits 0 when
+every file matched (printing nothing) and 1 when no file matched (printing every
+name) — previously these were inverted.

--- a/packages/just-bash/src/commands/grep/grep.exclude.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.exclude.test.ts
@@ -116,7 +116,7 @@ describe("grep -L (files without match)", () => {
     expect(result.stdout).toBe("/dir/no-match.txt\n/dir/also-no-match.txt\n");
   });
 
-  it("should return exit code 0 when files without match found", async () => {
+  it("should return exit code 0 when at least one file matched", async () => {
     const env = new Bash({
       files: {
         "/file1.txt": "hello",
@@ -128,7 +128,9 @@ describe("grep -L (files without match)", () => {
     expect(result.stdout).toBe("/file2.txt\n");
   });
 
-  it("should return exit code 1 when all files have matches", async () => {
+  // GNU grep 3.12: `grep -L hello file1 file2` with both files matching prints
+  // nothing and exits 0 — the status tracks selected lines, not printed names.
+  it("should return exit code 0 when all files have matches", async () => {
     const env = new Bash({
       files: {
         "/file1.txt": "hello",
@@ -136,7 +138,7 @@ describe("grep -L (files without match)", () => {
       },
     });
     const result = await env.exec("grep -L hello /file1.txt /file2.txt");
-    expect(result.exitCode).toBe(1);
+    expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("");
   });
 

--- a/packages/just-bash/src/commands/grep/grep.files-without-match.test.ts
+++ b/packages/just-bash/src/commands/grep/grep.files-without-match.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Exit-status truth table for `grep -L` / `--files-without-match`.
+ *
+ * GNU grep's status reports whether a *line was selected*, never whether a
+ * *filename was printed*. `-L` therefore has the same status rule as plain
+ * grep and `-l`: 0 if any input matched, 1 if none did, 2 on error. The
+ * counter-intuitive consequence is that `-L` exits 1 in exactly the case where
+ * it prints the most output (nothing matched, so every name is listed) and 0
+ * when it prints nothing at all (everything matched).
+ *
+ * Every expectation below was measured against GNU grep 3.12 (Homebrew
+ * `gnubin/grep`); the mixed-input cases were cross-checked against BSD grep,
+ * which agrees. BusyBox grep is the odd one out and deliberately inverts this
+ * — see the note in src/spec-tests/grep/skips.ts.
+ */
+
+const FILES = {
+  "/m1.txt": "hello\nworld\n",
+  "/m2.txt": "hello there\n",
+  "/n1.txt": "nothing here\n",
+  "/n2.txt": "nope\n",
+  "/empty.txt": "",
+};
+
+const env = (): Bash => new Bash({ files: FILES });
+
+describe("grep -L exit status (GNU semantics)", () => {
+  it("exits 0 and prints nothing when every file matches", async () => {
+    const result = await env().exec("grep -L hello /m1.txt /m2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 and lists every file when no file matches", async () => {
+    const result = await env().exec("grep -L hello /n1.txt /n2.txt");
+    expect(result.stdout).toBe("/n1.txt\n/n2.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 0 and lists only the non-matching file when input is mixed", async () => {
+    const result = await env().exec("grep -L hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 0 and prints nothing for a single matching file", async () => {
+    const result = await env().exec("grep -L hello /m1.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 and prints the name for a single non-matching file", async () => {
+    const result = await env().exec("grep -L hello /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 1 for an empty file, which can never match", async () => {
+    const result = await env().exec("grep -L hello /empty.txt");
+    expect(result.stdout).toBe("/empty.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("keeps -l as the mirror image of -L", async () => {
+    const listed = await env().exec("grep -l hello /m1.txt /n1.txt");
+    expect(listed.stdout).toBe("/m1.txt\n");
+    expect(listed.stderr).toBe("");
+    expect(listed.exitCode).toBe(0);
+
+    const none = await env().exec("grep -l hello /n1.txt /n2.txt");
+    expect(none.stdout).toBe("");
+    expect(none.stderr).toBe("");
+    expect(none.exitCode).toBe(1);
+  });
+});
+
+describe("grep -L exit status with unreadable operands", () => {
+  it("exits 2 when an operand is missing even though another matched", async () => {
+    const result = await env().exec("grep -L hello /m1.txt /missing.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: /missing.txt: No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("exits 2 when an operand is missing and prints the names it did resolve", async () => {
+    const result = await env().exec("grep -L hello /n1.txt /missing.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe(
+      "grep: /missing.txt: No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("exits 2 when the only operand is missing", async () => {
+    const result = await env().exec("grep -L hello /missing.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "grep: /missing.txt: No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(2);
+  });
+
+  it("lets an error outrank a listed name but not a -q match", async () => {
+    // GNU 3.12 exits before it ever opens /missing.txt here, so there is no
+    // diagnostic to print and the selected line wins over the error.
+    const result = await env().exec("grep -L -q hello /m1.txt /missing.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -L combined with -q", () => {
+  it("exits 0 and stays silent when every file matches", async () => {
+    const result = await env().exec("grep -L -q hello /m1.txt /m2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 and stays silent when no file matches", async () => {
+    const result = await env().exec("grep -L -q hello /n1.txt /n2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 0 and stays silent on mixed input", async () => {
+    const result = await env().exec("grep -L -q hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -L combined with -c", () => {
+  // GNU lets -L win over -c: names are printed, counts are not, and the status
+  // rule is unchanged.
+  it("exits 0 and prints nothing when every file matches", async () => {
+    const result = await env().exec("grep -L -c hello /m1.txt /m2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 and prints names, not counts, when no file matches", async () => {
+    const result = await env().exec("grep -L -c hello /n1.txt /n2.txt");
+    expect(result.stdout).toBe("/n1.txt\n/n2.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("exits 0 and prints only the non-matching name on mixed input", async () => {
+    const result = await env().exec("grep -L -c hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});
+
+describe("grep -L combined with other output options", () => {
+  it("ignores -n, which selects no lines to number", async () => {
+    const result = await env().exec("grep -L -n hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("ignores -o, which selects no matches to print", async () => {
+    const result = await env().exec("grep -L -o hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("ignores -m, which only caps matches per file", async () => {
+    const result = await env().exec("grep -L -m 1 hello /m1.txt /n1.txt");
+    expect(result.stdout).toBe("/n1.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("inverts which files are listed under -v", async () => {
+    // /m1.txt holds `hello` and `world`, so -v selects the `world` line and the
+    // file is not listed; /n2.txt is a single non-`hello` line, which -v selects
+    // as well. Nothing is left to list, and a line was selected, so exit 0.
+    const result = await env().exec("grep -L -v hello /m1.txt /n2.txt");
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("uses the same rule under --files-without-match", async () => {
+    const allMatch = await env().exec(
+      "grep --files-without-match hello /m1.txt /m2.txt",
+    );
+    expect(allMatch.stdout).toBe("");
+    expect(allMatch.stderr).toBe("");
+    expect(allMatch.exitCode).toBe(0);
+
+    const noneMatch = await env().exec(
+      "grep --files-without-match hello /n1.txt /n2.txt",
+    );
+    expect(noneMatch.stdout).toBe("/n1.txt\n/n2.txt\n");
+    expect(noneMatch.stderr).toBe("");
+    expect(noneMatch.exitCode).toBe(1);
+  });
+});
+
+describe("grep -L with recursive search", () => {
+  const tree = (): Bash =>
+    new Bash({
+      files: {
+        "/dir/has.txt": "hello\n",
+        "/dir/lacks.txt": "goodbye\n",
+        "/dir/sub/has2.txt": "hello\n",
+        "/dir/sub/lacks2.txt": "goodbye\n",
+      },
+    });
+
+  it("exits 0 while listing the non-matching files under the tree", async () => {
+    const result = await tree().exec("grep -rL hello /dir");
+    expect(result.stdout).toBe("/dir/lacks.txt\n/dir/sub/lacks2.txt\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("exits 1 when nothing under the tree matches", async () => {
+    const result = await tree().exec("grep -rL nowhere /dir");
+    expect(result.stdout).toBe(
+      "/dir/has.txt\n/dir/lacks.txt\n/dir/sub/has2.txt\n/dir/sub/lacks2.txt\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+});

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -523,13 +523,18 @@ export const grepCommand: RuntimeCommand = {
       }
     }
 
-    // Exit codes: 0 = match found (or files without match for -L), 1 = no match, 2 = error
-    // For -L, success means we found files without matches (stdout has content)
+    // Exit codes: 0 = a line was selected, 1 = no line was selected, 2 = error.
+    //
+    // -L deliberately does NOT get its own rule. GNU grep's status reports
+    // whether a line was *selected*, never whether a filename was *printed*, so
+    // `grep -L` exits 0 when every file matched (and it printed nothing) and 1
+    // when no file matched (and it listed them all). Verified against GNU grep
+    // 3.12 and BSD grep 2.6.0-FreeBSD; note that ripgrep 15.1.0's
+    // --files-without-match really does invert this, which is why
+    // src/commands/rg/rg-search.ts keeps the opposite rule on purpose.
     let exitCode: number;
     if (anyError) {
       exitCode = 2;
-    } else if (filesWithoutMatch) {
-      exitCode = stdout.length > 0 ? 0 : 1;
     } else {
       exitCode = anyMatch ? 0 : 1;
     }

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -1349,6 +1349,17 @@ async function searchFiles(
   // Exit codes:
   // - For --files-without-match: 0 if files without matches found, 1 otherwise
   // - For normal mode: 0 if any matches found, 1 otherwise
+  //
+  // The --files-without-match rule below is NOT a copy of grep's and must not
+  // be "fixed" to agree with it: ripgrep really does invert the status here,
+  // where GNU grep does not. Measured with ripgrep 15.1.0 against GNU grep
+  // 3.12, over two files where only the first contains the pattern:
+  //
+  //   both files match -> rg prints nothing, exits 1; grep -L exits 0
+  //   neither matches  -> rg lists both,     exits 0; grep -L exits 1
+  //   mixed            -> both list the miss and exit 0
+  //
+  // See the matching note in src/commands/grep/grep.ts.
   let exitCode: number;
   if (options.filesWithoutMatch) {
     // Success means we found files without matches (stdout has content)

--- a/packages/just-bash/src/comparison-tests/fixtures/grep-files-without-match.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/grep-files-without-match.comparison.fixtures.json
@@ -1,0 +1,408 @@
+{
+  "009b770e4d52e66b": {
+    "command": "grep -L hello n1.txt missing.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "grep: missing.txt: No such file or directory\n",
+    "exitCode": 2,
+    "locked": true
+  },
+  "01d40dba5bc939ae": {
+    "command": "grep -L -q hello m1.txt m2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "0a10969c7052bbb9": {
+    "command": "grep -L hello n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "0f829363d4be0682": {
+    "command": "grep -L -c hello m1.txt m2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "1b04a52005e33152": {
+    "command": "grep --files-without-match hello m1.txt m2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "1c64dbbff705e888": {
+    "command": "grep -L -q hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "207e929298a0994d": {
+    "command": "grep -L hello n1.txt n2.txt; echo status=$?",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\nn2.txt\nstatus=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "214274828240cd29": {
+    "command": "grep -L -c hello n1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\nn2.txt\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "2262b30f3f1ef888": {
+    "command": "grep -l hello n1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "39aa27a4fd38ee90": {
+    "command": "grep --files-without-match hello n1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\nn2.txt\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "43ccef00eaa53b73": {
+    "command": "grep -l hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "m1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "468791bf3e6d4af8": {
+    "command": "if grep -L hello n1.txt n2.txt >/dev/null; then echo yes; else echo no; fi",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "no\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "570ef3aaae0c5262": {
+    "command": "grep -L hello missing.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "grep: missing.txt: No such file or directory\n",
+    "exitCode": 2,
+    "locked": true
+  },
+  "574840e45c157cdc": {
+    "command": "grep -L hello m1.txt missing.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "grep: missing.txt: No such file or directory\n",
+    "exitCode": 2,
+    "locked": true
+  },
+  "574a3323d5002714": {
+    "command": "grep -L -m 1 hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "5a5f46cfc6515816": {
+    "command": "grep -L -q hello n1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "5b8adc3899c43896": {
+    "command": "grep -L hello m1.txt m2.txt; echo status=$?",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "status=0\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "7df6db4b52749304": {
+    "command": "grep -L hello m1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "81ea328383db77f9": {
+    "command": "grep -l hello m1.txt m2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "m1.txt\nm2.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "83f57d5a494cdaa1": {
+    "command": "grep -L hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "a30de201cb61f42e": {
+    "command": "grep -L hello m1.txt m2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ae62b94bc5450d2e": {
+    "command": "grep -L -q hello m1.txt missing.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "aff4ca10b0584c67": {
+    "command": "grep -L -c hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b4df228b24cdd393": {
+    "command": "if grep -L hello m1.txt m2.txt >/dev/null; then echo yes; else echo no; fi",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "yes\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ba01bcd1a77f25b3": {
+    "command": "grep -L hello empty.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "empty.txt\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  },
+  "c785a217d4aa37cd": {
+    "command": "grep -L -n hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ce67dfb9d3ab2b88": {
+    "command": "grep -L -v hello m1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d5166ed017f4a6b6": {
+    "command": "grep -L -o hello m1.txt n1.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d639fec203c7dffc": {
+    "command": "grep -L hello n1.txt n2.txt",
+    "files": {
+      "m1.txt": "hello\nworld\n",
+      "m2.txt": "hello there\n",
+      "n1.txt": "nothing here\n",
+      "n2.txt": "nope\n",
+      "empty.txt": ""
+    },
+    "stdout": "n1.txt\nn2.txt\n",
+    "stderr": "",
+    "exitCode": 1,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/grep-files-without-match.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/grep-files-without-match.comparison.test.ts
@@ -1,0 +1,222 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * `grep -L` / `--files-without-match` exit-status comparison tests.
+ *
+ * GNU grep's status reports whether a line was *selected*, not whether a
+ * filename was *printed*, so `-L` exits 0 when every file matched (printing
+ * nothing) and 1 when none did (printing every name).
+ *
+ * Fixtures are recorded against GNU grep 3.12, not the BSD grep that ships with
+ * macOS, and are therefore locked. To re-record:
+ *
+ *   PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
+ *     RECORD_FIXTURES=force pnpm test:run \
+ *     src/comparison-tests/grep-files-without-match.comparison.test.ts
+ */
+describe("grep -L - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const files = {
+    "m1.txt": "hello\nworld\n",
+    "m2.txt": "hello there\n",
+    "n1.txt": "nothing here\n",
+    "n2.txt": "nope\n",
+    "empty.txt": "",
+  };
+
+  describe("exit status", () => {
+    it("should exit 0 and print nothing when every file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello m1.txt m2.txt");
+    });
+
+    it("should exit 1 and list every file when no file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello n1.txt n2.txt");
+    });
+
+    it("should exit 0 and list only the non-matching file on mixed input", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello m1.txt n1.txt");
+    });
+
+    it("should exit 0 for a single matching file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello m1.txt");
+    });
+
+    it("should exit 1 for a single non-matching file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello n1.txt");
+    });
+
+    it("should exit 1 for an empty file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello empty.txt");
+    });
+
+    it("should report the status through $? after -L", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "grep -L hello m1.txt m2.txt; echo status=$?",
+      );
+    });
+
+    it("should report the status through $? when nothing matched", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "grep -L hello n1.txt n2.txt; echo status=$?",
+      );
+    });
+
+    it("should be usable as an if condition when every file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "if grep -L hello m1.txt m2.txt >/dev/null; then echo yes; else echo no; fi",
+      );
+    });
+
+    it("should be usable as an if condition when no file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "if grep -L hello n1.txt n2.txt >/dev/null; then echo yes; else echo no; fi",
+      );
+    });
+  });
+
+  describe("mirror of -l", () => {
+    it("should exit 0 and list matching files under -l", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -l hello m1.txt n1.txt");
+    });
+
+    it("should exit 1 and print nothing under -l when nothing matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -l hello n1.txt n2.txt");
+    });
+
+    it("should exit 0 under -l when every file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -l hello m1.txt m2.txt");
+    });
+  });
+
+  describe("unreadable operands", () => {
+    it("should exit 2 when an operand is missing even though another matched", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello m1.txt missing.txt");
+    });
+
+    it("should exit 2 and still list the resolved non-matching file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello n1.txt missing.txt");
+    });
+
+    it("should exit 2 when the only operand is missing", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L hello missing.txt");
+    });
+  });
+
+  describe("combined with -q", () => {
+    it("should exit 0 quietly when every file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -q hello m1.txt m2.txt");
+    });
+
+    it("should exit 1 quietly when no file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -q hello n1.txt n2.txt");
+    });
+
+    it("should exit 0 quietly on mixed input", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -q hello m1.txt n1.txt");
+    });
+
+    it("should let a -q match outrank a missing operand", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -q hello m1.txt missing.txt");
+    });
+  });
+
+  describe("combined with -c", () => {
+    it("should print names rather than counts when every file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -c hello m1.txt m2.txt");
+    });
+
+    it("should print names rather than counts when no file matches", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -c hello n1.txt n2.txt");
+    });
+
+    it("should print names rather than counts on mixed input", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -c hello m1.txt n1.txt");
+    });
+  });
+
+  describe("combined with other output options", () => {
+    it("should ignore -n under -L", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -n hello m1.txt n1.txt");
+    });
+
+    it("should ignore -o under -L", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -o hello m1.txt n1.txt");
+    });
+
+    it("should ignore -m under -L", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -m 1 hello m1.txt n1.txt");
+    });
+
+    it("should invert which files are listed under -v", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "grep -L -v hello m1.txt n2.txt");
+    });
+
+    it("should use the same rule under --files-without-match", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "grep --files-without-match hello n1.txt n2.txt",
+      );
+    });
+
+    it("should use the same rule under --files-without-match when all match", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "grep --files-without-match hello m1.txt m2.txt",
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/spec-tests/grep/skips.ts
+++ b/packages/just-bash/src/spec-tests/grep/skips.ts
@@ -155,7 +155,28 @@ const SKIP_TESTS: Map<string, string> = new Map<string, string>([
   ],
 
   // -L option (print files without matches)
-  ["busybox-grep.tests:grep -L exitcode 0", "-L option not implemented"],
+  //
+  // BusyBox deliberately inverts -L's exit status — its own comment above these
+  // two cases reads "-L ... has inverted exitcode (if it printed something,
+  // it's 'success')". GNU grep 3.12 and BSD grep both disagree: the status
+  // reports whether a *line was selected*, not whether a *name was printed*.
+  // Measured with GNU grep 3.12 and BSD grep 2.6.0-FreeBSD, `input` holding
+  // one line:
+  //
+  //   input="asd" -> `grep -L qwe input` prints "input", exits 1 (BusyBox: 0)
+  //   input="qwe" -> `grep -L qwe input` prints nothing, exits 0 (BusyBox: 1)
+  //
+  // just-bash follows GNU, so both cases are expected to fail here.
+  // ("grep -L exitcode 0 #2" is skipped above for an unrelated reason — its
+  // expectation is mixed input and does agree with GNU; it just needs `-`.)
+  [
+    "busybox-grep.tests:grep -L exitcode 0",
+    "BusyBox inverts -L exit status; just-bash follows GNU/BSD",
+  ],
+  [
+    "busybox-grep.tests:grep -L exitcode 1",
+    "BusyBox inverts -L exit status; just-bash follows GNU/BSD",
+  ],
 
   // -o option (only matching) - edge cases
   [


### PR DESCRIPTION
## Summary

`grep -L` returns the wrong exit status. just-bash derives it from whether any
filename was printed; GNU grep derives it from whether any **line was
selected**. The two agree only on mixed input, and are exact opposites when
every file matches or no file does.

No issue number — this was found while reviewing #327 (`grep -f`), which noted
it as a pre-existing gap it deliberately did not touch:

> **Known gap (pre-existing, not touched here):** `grep -L`'s exit code is
> inverted relative to GNU […] `-L` is already listed as unimplemented in the
> spec-test skips, so no `-L` assertion is included.

This PR closes that gap.

The offending branch, `packages/just-bash/src/commands/grep/grep.ts`:

```ts
} else if (filesWithoutMatch) {
  exitCode = stdout.length > 0 ? 0 : 1;
}
```

`stdout.length > 0` is "did I print a name", which is precisely the inverse of
"did a line match" — hence the inversion, and hence why `-L` scripted as
`if grep -L pat *.c; then …` took the wrong branch.

## Details

### Measured GNU truth table

Every row below was run against **GNU grep 3.12** (Homebrew `grep`, i.e.
`/opt/homebrew/opt/grep/libexec/gnubin/grep`), not read from documentation.
Files: `m1.txt`/`m2.txt` contain `hello`, `n1.txt`/`n2.txt` do not, `empty.txt`
is zero-length, `missing.txt` does not exist.

| # | command | GNU stdout | GNU stderr | GNU exit | just-bash **was** | now |
|---|---------|-----------|-----------|----------|-------------------|-----|
| a | `-L hello m1 m2` (all match) | — | — | **0** | 1 ❌ | 0 ✅ |
| b | `-L hello n1 n2` (none match) | `n1`,`n2` | — | **1** | 0 ❌ | 1 ✅ |
| c | `-L hello m1 n1` (mixed) | `n1` | — | 0 | 0 ✅ | 0 ✅ |
| d1 | `-L hello m1` (single, match) | — | — | **0** | 1 ❌ | 0 ✅ |
| d2 | `-L hello n1` (single, no match) | `n1` | — | **1** | 0 ❌ | 1 ✅ |
| e1 | `-L hello m1 missing` | — | `No such file or directory` | 2 | 2 ✅ | 2 ✅ |
| e2 | `-L hello n1 missing` | `n1` | `No such file or directory` | 2 | 2 ✅ | 2 ✅ |
| e3 | `-L hello missing` | — | `No such file or directory` | 2 | 2 ✅ | 2 ✅ |
| f1 | `-L -q hello m1 m2` | — | — | 0 | 0 ✅ | 0 ✅ |
| f2 | `-L -q hello n1 n2` | — | — | **1** | 0 ❌ | 1 ✅ |
| f3 | `-L -q hello m1 n1` | — | — | 0 | 0 ✅ | 0 ✅ |
| g1 | `-L hello` (stdin, matches) | — | — | 0 | 0 ✅ (stdout differs, see below) | 0 |
| g2 | `-L hello` (stdin, no match) | `(standard input)` | — | 1 | 1 ✅ (stdout differs) | 1 |
| h1 | `-L -c hello m1 m2` | — | — | **0** | 1 ❌ | 0 ✅ |
| h2 | `-L -c hello n1 n2` | `n1`,`n2` | — | **1** | 0 ❌ | 1 ✅ |
| h3 | `-L -c hello m1 n1` | `n1` | — | 0 | 0 ✅ | 0 ✅ |
| j | `-L hello empty.txt` | `empty.txt` | — | **1** | 0 ❌ | 1 ✅ |

Supplementary rows, same method:

| command | GNU stdout | GNU exit | note |
|---------|-----------|----------|------|
| `-L -q hello m1 missing` | — | **0** | a `-q` match outranks the error; GNU exits before opening `missing` |
| `-L -q hello missing m1` | — | 0 | same, but the diagnostic *is* printed first |
| `-L -q hello n1 missing` | — | 2 | no match, so the error stands |
| `-L -s hello n1 missing` | `n1` | 2 | `-s` hides the message, not the status ‡ |
| `-L -n / -o / -m 1 hello m1 n1` | `n1` | 0 | line-formatting flags are inert under `-L` |
| `-L -v hello m1 n2` | — | 0 | `-v` changes which lines are selected, not the rule |
| `-L -r hello .` | the non-matching files | 0 | recursion changes nothing |
| `-L hello sub` (a directory, no `-r`) | `sub` + `Is a directory` on stderr | 2 | see divergence 4 below |

‡ The `-s` row records GNU only, and is **not** a compatibility claim: just-bash
does not implement `-s` at all. It falls through to the unknown-option path and
prints `grep: invalid option -- 's'` with **exit 1**, where GNU rejects an
unknown option with **exit 2** (measured: `ggrep -Y hello n1.txt` → 2). Both the
missing `-s` and the unknown-option status are pre-existing and out of scope
here; `-s` is already noted as unimplemented in the grep spec skip list.

**The rule in one line:** `-L` has no exit-status rule of its own. Status is 0
if any line was selected anywhere, 1 if none was, 2 on error — except that under
`-q` a selected line wins over an error. `-l` and plain `grep` already follow
exactly this, which is what makes the fix a deletion rather than an addition.

The counter-intuitive consequence, and the reason the old code looked
plausible: `-L` exits **1** in the case where it prints the *most* (nothing
matched, so every name is listed) and **0** when it prints *nothing at all*.

Cross-checked against **BSD grep 2.6.0-FreeBSD** (`/usr/bin/grep` on macOS) for
rows a/b/d1/d2 — it agrees with GNU.

### The fix

One branch deleted in `grep.ts`, replaced with a comment recording the rule and
the measurement. `filesWithoutMatch` still drives *what gets printed*; it no
longer drives the status.

```ts
let exitCode: number;
if (anyError) {
  exitCode = 2;
} else {
  exitCode = anyMatch ? 0 : 1;
}
```

`-q` needed no change: the existing early return on first match already yields
GNU's "a `-q` match outranks an error", and quiet mode with no match now falls
through to the corrected rule (row f2).

### Deliberately *not* changed: `rg --files-without-match`

`src/commands/rg/rg-search.ts` carries the same `stdout.length > 0 ? 0 : 1`
shape. That one is **correct** and is left alone — real ripgrep genuinely does
invert the status here. Measured with **ripgrep 15.1.0**:

| command | rg stdout | rg exit | GNU grep exit |
|---------|-----------|---------|---------------|
| `rg --files-without-match hello m1 m2` | — | **1** | 0 |
| `rg --files-without-match hello n1 n2` | `n1`,`n2` | **0** | 1 |
| `rg --files-without-match hello m1 n1` | `n1` | 0 | 0 |

So grep and rg must keep opposite rules. To stop a future reader "fixing" the
two into agreement, both sides now carry a comment citing the measured versions:
`grep.ts` points at `rg-search.ts`, and `rg-search.ts` gets a **comment-only**
change pointing back, with the three-row table above inlined. No rg behaviour is
touched — `rg-search.ts`'s diff is entirely inside a comment block, and the rg
suite is unchanged at its baseline count.

### Spec tests

Net zero unskipped — the two BusyBox `-L` exit-status cases encode BusyBox's
own deliberate deviation, which the BusyBox test file states in a comment
directly above them:

> `# -L "show filenames which do not match" has inverted exitcode (if it printed something, it's "success")`

Measured, with `input` holding a single line:

| busybox case | infile | busybox expects | GNU 3.12 | BSD 2.6.0 |
|---|---|---|---|---|
| `grep -L exitcode 0` | `asd` | `input\n0\n` | `input\n1\n` | `input\n1\n` |
| `grep -L exitcode 1` | `qwe` | `1\n` | `0\n` | `0\n` |

- `grep -L exitcode 0` was **already skipped** (as `"-L option not
  implemented"`). It still fails, for the newly-understood reason; the skip
  reason is corrected to `"BusyBox inverts -L exit status; just-bash follows
  GNU/BSD"`.
- `grep -L exitcode 1` was **passing by accident** — just-bash happened to
  reproduce BusyBox's inversion — and is now skipped with the same reason. This
  is the one intentional spec regression, and it is a regression against
  BusyBox, not against GNU.
- `grep -L exitcode 0 #2` (`grep -L qwe input -`) is untouched. Its expectation
  is `(standard input)\n0\n`, and I verified GNU 3.12 produces exactly that —
  it is mixed input, the one shape where BusyBox and GNU agree. It stays
  skipped under its existing `"- stdin arg not supported"` reason, which
  belongs to the `-` stdin operand work, not here.

The skip list now carries the measured numbers inline so the next reader does
not have to re-derive them.

### Known divergences left in place (out of scope)

Found while measuring; each is pre-existing, none is an exit-status bug, and
each belongs to a different region of `grep.ts`:

1. **`-L` / `-l` with stdin print the wrong thing.** GNU prints
   `(standard input)`; just-bash prints matching lines. Affects `-l` identically,
   so it is not a `-L` inversion, and it overlaps the `-` stdin operand work in
   flight. Exit codes on this path are already GNU-correct (rows g1/g2), which
   is why the fix here is self-contained.
2. **`-l` and `-L` together apply both flags.** GNU takes the last one
   (`-L -l` → `m1`; `-l -L` → `n1`); just-bash prints both files. Option-parsing
   bug, not a status bug.
3. **`-q` swallows stderr.** GNU still prints `grep: missing: No such file or
   directory` under `-q`; just-bash returns `stderr: ""`. Applies to all of
   `-q`, not just `-L`.
4. **A directory operand without `-r` gets the wrong exit status too.** Calling
   this out explicitly because this PR is about exit codes: it is not merely a
   printing difference. just-bash prints the `Is a directory` diagnostic but
   does not treat it as an error, so the status comes out 1 (or 0) where GNU
   gives 2. Measured against GNU 3.12, with `sub/` a directory containing a
   matching file:

   | command | GNU stdout / exit | just-bash stdout / exit |
   |---|---|---|
   | `grep hello sub` | — / **2** | — / 1 |
   | `grep -l hello sub` | — / **2** | — / 1 |
   | `grep -L hello sub` | `sub` / **2** | — / 1 |
   | `grep -L hello m1.txt sub` | `sub` / **2** | — / **0** |

   Root cause is `grep.ts`'s result loop, which deliberately excludes this one
   diagnostic from the error flag:

   ```ts
   if (!res.error.includes("Is a directory")) {
     anyError = true;
   }
   ```

   It is pre-existing, it is shared identically by plain `grep` and `-l`, and it
   is a *different* rule from the `-L` inversion this PR fixes (the error flag,
   not the match flag). Removing that exclusion changes plain `grep` and `-l`
   behaviour and needs its own truth table, so it stays out of scope — but it is
   the most closely related remaining bug and the obvious follow-up. GNU also
   still lists the directory name under `-L`, which just-bash does not.

### Composition with other open grep PRs

Based on `upstream/main` (`1e06ce6`). Touches only the exit-status computation
near the end of `execute`, plus tests and the spec-skip list.

- **#327 (`grep -f`)** restructures pattern/operand handling in the *first*
  half of `execute` and deletes entries from `skips.ts`. Different region of
  `grep.ts`; the only shared file region is `skips.ts`, where #327 removes
  `-f`-related entries and this PR edits the `-L` entries — disjoint lines.
- **#314 (`-e` last-wins)** likewise works on pattern combination, not on the
  result loop.

Neither PR reads or writes `anyMatch`/`anyError`, so whichever order they land
in, no semantic conflict arises.

## Tests

**New:** `packages/just-bash/src/commands/grep/grep.files-without-match.test.ts`
— 24 tests, 242 lines, covering the whole measured table: the four homogeneous
and mixed shapes, single-file both ways, empty file, the `-l` mirror, three
missing-operand cases, the `-q` match-outranks-error case, `-q` × 3, `-c` × 3,
`-n`/`-o`/`-m`/`-v`, `--files-without-match` long form, and `-r` both ways.
Every assertion is full-string `stdout` **and** `stderr` plus exit code — 26
complete trios across the 24 tests (two tests exercise two invocations each).

**New:**
`packages/just-bash/src/comparison-tests/grep-files-without-match.comparison.test.ts`
+ `fixtures/grep-files-without-match.comparison.fixtures.json` — **29
fixtures**, including two `; echo status=$?` cases and two `if grep -L …; then`
cases that pin the status as a *script* observes it, which is how the bug
actually bites.

**Changed:** `grep.exclude.test.ts` — exactly one assertion flipped, from

```ts
it("should return exit code 1 when all files have matches", …)
  expect(result.exitCode).toBe(1);
```

to `0`, because GNU 3.12 gives:

```
$ ggrep -L hello file1.txt file2.txt   # both contain "hello"
$ echo $?
0
```

(the test's own stdout expectation, `""`, was already right). One sibling test
was renamed from "…when files without match found" to "…when at least one file
matched" — its expectation was already correct, but the old name described the
disproven rule. No other existing test asserted the inverted behaviour.

**Fixture recording.** macOS ships BSD grep 2.6.0-FreeBSD, so fixtures were
recorded against **GNU grep 3.12** with its `gnubin` first on `PATH`, and all
29 entries are marked `"locked": true` so a re-record on a BSD box cannot
silently swap GNU behaviour for BSD behaviour. The command is documented at the
top of the test file, per #327:

```
PATH=/opt/homebrew/opt/grep/libexec/gnubin:$PATH \
  RECORD_FIXTURES=force pnpm test:run \
  src/comparison-tests/grep-files-without-match.comparison.test.ts
```

**Verification** (all from this branch):

| check | result |
|---|---|
| `pnpm typecheck` | clean |
| `pnpm lint:fix` | clean, no fixes applied (1040 files) |
| `pnpm lint:banned` | clean |
| `pnpm knip` | clean — only the 2 pre-existing configuration hints |
| `pnpm test:comparison` | **596 passed**, 36 files (baseline 567 / 35 → +29 / +1) |
| grep + rg + search-engine + spec-tests/grep | **1154 passed, 90 skipped**, 33 files (baseline 1130 / 90 / 32 → +24 tests, +1 file) |
| `pnpm test:run` (full, after `pnpm build`) | **14 340 passed, 97 skipped, 6 failed** in 5 files |

The 6 remaining failures are all python3/CPython-WASM probes and are
**pre-existing**:

```
src/cli/just-bash.bundle.test.ts                            (python3 lazy-load)
src/security/attacks/code-exec-exploit-regression.test.ts   (python worker escape)
src/security/attacks/defense-in-depth-independence.test.ts  (python exploit probes)
src/security/sandbox/python-sqlite-information-disclosure.test.ts  (2 tests)
src/security/sandbox/worker-protocol-runtime-desync.test.ts (python3 stdout)
```

Every failing test name contains `python`. All five files were already failing
on a clean `upstream/main` tree before this change (they were part of a larger
`12 files / 96 failed` set that `pnpm build` reduces to this residue by
supplying `dist/` and the bundled workers). Two of the five mention grep at all:
`just-bash.bundle.test.ts` has a *passing* `lazy-load commands (grep)` case
alongside the failing python3 one, and
`python-sqlite-information-disclosure.test.ts` uses `grep -Eq` internally —
neither sets `-L`, so both take the `else` branch, which this PR leaves
byte-for-byte unchanged.

On the tally: the +24 is exactly the new unit-test file (1130 → 1154), and the
reported "90 skipped" is unchanged. Adding `grep -L exitcode 1` to the grep
skip list does not move either number, because `grep-spec.test.ts` handles
skips internally — it calls `it()` unconditionally and returns early when
`getSkipReason` matched, so a skipped spec case still registers as a passing
vitest test. `src/spec-tests/grep` reports `332 passed (332)` both before and
after; the 90 skipped come from other files in the grep/rg/search-engine
suites.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019DayCPuYZEmv4VszJXTHT3
