### PR TITLE
Bound real directory enumeration

### DIFF
--- a/.changeset/lazy-directory-limits.md
+++ b/.changeset/lazy-directory-limits.md
@@ -1,0 +1,7 @@
+---
+"just-bash": patch
+---
+
+Bound real filesystem directory enumeration before retaining oversized listings.
+`ls` now applies the existing traversal-entry and output-byte limits while
+reading directories lazily with `opendir`.

--- a/packages/just-bash/src/browser.ts
+++ b/packages/just-bash/src/browser.ts
@@ -42,6 +42,7 @@ export type {
   LazyFileEntry,
   LazyFileProvider,
   MkdirOptions,
+  ReaddirOptions,
   RmOptions,
   SymlinkEntry,
 } from "./fs/interface.js";

--- a/packages/just-bash/src/commands/ls/ls.directory-limits.test.ts
+++ b/packages/just-bash/src/commands/ls/ls.directory-limits.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+import type { ReaddirOptions } from "../../fs/interface.js";
+
+class CapturingReaddirFs extends InMemoryFs {
+  seenOptions?: ReaddirOptions;
+
+  override readdir(path: string, options?: ReaddirOptions): Promise<string[]> {
+    if (this.resolvePath("/", path) === "/root") {
+      this.seenOptions = options;
+    }
+    return super.readdir(path);
+  }
+}
+
+describe("ls directory enumeration limits", () => {
+  it("uses the traversal entry cap and shell output byte cap", async () => {
+    const fs = new CapturingReaddirFs({ "/root/file.txt": "" });
+    const bash = new Bash({
+      fs,
+      executionLimits: {
+        maxTraversalEntries: 100_000,
+        maxOutputSize: 1024 * 1024,
+      },
+    });
+
+    const result = await bash.exec("ls /root");
+
+    expect(result).toMatchObject({
+      stdout: "file.txt\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(fs.seenOptions).toEqual({
+      maxEntries: 100_000,
+      maxNameBytes: 1024 * 1024,
+    });
+  });
+});

--- a/packages/just-bash/src/commands/ls/ls.ts
+++ b/packages/just-bash/src/commands/ls/ls.ts
@@ -1,7 +1,11 @@
 import { minimatch } from "minimatch";
 import { BoundedStringBuilder } from "../../bounded-builder.js";
 import { utf8ByteLength } from "../../encoding.js";
-import type { FsStat } from "../../fs/interface.js";
+import {
+  DirectoryReadLimitError,
+  type FsStat,
+  type ReaddirOptions,
+} from "../../fs/interface.js";
 import { FileTraversalBudget } from "../../fs/traversal.js";
 import {
   ExecutionAbortedError,
@@ -44,6 +48,13 @@ function joinLsLines(
   }
   if (lines.length > 0) output.append("\n");
   return output.build();
+}
+
+function getReaddirOptions(ctx: RuntimeCommandContext): ReaddirOptions {
+  return {
+    maxEntries: ctx.limits.maxTraversalEntries,
+    maxNameBytes: ctx.limits.maxOutputSize,
+  };
 }
 
 // Format size in human-readable format (e.g., 1.5K, 234M, 2G)
@@ -462,7 +473,8 @@ async function listPath(
     if (identity !== undefined) childAncestors.add(identity);
 
     // It's a directory
-    let entries = await ctx.fs.readdir(fullPath);
+    let entries = await ctx.fs.readdir(fullPath, getReaddirOptions(ctx));
+    traversalBudget.discover(entries.length);
     traversalBudget.checkpoint();
 
     // Filter hidden files unless -a or -A
@@ -619,7 +631,10 @@ async function listPath(
       let dirEntries: { name: string; isDirectory: boolean }[] = [];
 
       if (ctx.fs.readdirWithFileTypes) {
-        const entriesWithTypes = await ctx.fs.readdirWithFileTypes(fullPath);
+        const entriesWithTypes = await ctx.fs.readdirWithFileTypes(
+          fullPath,
+          getReaddirOptions(ctx),
+        );
         dirEntries = entriesWithTypes
           .filter((e) => e.isDirectory && filteredEntries.includes(e.name))
           .map((e) => ({ name: e.name, isDirectory: true }));
@@ -698,6 +713,9 @@ async function listPath(
 
     return { stdout, stderr, exitCode };
   } catch (error) {
+    if (error instanceof DirectoryReadLimitError) {
+      throw new ExecutionLimitError(`ls: ${error.message}`, "iterations");
+    }
     if (
       error instanceof ExecutionLimitError ||
       error instanceof ExecutionAbortedError

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -74,6 +74,19 @@ export interface DirentEntry {
   isSymbolicLink: boolean;
 }
 
+/** Limits applied while enumerating one directory. */
+export interface ReaddirOptions {
+  /** Maximum number of names retained from one directory. */
+  maxEntries?: number;
+  /** Maximum cumulative UTF-8 bytes across retained names. */
+  maxNameBytes?: number;
+}
+
+/** Raised before a directory enumeration can exceed its configured bounds. */
+export class DirectoryReadLimitError extends Error {
+  readonly name = "DirectoryReadLimitError";
+}
+
 /**
  * Stat result from the filesystem
  */
@@ -198,7 +211,7 @@ export interface IFileSystem {
    * @returns Array of entry names (not full paths)
    * @throws Error if path doesn't exist or is not a directory
    */
-  readdir(path: string): Promise<string[]>;
+  readdir(path: string, options?: ReaddirOptions): Promise<string[]>;
 
   /**
    * Read directory contents with file type information (optional)
@@ -206,7 +219,10 @@ export interface IFileSystem {
    * @returns Array of DirentEntry objects with name and type
    * @throws Error if path doesn't exist or is not a directory
    */
-  readdirWithFileTypes?(path: string): Promise<DirentEntry[]>;
+  readdirWithFileTypes?(
+    path: string,
+    options?: ReaddirOptions,
+  ): Promise<DirentEntry[]>;
 
   /**
    * Remove a file or directory

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from "vitest";
 import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
+import type { ReaddirOptions } from "../interface.js";
 import { MountableFs } from "./mountable-fs.js";
+
+class ReaddirOptionsFs extends InMemoryFs {
+  seenOptions?: ReaddirOptions;
+
+  override readdir(path: string, options?: ReaddirOptions): Promise<string[]> {
+    this.seenOptions = options;
+    return super.readdir(path);
+  }
+}
 
 describe("MountableFs", () => {
   describe("mount/unmount operations", () => {
@@ -624,6 +634,17 @@ describe("MountableFs", () => {
   });
 
   describe("edge cases", () => {
+    it("forwards directory read limits through a mount", async () => {
+      const mounted = new ReaddirOptionsFs({ "/test.txt": "content" });
+      const fs = new MountableFs();
+      fs.mount("/mnt/data", mounted);
+      const options = { maxEntries: 100_000, maxNameBytes: 1024 * 1024 };
+
+      await fs.readdir("/mnt/data", options);
+
+      expect(mounted.seenOptions).toEqual(options);
+    });
+
     it("should handle trailing slashes in mount points", () => {
       const fs = new MountableFs();
       const mounted = new InMemoryFs();

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -7,6 +7,7 @@ import type {
   FsStat,
   IFileSystem,
   MkdirOptions,
+  ReaddirOptions,
   ReadFileOptions,
   RmOptions,
   WriteFileOptions,
@@ -415,7 +416,7 @@ export class MountableFs implements IFileSystem {
     return fs.mkdir(relativePath, options);
   }
 
-  async readdir(path: string): Promise<string[]> {
+  async readdir(path: string, options?: ReaddirOptions): Promise<string[]> {
     const normalized = normalizePath(path);
     const entries = new Set<string>();
     let readdirError: Error | null = null;
@@ -423,7 +424,7 @@ export class MountableFs implements IFileSystem {
     // Get entries from the owning filesystem
     const { fs, relativePath } = this.routePath(path);
     try {
-      const fsEntries = await fs.readdir(relativePath);
+      const fsEntries = await fs.readdir(relativePath, options);
       for (const entry of fsEntries) {
         entries.add(entry);
       }

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.test.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.test.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DirectoryReadLimitError } from "../interface.js";
 import { ReadWriteFs } from "./read-write-fs.js";
 
 describe("ReadWriteFs", () => {
@@ -598,6 +599,31 @@ describe("ReadWriteFs", () => {
       const namesFromWithTypes = entriesWithTypes.map((e) => e.name);
 
       expect(namesFromWithTypes).toEqual(namesFromReaddir);
+    });
+
+    it("stops lazy enumeration at the entry limit", async () => {
+      const rwfs = new ReadWriteFs({ root: tempDir, allowSymlinks: true });
+      fs.writeFileSync(path.join(tempDir, "a"), "");
+      fs.writeFileSync(path.join(tempDir, "b"), "");
+      fs.writeFileSync(path.join(tempDir, "c"), "");
+
+      await expect(rwfs.readdir("/", { maxEntries: 2 })).rejects.toThrowError(
+        new DirectoryReadLimitError(
+          "directory entry limit exceeded (2), scandir '/'",
+        ),
+      );
+    });
+
+    it("stops lazy enumeration at the cumulative filename byte limit", async () => {
+      const rwfs = new ReadWriteFs({ root: tempDir, allowSymlinks: true });
+      fs.writeFileSync(path.join(tempDir, "😀"), "");
+      fs.writeFileSync(path.join(tempDir, "😀😀"), "");
+
+      await expect(rwfs.readdir("/", { maxNameBytes: 8 })).rejects.toThrowError(
+        new DirectoryReadLimitError(
+          "directory name size limit exceeded (8 bytes), scandir '/'",
+        ),
+      );
     });
   });
 });

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
@@ -26,10 +26,12 @@ import type {
   FsStat,
   IFileSystem,
   MkdirOptions,
+  ReaddirOptions,
   ReadFileOptions,
   RmOptions,
   WriteFileOptions,
 } from "../interface.js";
+import { DirectoryReadLimitError } from "../interface.js";
 import { resolvePath as resolveVPath } from "../path-utils.js";
 import {
   isPathWithinRoot,
@@ -356,12 +358,15 @@ export class ReadWriteFs implements IFileSystem {
     }
   }
 
-  async readdir(path: string): Promise<string[]> {
-    const entries = await this.readdirWithFileTypes(path);
+  async readdir(path: string, options?: ReaddirOptions): Promise<string[]> {
+    const entries = await this.readdirWithFileTypes(path, options);
     return entries.map((e) => e.name);
   }
 
-  async readdirWithFileTypes(path: string): Promise<DirentEntry[]> {
+  async readdirWithFileTypes(
+    path: string,
+    options?: ReaddirOptions,
+  ): Promise<DirentEntry[]> {
     validatePath(path, "scandir");
     const realPath = this.toRealPath(path);
     const canonical = this.resolveAndValidate(realPath, path);
@@ -377,18 +382,42 @@ export class ReadWriteFs implements IFileSystem {
           throw new Error(`EACCES: permission denied, '${path}' is a symlink`);
         }
       }
-      const entries = await fs.promises.readdir(canonical, {
-        withFileTypes: true,
-      });
-      return entries
-        .map((dirent) => ({
+      const entries: DirentEntry[] = [];
+      let nameBytes = 0;
+      const directory = await fs.promises.opendir(canonical);
+
+      for await (const dirent of directory) {
+        if (
+          options?.maxEntries !== undefined &&
+          entries.length >= options.maxEntries
+        ) {
+          throw new DirectoryReadLimitError(
+            `directory entry limit exceeded (${options.maxEntries}), scandir '${path}'`,
+          );
+        }
+
+        nameBytes += Buffer.byteLength(dirent.name, "utf8");
+        if (
+          options?.maxNameBytes !== undefined &&
+          nameBytes > options.maxNameBytes
+        ) {
+          throw new DirectoryReadLimitError(
+            `directory name size limit exceeded (${options.maxNameBytes} bytes), scandir '${path}'`,
+          );
+        }
+
+        entries.push({
           name: dirent.name,
           isFile: dirent.isFile(),
           isDirectory: dirent.isDirectory(),
           isSymbolicLink: dirent.isSymbolicLink(),
-        }))
-        .sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+        });
+      }
+      return entries.sort((a, b) =>
+        a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+      );
     } catch (e) {
+      if (e instanceof DirectoryReadLimitError) throw e;
       const err = e as NodeJS.ErrnoException;
       if (err.code === "ENOENT") {
         throw new Error(`ENOENT: no such file or directory, scandir '${path}'`);

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -66,9 +66,11 @@ export type {
   LazyFileEntry,
   LazyFileProvider,
   MkdirOptions,
+  ReaddirOptions,
   RmOptions,
   SymlinkEntry,
 } from "./fs/interface.js";
+export { DirectoryReadLimitError } from "./fs/interface.js";
 export {
   MountableFs,
   type MountableFsOptions,


### PR DESCRIPTION
## Summary

- enumerate real filesystem directories lazily with `fs.promises.opendir()`
- bound retained directory entries by the existing traversal-entry limit and cumulative UTF-8 filename bytes by the existing output limit
- thread those limits through `ls` and `MountableFs`
- export the new readdir options and limit error, with focused coverage and a patch changeset

## Why

`ReadWriteFs.readdirWithFileTypes()` previously used `fs.promises.readdir()`, which eagerly materializes every entry in a real directory. An `ls` against a very large mounted directory (for example, an NFS directory with millions of entries) could therefore exhaust the host process memory before just-bash's existing traversal or output guards had a chance to run.

This change stops enumeration before retained entries exceed either existing bound. It does not add or change a numeric limit.

## Validation

- `pnpm lint` (passes; reports one pre-existing unused-parameter warning in `src/interpreter/interpreter.ts`)
- `pnpm knip`
- 151 focused tests across `ls`, `ls.security`, the new `ls` limits coverage, `ReadWriteFs`, and `MountableFs`
- `pnpm --filter just-bash typecheck` reports only the existing upstream errors:
  - `src/interpreter/interpreter.ts(599,50): Cannot find name 'stdinOwned'`
  - `src/interpreter/interpreter.ts(601,47): Cannot find name 'stdinOwned'`

## Risk

The filesystem interface gains optional read limits, so existing implementations remain source-compatible. Unlimited calls preserve existing behavior, while `ls` supplies the already-resolved execution limits.
