### PR TITLE
fix(network): read the pinned transport off the bundled undici namespace

### DIFF
--- a/.changeset/dns-pin-bundled-undici-interop.md
+++ b/.changeset/dns-pin-bundled-undici-interop.md
@@ -1,0 +1,11 @@
+---
+"just-bash": patch
+---
+
+network: restore private-range-enforced requests from the bundled build
+
+Every request made with `denyPrivateRanges` enabled failed with `Network access denied: DNS pinning unavailable for private IP enforcement`, so `curl` could not reach any host at all. The published ESM bundle was affected; source consumers and the CommonJS bundle were not.
+
+The pinned connection owner reads `Agent` and `fetch` off a dynamic `import("undici")`. Node's resolution of the package exposes those as named exports, but the ESM build inlines undici's CommonJS module into a chunk whose namespace carries it under `default` alone, so `Agent` was `undefined` and the `TypeError` from constructing it was reported as a runtime incapable of pinning.
+
+The namespace is now normalized before the transport is read off it, which also covers a consumer that bundles just-bash further.

--- a/packages/just-bash/src/network/dns-pin.test.ts
+++ b/packages/just-bash/src/network/dns-pin.test.ts
@@ -1,6 +1,10 @@
 import dns from "node:dns";
 import { describe, expect, it } from "vitest";
-import { _createPinnedLookup, createPinnedConnectionOwner } from "./dns-pin.js";
+import {
+  _createPinnedLookup,
+  _undiciExports,
+  createPinnedConnectionOwner,
+} from "./dns-pin.js";
 
 function lookup(
   pin: { hostname: string; address: string; family: 4 | 6 },
@@ -70,6 +74,19 @@ describe("request-owned DNS connector lookup", () => {
       { address: "1.1.1.1", family: 4 },
       { address: "8.8.8.8", family: 4 },
     ]);
+  });
+
+  it("reads the transport off a bundled namespace", async () => {
+    const undici = await import("undici");
+    // What a bundler that inlined undici's CommonJS module hands back: one
+    // key, with everything the transport needs behind it. Reading `Agent`
+    // straight off this namespace is undefined, and the resulting TypeError
+    // reports as a runtime that cannot pin at all.
+    const bundled = { default: undici.default };
+
+    expect(_undiciExports(bundled).Agent).toBe(undici.Agent);
+    expect(_undiciExports(bundled).fetch).toBe(undici.fetch);
+    expect(_undiciExports(undici).Agent).toBe(undici.Agent);
   });
 
   it("creates independent pools without patching process-global DNS", async () => {

--- a/packages/just-bash/src/network/dns-pin.ts
+++ b/packages/just-bash/src/network/dns-pin.ts
@@ -36,6 +36,24 @@ export class DnsPinningUnavailableError extends Error {
   }
 }
 
+/**
+ * Both shapes a dynamic `import("undici")` can resolve to.
+ *
+ * Node resolves the package and exposes its CommonJS exports as named ones. A
+ * bundler that inlines the same module into its own graph cannot always do
+ * that, and hands back a namespace carrying the module under `default` alone.
+ */
+type UndiciNamespace =
+  | typeof import("undici")
+  | Pick<typeof import("undici"), "default">;
+
+type UndiciExports = typeof import("undici") | typeof import("undici").default;
+
+/** @internal Pure namespace normalization used by focused interop tests. */
+export function _undiciExports(namespace: UndiciNamespace): UndiciExports {
+  return "Agent" in namespace ? namespace : namespace.default;
+}
+
 type PinnedLookup = import("node:net").LookupFunction;
 
 function lookupDenied(hostname: string): NodeJS.ErrnoException {
@@ -87,8 +105,14 @@ export const createPinnedConnectionOwner: PinnedConnectionOwnerFactory = async (
 
   try {
     // This branch is removed from the browser build by __BROWSER__ folding.
-    const undici = await import("undici");
-    const agent = new undici.Agent({
+    // Read the transport off the normalized namespace: a bundled undici is
+    // reachable only through `default`, and `new undefined()` here would be
+    // reported as a runtime that cannot pin rather than as the packaging
+    // problem it is.
+    const { Agent, fetch: undiciFetch } = _undiciExports(
+      await import("undici"),
+    );
+    const agent = new Agent({
       connections: 1,
       pipelining: 0,
       connect: {
@@ -100,7 +124,7 @@ export const createPinnedConnectionOwner: PinnedConnectionOwnerFactory = async (
     return {
       async fetch(url, init) {
         if (closed) throw new DnsPinningUnavailableError();
-        const boundFetch = undici.fetch as unknown as (
+        const boundFetch = undiciFetch as unknown as (
           input: string,
           options: unknown,
         ) => Promise<unknown>;


### PR DESCRIPTION
## Problem

With `denyPrivateRanges` enabled, every request fails. Not some hosts — every host, including the one in the docs:

```js
const bash = new Bash({
  commands: ["curl"],
  network: { dangerouslyAllowFullInternetAccess: true, denyPrivateRanges: true },
})
await bash.exec("curl -sS https://example.com/")
// curl: (7) Network access denied: DNS pinning unavailable for private IP enforcement
```

The published `just-bash@3.2.0` ESM bundle and the `just-bash` CLI bundle are both affected. Source consumers and `dist/bundle/index.cjs` are not, which is why this reads as an environment problem: the same code works under `tsx` and fails from the package on npm.

`curl` is the only command that reaches the network, so for a harness that enables the private-range guard — the case the option exists for — the sandbox loses its download primitive entirely. An agent hits it as "the network is broken here", tries a different URL, and works around it.

## Cause

`createPinnedConnectionOwner` reads the transport off a dynamic import:

```ts
const undici = await import("undici");
const agent = new undici.Agent({ ... });
```

`build:lib` does not list undici in its externals, so esbuild inlines it. The chunk it emits for a dynamically imported CommonJS module exposes one key:

```
namespace keys: [ 'default' ]
default keys:   [ 'Dispatcher', 'Client', 'Pool', …, 'Agent', 'fetch', … ]
```

So `undici.Agent` is `undefined`, `new undici.Agent(...)` throws `TypeError: undici.Agent is not a constructor`, and the blanket `catch` at the end of the factory rewrites it as `DnsPinningUnavailableError`. `fetch.ts` turns that into `NetworkAccessDeniedError("DNS pinning unavailable for private IP enforcement")`. The reported cause is a runtime that cannot pin; the actual cause is a namespace shape.

`build:lib:cjs` is unaffected because esbuild routes that require through `__toESM`, which copies the named exports across.

Nothing in the suite could see it. `dns-pin-fetch.test.ts` injects `_createConnectionOwner`, so the real factory never runs there, and `dns-pin.test.ts` does construct it — from source, where Node's own CommonJS named-export detection makes `Agent` present. The failure only exists in the artifact, and the artifact is only exercised by `just-bash.bundle.test.ts`, which does not make requests.

## Fix

Normalize the namespace before reading `Agent` and `fetch` off it.

`--external:undici` in `build:lib` would fix the shipped bundle too, and it is a reasonable companion change — undici is already a declared dependency, and `build:browser` already externalizes it. I did not do it here because it does not cover the same ground: a consumer that bundles just-bash again can reproduce the identical namespace shape from its own graph, and normalizing at the read site holds either way. Happy to add it if you want both.

## Scope

Unchanged: the private-range decision, the DNS rebinding guard, per-hop redirect review, and pool identity. Confirmed against the built bundle that loopback and the metadata address are still refused before any connection is made.

Not addressed, deliberately: the `catch` converts every failure into `DnsPinningUnavailableError` and drops the original. Fail-closed is right, but the discarded error is the whole diagnosis — attaching it as `cause` would have made this a two-minute read instead of a bundle spelunk. Left out to keep this diff to the defect; say the word and it is one line.

## Tests

One case added to `dns-pin.test.ts`, asserting the transport is reachable through both namespace shapes.

What that case cannot do is prove the built artifact works, and I would rather name the gap than imply coverage. Reaching the pinned owner at all requires a hostname that resolves to an address the private-range filter accepts, and every such address is by definition a routable public one — 0/8, 100.64/10, 198.18/15, the TEST-NETs and 240/4 are all filtered. So an end-to-end test needs real DNS and a real connection; there is no hermetic way to stand in for the network here.

Verified by hand instead, same script against two bundles:

```
### this branch, built
{"url":"https://registry.npmjs.org/-/ping","exitCode":0,"stdout":"200","stderr":""}
{"url":"http://127.0.0.1:9/","exitCode":7,"stderr":"...private/loopback IP address blocked..."}
{"url":"http://169.254.169.254/latest/meta-data/","exitCode":7,"stderr":"...private/loopback IP address blocked..."}

### published 3.2.0
{"url":"https://registry.npmjs.org/-/ping","exitCode":7,"stderr":"...DNS pinning unavailable for private IP enforcement..."}
{"url":"http://127.0.0.1:9/","exitCode":7,"stderr":"...private/loopback IP address blocked..."}
{"url":"http://169.254.169.254/latest/meta-data/","exitCode":7,"stderr":"...private/loopback IP address blocked..."}
```

`test:dist`: 18 passing against a full build.

`test:run`: 689 failing, 14350 passing. The same 689 fail on `main`, which passes 14349 — the one test added here is the difference. Verified by stashing this change and re-running, not inferred.

`main` also does not typecheck at `d97425d` (`stdinOwned` at `interpreter.ts:599,601`), as noted in #338, so `pnpm build` stops before the bundlers run and the steps have to be driven past the `tsc` failure by hand.

Biome clean apart from the pre-existing `interpreter.ts:550` warning. `lint:banned` clean, `knip` clean, changeset included.

---

Model: Claude Opus 5
