### PR TITLE
fix(interpreter): restore group and subshell execution

### DIFF
--- a/.changeset/forward-stdin-ownership.md
+++ b/.changeset/forward-stdin-ownership.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Forward stdin ownership through command dispatch so subshell and group execution receive the ownership state selected by their caller.

--- a/.changeset/forward-stdin-ownership.md
+++ b/.changeset/forward-stdin-ownership.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Forward stdin ownership through command dispatch so subshell and group execution receive the ownership state selected by their caller.
+Restore command groups and subshells after the process-substitution and stdin-ownership changes were combined without forwarding ownership through inner command dispatch.

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -552,7 +552,7 @@ export class Interpreter {
     const procSubMark = markProcessSubstitutions(this.ctx);
     let result: ExecResult;
     try {
-      result = await this.executeCommandInner(node, stdin);
+      result = await this.executeCommandInner(node, stdin, stdinOwned);
     } catch (error) {
       await releaseProcessSubstitutions(this.ctx, procSubMark).catch(
         () => undefined,
@@ -576,6 +576,7 @@ export class Interpreter {
   private async executeCommandInner(
     node: CommandNode,
     stdin: string,
+    stdinOwned: boolean,
   ): Promise<ExecResult> {
     this.assertDefenseContext("command");
 


### PR DESCRIPTION
## Problem

`main` does not typecheck, and every command group (`{ ...; }`) or subshell (`(...)`) reaches an undefined `stdinOwned` binding. Scripts such as `echo hi | { cat; }` and `echo hi | (cat)` therefore fail before their bodies can run.

This came from the interaction between PR #325 and PR #336:

- #325 split command execution into an outer lifecycle wrapper and `executeCommandInner()`.
- #336 combined the stdin-ownership work from #330 with the numeric-fd and loop-redirection changes from #326 and #329. Its reviewed head passed `stdinOwned` correctly before the split.
- When #336 was squashed onto the newly updated `main`, the parameter remained on the outer function while the group and subshell branches moved into the inner function. The call between them did not forward it.

The failure is visible in the [base typecheck](https://github.com/vercel-labs/just-bash/actions/runs/31064721094) and [comparison tests](https://github.com/vercel-labs/just-bash/actions/runs/31064721175). Group and subshell regression coverage already landed through #336, so those tests are present on this PR's base rather than appearing as new files in this diff.

## Changes

Forward `stdinOwned` from `executeCommand()` into `executeCommandInner()` and declare it there. This reconnects #325's command-lifecycle wrapper with #330's ownership handling, restoring group and subshell execution while preserving whether empty stdin means inherited input or owned EOF.

cc @trieloff for visibility on the #325/#336 integration.
