### PR TITLE
fix(parser): preserve escaped reserved words

### DIFF
--- a/.changeset/calm-dingos-escape.md
+++ b/.changeset/calm-dingos-escape.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Fix escaped reserved words being parsed as shell syntax. Unquoted escapes now retain their provenance through lexing and word parsing, including when the word is serialized back to Bash.

--- a/packages/just-bash/src/interpreter/alias-expansion.ts
+++ b/packages/just-bash/src/interpreter/alias-expansion.ts
@@ -14,6 +14,7 @@ import type { ScriptNode, SimpleCommandNode, WordNode } from "../ast/types.js";
 import { utf8ByteLength } from "../commands/printf/escapes.js";
 import { Parser } from "../parser/parser.js";
 import { ParseException } from "../parser/types.js";
+import { serializeWord } from "../transform/serialize.js";
 import { ExecutionLimitError } from "./errors.js";
 
 /**
@@ -139,7 +140,7 @@ function expandAliasOnce(
     if (!expandNext) {
       // Convert args to strings for re-parsing
       for (const arg of node.args) {
-        const argLiteral = wordNodeToString(arg);
+        const argLiteral = serializeWord(arg);
         fullCommand = appendBounded(
           fullCommand,
           ` ${argLiteral}`,
@@ -273,7 +274,7 @@ function handleComplexAlias(
     fullCommandBytes,
   );
   for (const arg of node.args) {
-    const argLiteral = wordNodeToString(arg);
+    const argLiteral = serializeWord(arg);
     fullCommand = appendBounded(
       fullCommand,
       ` ${argLiteral}`,
@@ -313,46 +314,4 @@ function handleComplexAlias(
     redirections: node.redirections,
     line: node.line,
   };
-}
-
-/**
- * Convert a WordNode back to a string representation for re-parsing.
- * This is a simplified conversion that handles common cases.
- */
-function wordNodeToString(word: WordNode): string {
-  let result = "";
-  for (const part of word.parts) {
-    switch (part.type) {
-      case "Literal":
-        // Escape special characters
-        result += part.value.replace(/([\s"'$`\\*?[\]{}()<>|&;#!])/g, "\\$1");
-        break;
-      case "SingleQuoted":
-        result += `'${part.value}'`;
-        break;
-      case "DoubleQuoted":
-        // Handle double-quoted content
-        result += `"${part.parts.map((p) => (p.type === "Literal" ? p.value : `$${p.type}`)).join("")}"`;
-        break;
-      case "ParameterExpansion":
-        // Use braced form to be safe
-        result += `\${${part.parameter}}`;
-        break;
-      case "CommandSubstitution":
-        // CommandSubstitutionPart has body (ScriptNode), not command string
-        // We need to reconstruct - for simplicity, wrap in $(...)
-        result += `$(...)`;
-        break;
-      case "ArithmeticExpansion":
-        result += `$((${part.expression}))`;
-        break;
-      case "Glob":
-        result += part.pattern;
-        break;
-      default:
-        // For other types, try to preserve as-is
-        break;
-    }
-  }
-  return result;
 }

--- a/packages/just-bash/src/interpreter/builtins/compgen.ts
+++ b/packages/just-bash/src/interpreter/builtins/compgen.ts
@@ -22,6 +22,7 @@
  *   compgen -o option             - Completion option (plusdirs, dirnames, default, etc.)
  */
 
+import { AST, type WordPart } from "../../ast/types.js";
 import { BoundedStringBuilder } from "../../bounded-builder.js";
 import { utf8ByteLength } from "../../encoding.js";
 import { type ParseException, Parser, parse } from "../../parser/parser.js";
@@ -39,6 +40,14 @@ import {
 } from "../helpers/array.js";
 import { failure, result, success } from "../helpers/result.js";
 import type { InterpreterContext } from "../types.js";
+
+const preserveWordlistEscapes = (part: WordPart): WordPart => {
+  if (part.type === "Escaped") return AST.literal(`\\${part.value}`);
+  if (part.type === "DoubleQuoted") {
+    return { ...part, parts: part.parts.map(preserveWordlistEscapes) };
+  }
+  return part;
+};
 
 // List of shell keywords (matches bash)
 const SHELL_KEYWORDS = [
@@ -1039,8 +1048,11 @@ async function expandWordlistString(
   // Parse the wordlist as a word (not in quotes, so expansions apply)
   const wordNode = parser.parseWordFromString(wordlist, false, false);
   // Expand the word - this handles $(), ${}, etc.
-  // Errors (like arithmetic errors) will propagate up
-  return await expandWord(ctx, wordNode);
+  // Preserve escaped IFS characters for splitWordlist to consume.
+  return await expandWord(
+    ctx,
+    AST.word(wordNode.parts.map(preserveWordlistEscapes)),
+  );
 }
 
 /**

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -53,6 +53,16 @@ describe("escaped words", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("keeps quoted array subscript escapes distinct", async () => {
+    const result = await new Bash().exec(
+      "q=1; a['\\q']=x; printf '<%s>' \"${a[q]}\"",
+    );
+
+    expect(result.stdout).toBe("<>");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("does not over-escape literals in function descriptions", async () => {
     const result = await new Bash().exec(
       "function f { echo foo#bar mid!word pre~post; }; type f",

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -64,4 +64,14 @@ describe("escaped words", () => {
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
   });
+
+  it("preserves escaped IFS delimiters in compgen wordlists", async () => {
+    const result = await new Bash().exec(
+      "IFS=':%'; compgen -W 'spam:eggs%ham cheese\\:colon'",
+    );
+
+    expect(result.stdout).toBe("spam\neggs\nham cheese:colon\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
 });

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -63,6 +63,16 @@ describe("escaped words", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("keeps escaped parameter markers literal in array subscripts", async () => {
+    const result = await new Bash().exec(
+      "declare -A a; x=key; a[\\$x]=literal; declare -p a",
+    );
+
+    expect(result.stdout).toBe("declare -A a=(['$x']=literal)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("does not over-escape literals in function descriptions", async () => {
     const result = await new Bash().exec(
       "function f { echo foo#bar mid!word pre~post; }; type f",

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -42,4 +42,26 @@ describe("escaped words", () => {
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
   });
+
+  it("quote-removes escaped array subscripts", async () => {
+    const result = await new Bash().exec(
+      'q=1; a[\\q]=x; printf "%s:%s" "${a[\\q]}" "${a[q]}"',
+    );
+
+    expect(result.stdout).toBe("x:x");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not over-escape literals in function descriptions", async () => {
+    const result = await new Bash().exec(
+      "function f { echo foo#bar mid!word pre~post; }; type f",
+    );
+
+    expect(result.stdout).toBe(
+      "f is a function\nf () \n{ \n    echo foo#bar mid!word pre~post\n}\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
 });

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -73,6 +73,16 @@ describe("escaped words", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("keeps escaped quotes inside double-quoted array subscripts", async () => {
+    const result = await new Bash().exec(
+      'declare -A a; a["a\\"b\\q"]=ok; declare -p a',
+    );
+
+    expect(result.stdout).toBe("declare -A a=(['a\"b\\q']=ok)\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("does not over-escape literals in function descriptions", async () => {
     const result = await new Bash().exec(
       "function f { echo foo#bar mid!word pre~post; }; type f",

--- a/packages/just-bash/src/interpreter/escaped-words.test.ts
+++ b/packages/just-bash/src/interpreter/escaped-words.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+describe("escaped words", () => {
+  it("treats an escaped ordinary regex character literally", async () => {
+    const result = await new Bash().exec("[[ q =~ \\q ]]");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("treats an escaped ordinary character in a regex bracket expression literally", async () => {
+    const result = await new Bash().exec("[[ q =~ [\\q] ]]");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves escaped alias arguments while re-parsing", async () => {
+    const result = await new Bash().exec(`
+      shopt -s expand_aliases
+      alias a='echo'
+      a \\time
+    `);
+
+    expect(result.stdout).toBe("time\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("preserves escaped words in function descriptions", async () => {
+    const result = await new Bash().exec(`
+      function f { echo \\time; }
+      type f
+    `);
+
+    expect(result.stdout).toBe(
+      "f is a function\nf () \n{ \n    echo \\time\n}\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/interpreter/expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion.ts
@@ -203,9 +203,8 @@ export async function expandWordForRegex(
   const parts: string[] = [];
   for (const part of word.parts) {
     if (part.type === "Escaped") {
-      // For regex patterns, preserve ALL backslash escapes
-      // This allows \[ \] \. \* etc. to work as regex escapes
-      parts.push(`\\${part.value}`);
+      // Quoting makes this character literal in the regular expression.
+      parts.push(escapeRegexChars(part.value));
     } else if (part.type === "SingleQuoted") {
       // Single-quoted content is literal in regex
       parts.push(part.value);

--- a/packages/just-bash/src/interpreter/type-command.ts
+++ b/packages/just-bash/src/interpreter/type-command.ts
@@ -8,13 +8,16 @@
  * Also includes helpers for function source serialization.
  */
 
-import type {
-  CommandNode,
-  FunctionDefNode,
-  GroupNode,
-  PipelineNode,
-  SimpleCommandNode,
-  StatementNode,
+import {
+  AST,
+  type CommandNode,
+  type FunctionDefNode,
+  type GroupNode,
+  type PipelineNode,
+  type SimpleCommandNode,
+  type StatementNode,
+  type WordNode,
+  type WordPart,
 } from "../ast/types.js";
 import type { IFileSystem } from "../fs/interface.js";
 import { serializeWord } from "../transform/serialize.js";
@@ -332,10 +335,10 @@ function serializeCompoundCommand(
     const cmd = node as SimpleCommandNode;
     const parts: string[] = [];
     if (cmd.name) {
-      parts.push(serializeWord(cmd.name));
+      parts.push(serializeFunctionWord(cmd.name));
     }
     for (const arg of cmd.args) {
-      parts.push(serializeWord(arg));
+      parts.push(serializeFunctionWord(arg));
     }
     return parts.join(" ");
   }
@@ -348,6 +351,25 @@ function serializeCompoundCommand(
 
   // For other compound commands, return a placeholder
   return "...";
+}
+
+function serializeFunctionWord(word: WordNode): string {
+  return word.parts.map(serializeFunctionWordPart).join("");
+}
+
+function serializeFunctionWordPart(part: WordPart): string {
+  switch (part.type) {
+    case "Literal":
+      return part.value;
+    case "Escaped":
+      return `\\${part.value}`;
+    case "SingleQuoted":
+      return `'${part.value}'`;
+    case "DoubleQuoted":
+      return `"${part.parts.map(serializeFunctionWordPart).join("")}"`;
+    default:
+      return serializeWord(AST.word([part]));
+  }
 }
 
 function serializePipeline(pipeline: PipelineNode): string {

--- a/packages/just-bash/src/interpreter/type-command.ts
+++ b/packages/just-bash/src/interpreter/type-command.ts
@@ -15,9 +15,9 @@ import type {
   PipelineNode,
   SimpleCommandNode,
   StatementNode,
-  WordNode,
 } from "../ast/types.js";
 import type { IFileSystem } from "../fs/interface.js";
+import { serializeWord } from "../transform/serialize.js";
 import type { CommandRegistry, ExecResult } from "../types.js";
 import { result } from "./helpers/result.js";
 import { SHELL_BUILTINS, SHELL_KEYWORDS } from "./helpers/shell-constants.js";
@@ -353,35 +353,6 @@ function serializeCompoundCommand(
 function serializePipeline(pipeline: PipelineNode): string {
   const parts = pipeline.commands.map((cmd) => serializeCompoundCommand(cmd));
   return (pipeline.negated ? "! " : "") + parts.join(" | ");
-}
-
-function serializeWord(word: WordNode): string {
-  // Simple serialization - just concatenate parts
-  let result = "";
-  for (const part of word.parts) {
-    if (part.type === "Literal") {
-      result += part.value;
-    } else if (part.type === "DoubleQuoted") {
-      result += `"${part.parts.map((p) => serializeWordPart(p)).join("")}"`;
-    } else if (part.type === "SingleQuoted") {
-      result += `'${part.value}'`;
-    } else {
-      result += serializeWordPart(part);
-    }
-  }
-  return result;
-}
-
-function serializeWordPart(part: unknown): string {
-  const p = part as { type: string; value?: string; name?: string };
-  if (p.type === "Literal") {
-    return p.value ?? "";
-  }
-  if (p.type === "Variable") {
-    return `$${p.name}`;
-  }
-  // For other part types, return empty or placeholder
-  return "";
 }
 
 /**

--- a/packages/just-bash/src/parser/command-parser.ts
+++ b/packages/just-bash/src/parser/command-parser.ts
@@ -261,7 +261,7 @@ function parseAssignment(p: Parser): AssignmentNode {
     if (depth !== 0) {
       p.error(`Invalid assignment: ${value}`);
     }
-    subscript = value.slice(subscriptStart, pos);
+    subscript = WordParser.quoteRemoveEscapes(value.slice(subscriptStart, pos));
     pos++; // skip closing ]
   }
 

--- a/packages/just-bash/src/parser/expansion-parser.ts
+++ b/packages/just-bash/src/parser/expansion-parser.ts
@@ -144,7 +144,7 @@ function parseParameterExpansion(
   // Handle array subscript
   if (value[i] === "[") {
     const closeIdx = WordParser.findMatchingBracket(p, value, i, "[", "]");
-    name += value.slice(i, closeIdx + 1);
+    name += `[${WordParser.quoteRemoveEscapes(value.slice(i + 1, closeIdx))}]`;
     i = closeIdx + 1;
 
     // Check for multiple subscripts like ${a[0][0]} - this is invalid syntax

--- a/packages/just-bash/src/parser/expansion-parser.ts
+++ b/packages/just-bash/src/parser/expansion-parser.ts
@@ -17,6 +17,23 @@ import type { Parser } from "./parser.js";
 import { ParseException } from "./types.js";
 import * as WordParser from "./word-parser.js";
 
+function normalizeRegexBracketEscapes(pattern: string): string {
+  let normalized = "";
+  for (let index = 0; index < pattern.length; index++) {
+    const character = pattern[index];
+    const escaped = pattern[index + 1];
+    if (character !== "\\" || escaped === undefined) {
+      normalized += character;
+      continue;
+    }
+
+    if ("\\[]^-".includes(escaped)) normalized += "\\";
+    normalized += escaped;
+    index++;
+  }
+  return normalized;
+}
+
 /** Ensure a word-parts array is non-empty (use empty-string literal as fallback). */
 function ensureNonEmpty(parts: WordPart[]): WordPart[] {
   return parts.length > 0 ? parts : [AST.literal("")];
@@ -887,14 +904,8 @@ export function parseWordParts(
   while (i < value.length) {
     const char = value[i];
 
-    // Handle escape sequences
-    // In unquoted context, only certain characters are escapable
-    // In here-docs, only $, `, \, newline are escapable (NOT ")
-    // In regular words, $, `, \, ", newline are escapable
-    // Glob metacharacters (*, ?, [, ]) when escaped should create Escaped nodes
-    // so they're treated as literals during globbing
-    // In regex patterns, ALL escaped characters create Escaped nodes so the backslash
-    // is preserved for the regex engine (e.g., \$ matches literal $)
+    // Handle escape sequences. Unquoted words preserve every escape as an
+    // Escaped part, while here-docs and double quotes use narrower rules.
     if (char === "\\" && i + 1 < value.length) {
       const next = value[i + 1];
 
@@ -907,8 +918,16 @@ export function parseWordParts(
         continue;
       }
 
-      // Characters that should be escaped (result in just the literal char)
-      // Inside parameter expansion default values, \} is also escapable to produce }
+      if (!hereDoc && !singleQuotesAreLiteral) {
+        if (next !== "\n") {
+          flushLiteral();
+          parts.push(AST.escaped(next));
+        }
+        i += 2;
+        continue;
+      }
+
+      // Handle the narrower here-doc and double-quote escape sets.
       const isEscapable = hereDoc
         ? next === "$" || next === "`" || next === "\n"
         : next === "$" ||
@@ -1055,7 +1074,10 @@ export function parseWordParts(
     if (char === "*" || char === "?" || char === "[") {
       flushLiteral();
       const { pattern, endIndex } = WordParser.parseGlobPattern(p, value, i);
-      parts.push({ type: "Glob", pattern });
+      parts.push({
+        type: "Glob",
+        pattern: regexPattern ? normalizeRegexBracketEscapes(pattern) : pattern,
+      });
       i = endIndex;
       continue;
     }

--- a/packages/just-bash/src/parser/lexer.ts
+++ b/packages/just-bash/src/parser/lexer.ts
@@ -1323,39 +1323,9 @@ export class Lexer {
             continue;
           }
         } else {
-          // Outside quotes, backslash escapes next character
-          // Keep the backslash for:
-          // - backslash itself (so parser can distinguish \\ from \)
-          // - quotes (so parser knows they're escaped)
-          // - glob metacharacters (so parser creates Escaped nodes that won't be glob-expanded)
-          // - parentheses (so \( and \) are treated as literal, not extglob operators)
-          // - dollar sign (so \$ in regex patterns creates Escaped("$") for literal $ matching)
-          // - dash (so \- inside character classes is literal dash, not range)
-          // - regex metacharacters (so \. \^ \+ \{ \} work in [[ =~ ]] patterns)
-          if (
-            nextChar === "\\" ||
-            nextChar === '"' ||
-            nextChar === "'" ||
-            nextChar === "`" ||
-            nextChar === "*" ||
-            nextChar === "?" ||
-            nextChar === "[" ||
-            nextChar === "]" ||
-            nextChar === "(" ||
-            nextChar === ")" ||
-            nextChar === "$" ||
-            nextChar === "-" ||
-            // Regex-specific metacharacters for [[ =~ ]] patterns
-            nextChar === "." ||
-            nextChar === "^" ||
-            nextChar === "+" ||
-            nextChar === "{" ||
-            nextChar === "}"
-          ) {
-            value += char + nextChar;
-          } else {
-            value += nextChar;
-          }
+          // Preserve the escape until word parsing so token classification can
+          // distinguish escaped text from shell syntax.
+          value += char + nextChar;
           pos += 2;
           col += 2;
           continue;

--- a/packages/just-bash/src/parser/reserved-words.test.ts
+++ b/packages/just-bash/src/parser/reserved-words.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { serialize } from "../transform/serialize.js";
+import { Lexer, TokenType } from "./lexer.js";
+import { parse } from "./parser.js";
+
+const RESERVED_WORDS = [
+  ["if", TokenType.IF],
+  ["then", TokenType.THEN],
+  ["elif", TokenType.ELIF],
+  ["else", TokenType.ELSE],
+  ["fi", TokenType.FI],
+  ["time", TokenType.TIME],
+  ["for", TokenType.FOR],
+  ["in", TokenType.IN],
+  ["until", TokenType.UNTIL],
+  ["while", TokenType.WHILE],
+  ["do", TokenType.DO],
+  ["done", TokenType.DONE],
+  ["case", TokenType.CASE],
+  ["esac", TokenType.ESAC],
+  ["coproc", TokenType.COPROC],
+  ["select", TokenType.SELECT],
+  ["function", TokenType.FUNCTION],
+  ["{", TokenType.LBRACE],
+  ["}", TokenType.RBRACE],
+  ["[[", TokenType.DBRACK_START],
+  ["]]", TokenType.DBRACK_END],
+  ["!", TokenType.BANG],
+] as const;
+
+describe("reserved words", () => {
+  it.each(
+    RESERVED_WORDS,
+  )("treats escaped %s as an ordinary word", (word, reservedType) => {
+    const escaped = `\\${word}`;
+    const [token] = new Lexer(escaped).tokenize();
+
+    expect(token).toMatchObject({
+      type: TokenType.WORD,
+      value: escaped,
+    });
+    expect(token.type).not.toBe(reservedType);
+
+    const command = parse(escaped).statements[0].pipelines[0].commands[0];
+    expect(command.type).toBe("SimpleCommand");
+  });
+
+  describe.each(["'", '"'])("when quoted with %s", (quote) => {
+    it.each(
+      RESERVED_WORDS,
+    )("treats %s as an ordinary word", (word, reservedType) => {
+      const source = `${quote}${word}${quote}`;
+      const [token] = new Lexer(source).tokenize();
+
+      expect(token.value).toBe(word);
+      expect(token.type).not.toBe(reservedType);
+
+      const command = parse(source).statements[0].pipelines[0].commands[0];
+      expect(command.type).toBe("SimpleCommand");
+    });
+  });
+
+  it.each(
+    RESERVED_WORDS.filter(([word]) => word.length > 1),
+  )("does not recognize partially quoted %s as reserved", (word, reservedType) => {
+    for (let quotedIndex = 0; quotedIndex < word.length; quotedIndex++) {
+      const escaped = `${word.slice(0, quotedIndex)}\\${word.slice(quotedIndex)}`;
+      const quoted = `${word.slice(0, quotedIndex)}"${word[quotedIndex]}"${word.slice(quotedIndex + 1)}`;
+
+      for (const source of [escaped, quoted]) {
+        const [token] = new Lexer(source).tokenize();
+        expect(token.type).not.toBe(reservedType);
+        expect(parse(source).statements[0].pipelines[0].commands[0].type).toBe(
+          "SimpleCommand",
+        );
+      }
+    }
+  });
+
+  it("preserves an escaped reserved word as an untimed command", () => {
+    const source = "\\time echo";
+    const script = parse(source);
+    const pipeline = script.statements[0].pipelines[0];
+    const command = pipeline.commands[0];
+
+    expect(pipeline.timed).toBe(false);
+    expect(command).toMatchObject({
+      type: "SimpleCommand",
+      name: {
+        type: "Word",
+        parts: [
+          { type: "Escaped", value: "t" },
+          { type: "Literal", value: "ime" },
+        ],
+      },
+      args: [
+        {
+          type: "Word",
+          parts: [{ type: "Literal", value: "echo" }],
+        },
+      ],
+    });
+    expect(serialize(script)).toBe(source);
+  });
+
+  it("recognizes a reserved word across a backslash-newline", () => {
+    const source = "ti\\\nme echo";
+    const [token] = new Lexer(source).tokenize();
+    const pipeline = parse(source).statements[0].pipelines[0];
+
+    expect(token).toMatchObject({ type: TokenType.TIME, value: "time" });
+    expect(pipeline.timed).toBe(true);
+  });
+});

--- a/packages/just-bash/src/parser/word-parser.ts
+++ b/packages/just-bash/src/parser/word-parser.ts
@@ -20,6 +20,10 @@ import type { Parser } from "./parser.js";
 // PURE STRING UTILITIES
 // =============================================================================
 
+/** Lexer-level escapes in raw arithmetic subscripts need quote removal. */
+export const quoteRemoveEscapes = (value: string): string =>
+  value.replace(/\\(.)/g, "$1");
+
 /**
  * Decode a byte array as UTF-8 with error recovery.
  * Valid UTF-8 sequences are decoded to their Unicode characters.

--- a/packages/just-bash/src/parser/word-parser.ts
+++ b/packages/just-bash/src/parser/word-parser.ts
@@ -33,7 +33,8 @@ export const quoteRemoveEscapes = (value: string): string => {
       continue;
     }
     if (character === "\\" && !quote && index + 1 < value.length) {
-      result += value[index + 1];
+      const escaped = value[index + 1];
+      result += escaped === "$" || escaped === "`" ? `\\${escaped}` : escaped;
       index += 1;
       continue;
     }

--- a/packages/just-bash/src/parser/word-parser.ts
+++ b/packages/just-bash/src/parser/word-parser.ts
@@ -20,9 +20,27 @@ import type { Parser } from "./parser.js";
 // PURE STRING UTILITIES
 // =============================================================================
 
-/** Lexer-level escapes in raw arithmetic subscripts need quote removal. */
-export const quoteRemoveEscapes = (value: string): string =>
-  value.replace(/\\(.)/g, "$1");
+/** Lexer-level escapes in unquoted arithmetic subscripts need quote removal. */
+export const quoteRemoveEscapes = (value: string): string => {
+  let quote: "'" | '"' | undefined;
+  let result = "";
+  for (let index = 0; index < value.length; index++) {
+    const character = value[index];
+    if (character === "'" || character === '"') {
+      if (quote === character) quote = undefined;
+      else if (!quote) quote = character;
+      result += character;
+      continue;
+    }
+    if (character === "\\" && !quote && index + 1 < value.length) {
+      result += value[index + 1];
+      index += 1;
+      continue;
+    }
+    result += character;
+  }
+  return result;
+};
 
 /**
  * Decode a byte array as UTF-8 with error recovery.

--- a/packages/just-bash/src/parser/word-parser.ts
+++ b/packages/just-bash/src/parser/word-parser.ts
@@ -26,6 +26,11 @@ export const quoteRemoveEscapes = (value: string): string => {
   let result = "";
   for (let index = 0; index < value.length; index++) {
     const character = value[index];
+    if (character === "\\" && quote === '"' && index + 1 < value.length) {
+      result += character + value[index + 1];
+      index += 1;
+      continue;
+    }
     if (character === "'" || character === '"') {
       if (quote === character) quote = undefined;
       else if (!quote) quote = character;

--- a/packages/just-bash/src/spec-tests/bash/cases/alias.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/alias.test.sh
@@ -526,7 +526,6 @@ four
 ## END
 
 #### Alias and command sub (bug regression)
-## SKIP (unimplementable): alias expansion not implemented - parsing happens before execution
 cd $TMP
 shopt -s expand_aliases
 echo foo bar > tmp.txt
@@ -535,7 +534,6 @@ a `cat tmp.txt`
 ## stdout: ['foo', 'bar']
 
 #### Alias and arithmetic
-## SKIP (unimplementable): alias expansion not implemented - parsing happens before execution
 shopt -s expand_aliases
 alias a=argv.py
 a $((1 + 2))


### PR DESCRIPTION
## Problem

The lexer removed ordinary backslashes before classifying reserved words. As a result, `\time echo` became the `time` pipeline modifier instead of invoking a command named `time`. The lost escape provenance also corrupted alias re-parsing, function descriptions, and quoted regular-expression characters.

Both [GNU Bash quoting](https://www.gnu.org/software/bash/manual/html_node/Quoting.html) and [POSIX shell quoting](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/V3_chap02.html#tag_19_02) specify that quoting removes special meaning and prevents reserved-word recognition.

## Changes

- Preserves unquoted escapes through lexical classification and represents them as `Escaped` word parts.
- Keeps backslash-newline handling unchanged so line continuations still join tokens before recognition.
- Uses canonical word serialization for alias expansion and function descriptions instead of incomplete local serializers.
- Treats escaped regular-expression characters literally, including ordinary characters inside bracket expressions.
- Carries escaped IFS delimiters through `compgen -W` wordlist expansion.
- Covers leading and partial quoting at every character position across the Bash reserved-word set.
