### PR TITLE
ci: run WASM tests on Node 24 in PRs

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -36,3 +36,29 @@ jobs:
 
       - name: Run WASM tests
         run: pnpm test:wasm
+
+  python-tests-node-24:
+    if: github.event.action != 'edited' || github.event.changes.base.ref.from
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          lfs: true
+          persist-credentials: false
+
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Run WASM tests
+        run: pnpm test:wasm

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -11,9 +11,14 @@ permissions:
   contents: read
 
 jobs:
-  python-tests:
+  wasm-tests:
+    name: Node ${{ matrix.node-version }}
     if: github.event.action != 'edited' || github.event.changes.base.ref.from
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ["22", "24"]
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -25,33 +30,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "22"
-          cache: "pnpm"
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
-
-      - name: Run WASM tests
-        run: pnpm test:wasm
-
-  python-tests-node-24:
-    if: github.event.action != 'edited' || github.event.changes.base.ref.from
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          lfs: true
-          persist-credentials: false
-
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "24"
+          node-version: ${{ matrix.node-version }}
           cache: "pnpm"
 
       - name: Install dependencies


### PR DESCRIPTION
## Problem

The WASM suite exercises a runtime boundary that can differ between Node releases. Pull requests run it only on Node 22, so a regression specific to Node 24 cannot be detected before merge.

## Changes

`WASM Tests` now uses a Node 22/24 matrix. Each cell runs the same install, build, and WASM test steps, and `fail-fast: false` reports results from both Node versions when one fails. The workflow remains read-only and does not add credentials, release behavior, or publishing.