### PR TITLE
ci: run checks after pull request retargeting

### DIFF
--- a/.github/workflows/comparison-tests.yml
+++ b/.github/workflows/comparison-tests.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
 
 jobs:
   comparison-tests:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
 
 jobs:
   lint:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
 
 jobs:
   python-tests:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
 
 jobs:
   typecheck:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, edited]
 
 permissions:
   contents: read
 
 jobs:
   unit-tests:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
## Problem

Pull request CI only listened for GitHub's default `opened`, `synchronize`, and `reopened` events. If commits were pushed while a stacked pull request targeted another branch, then the pull request was retargeted to `main`, the base edit did not run lint, typecheck, or tests. Reviewers could therefore see a current diff without current first-party CI results.

## Changes

The five pull request CI workflows now also listen for `edited` events. Each job runs for an edit only when GitHub reports a previous base ref, so retargeting to `main` starts the full suite while title and description edits do not consume CI.

The workflows retain their existing read-only permissions, pinned actions, runners, and default pull request events.
