### PR TITLE
fix(js-exec): wait for top-level await completion

### DIFF
--- a/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
@@ -10,6 +10,7 @@
  */
 
 import { stripTypeScriptTypes } from "node:module";
+import { setTimeout } from "node:timers/promises";
 import { parentPort } from "node:worker_threads";
 import {
   getQuickJS,
@@ -1070,7 +1071,7 @@ async function initializeWithDefense(): Promise<void> {
   }
   // Yield to let the ExperimentalWarning flush through the event loop.
   // Must use setTimeout (not Promise.resolve) because the warning is a macrotask.
-  await new Promise<void>((r) => setTimeout(r, 0));
+  await setTimeout(0);
 
   // Activate defense after QuickJS is loaded.
   // QuickJS needs only SharedArrayBuffer + Atomics exclusions
@@ -1437,6 +1438,9 @@ async function executeCode(
       }
       if (moduleState?.type === "pending") {
         moduleState = context.getPromiseState(result.value);
+        if (pendingResult.value === 0 && moduleState.type === "pending") {
+          await setTimeout(0);
+        }
       } else {
         break;
       }

--- a/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
@@ -84,6 +84,8 @@ const MEMORY_LIMIT = 64 * 1024 * 1024;
 /** Maximum execution cycles before interrupt check */
 const INTERRUPT_CYCLES = 100000;
 
+const PROCESS_EXIT_MARKER = "__just_bash_process_exit_marker__";
+
 /**
  * Format a dumped QuickJS error value into a readable error string
  * that includes the file name and line number from the stack trace.
@@ -124,6 +126,17 @@ function throwError(
   message: string,
 ): { error: QuickJSHandle } {
   return { error: context.newError(message) };
+}
+
+function isProcessExit(
+  context: QuickJSContext,
+  error: QuickJSHandle,
+  processExitMarker: QuickJSHandle,
+): boolean {
+  const marker = context.getProp(error, PROCESS_EXIT_MARKER);
+  const isExit = context.sameValue(marker, processExitMarker);
+  marker.dispose();
+  return isExit;
 }
 
 /**
@@ -380,6 +393,7 @@ function setupContext(
   context: QuickJSContext,
   backend: SyncBackend,
   input: JsExecWorkerInput,
+  processExitMarker: QuickJSHandle,
 ): void {
   // --- console ---
   const consoleObj = context.newObject();
@@ -827,7 +841,9 @@ function setupContext(
     }
     backend.exit(code);
     // Throw to stop execution
-    return throwError(context, "__EXIT__");
+    const exitError = context.newError("process.exit()");
+    context.setProp(exitError, PROCESS_EXIT_MARKER, processExitMarker);
+    return { error: exitError };
   });
   context.setProp(processObj, "exit", exitFn);
   exitFn.dispose();
@@ -1124,6 +1140,7 @@ async function executeCode(
 
   let runtime: QuickJSRuntime | undefined;
   let context: QuickJSContext | undefined;
+  let processExitMarker: QuickJSHandle | undefined;
   try {
     runtime = qjs.newRuntime();
     runtime.setMemoryLimit(MEMORY_LIMIT);
@@ -1139,7 +1156,8 @@ async function executeCode(
     });
 
     context = runtime.newContext();
-    setupContext(context, backend, input);
+    processExitMarker = context.newObject();
+    setupContext(context, backend, input, processExitMarker);
 
     // Defense-in-depth: remove eval(), neuter Function constructors,
     // and freeze all intrinsic prototypes to prevent prototype pollution.
@@ -1380,20 +1398,13 @@ async function executeCode(
       : context.evalCode(jsCode, filename);
 
     if (result.error) {
-      const errorVal = context.dump(result.error);
-      result.error.dispose();
-
-      // Check if this is a process.exit() call (check raw message before formatting)
-      const rawMsg =
-        typeof errorVal === "object" &&
-        errorVal !== null &&
-        "message" in errorVal
-          ? (errorVal as { message: string }).message
-          : String(errorVal);
-      if (rawMsg === "__EXIT__") {
-        // Exit was already signaled via backend.exit()
+      if (isProcessExit(context, result.error, processExitMarker)) {
+        result.error.dispose();
+        // Exit was already signaled via backend.exit().
         return { success: true };
       }
+      const errorVal = context.dump(result.error);
+      result.error.dispose();
 
       const errorMsg = formatError(errorVal);
       try {
@@ -1407,58 +1418,21 @@ async function executeCode(
 
     // Execute pending jobs (promise callbacks, module bodies).
     // Must always run so .then() chains work in both script and module mode.
-    // Must happen before exit so bridge is still alive. Module evaluation can
-    // return a promise for top-level await, which must settle before completion.
-    let moduleState = input.isModule
-      ? context.getPromiseState(result.value)
+    // Must happen before exit so bridge is still alive. Modules use the native
+    // promise bridge to wait for top-level await without polling the VM state.
+    const moduleCompletion = input.isModule
+      ? context.resolvePromise(result.value)
       : undefined;
-    do {
-      const pendingResult = runtime.executePendingJobs();
-      if ("error" in pendingResult && pendingResult.error) {
-        const errorVal = context.dump(pendingResult.error);
+    const pendingResult = runtime.executePendingJobs();
+    if ("error" in pendingResult && pendingResult.error) {
+      if (isProcessExit(context, pendingResult.error, processExitMarker)) {
         pendingResult.error.dispose();
         result.value.dispose();
-        const rawPendingMsg =
-          typeof errorVal === "object" &&
-          errorVal !== null &&
-          "message" in errorVal
-            ? (errorVal as { message: string }).message
-            : String(errorVal);
-        if (rawPendingMsg !== "__EXIT__") {
-          const errorMsg = formatError(errorVal);
-          try {
-            backend.writeStderr(`${errorMsg}\n`);
-          } catch {
-            // Output limit exceeded — ignore writeStderr failure
-          }
-          backend.exit(1);
-          return { success: true };
-        }
         return { success: true };
       }
-      if (moduleState?.type === "pending") {
-        moduleState = context.getPromiseState(result.value);
-        if (pendingResult.value === 0 && moduleState.type === "pending") {
-          await setTimeout(0);
-        }
-      } else {
-        break;
-      }
-    } while (moduleState?.type === "pending");
-
-    if (moduleState?.type === "rejected") {
-      const errorVal = context.dump(moduleState.error);
-      moduleState.error.dispose();
+      const errorVal = context.dump(pendingResult.error);
+      pendingResult.error.dispose();
       result.value.dispose();
-      const rawModuleMsg =
-        typeof errorVal === "object" &&
-        errorVal !== null &&
-        "message" in errorVal
-          ? (errorVal as { message: string }).message
-          : String(errorVal);
-      if (rawModuleMsg === "__EXIT__") {
-        return { success: true };
-      }
       const errorMsg = formatError(errorVal);
       try {
         backend.writeStderr(`${errorMsg}\n`);
@@ -1469,8 +1443,28 @@ async function executeCode(
       return { success: true };
     }
 
-    if (moduleState?.type === "fulfilled" && !moduleState.notAPromise) {
-      moduleState.value.dispose();
+    if (moduleCompletion) {
+      const moduleResult = await moduleCompletion;
+      if (moduleResult.error) {
+        if (isProcessExit(context, moduleResult.error, processExitMarker)) {
+          moduleResult.error.dispose();
+          result.value.dispose();
+          // Exit was already signaled via backend.exit().
+          return { success: true };
+        }
+        const errorVal = context.dump(moduleResult.error);
+        moduleResult.error.dispose();
+        result.value.dispose();
+        const errorMsg = formatError(errorVal);
+        try {
+          backend.writeStderr(`${errorMsg}\n`);
+        } catch {
+          // Output limit exceeded — ignore writeStderr failure
+        }
+        backend.exit(1);
+        return { success: true };
+      }
+      moduleResult.value.dispose();
     }
 
     result.value.dispose();
@@ -1498,6 +1492,7 @@ async function executeCode(
     }
     return { success: true };
   } finally {
+    processExitMarker?.dispose();
     context?.dispose();
     runtime?.dispose();
   }

--- a/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec-worker.ts
@@ -1406,12 +1406,17 @@ async function executeCode(
 
     // Execute pending jobs (promise callbacks, module bodies).
     // Must always run so .then() chains work in both script and module mode.
-    // Must happen before exit so bridge is still alive.
-    {
+    // Must happen before exit so bridge is still alive. Module evaluation can
+    // return a promise for top-level await, which must settle before completion.
+    let moduleState = input.isModule
+      ? context.getPromiseState(result.value)
+      : undefined;
+    do {
       const pendingResult = runtime.executePendingJobs();
       if ("error" in pendingResult && pendingResult.error) {
         const errorVal = context.dump(pendingResult.error);
         pendingResult.error.dispose();
+        result.value.dispose();
         const rawPendingMsg =
           typeof errorVal === "object" &&
           errorVal !== null &&
@@ -1430,6 +1435,38 @@ async function executeCode(
         }
         return { success: true };
       }
+      if (moduleState?.type === "pending") {
+        moduleState = context.getPromiseState(result.value);
+      } else {
+        break;
+      }
+    } while (moduleState?.type === "pending");
+
+    if (moduleState?.type === "rejected") {
+      const errorVal = context.dump(moduleState.error);
+      moduleState.error.dispose();
+      result.value.dispose();
+      const rawModuleMsg =
+        typeof errorVal === "object" &&
+        errorVal !== null &&
+        "message" in errorVal
+          ? (errorVal as { message: string }).message
+          : String(errorVal);
+      if (rawModuleMsg === "__EXIT__") {
+        return { success: true };
+      }
+      const errorMsg = formatError(errorVal);
+      try {
+        backend.writeStderr(`${errorMsg}\n`);
+      } catch {
+        // Output limit exceeded — ignore writeStderr failure
+      }
+      backend.exit(1);
+      return { success: true };
+    }
+
+    if (moduleState?.type === "fulfilled" && !moduleState.notAPromise) {
+      moduleState.value.dispose();
     }
 
     result.value.dispose();

--- a/packages/just-bash/src/commands/js-exec/js-exec.esm.test.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.esm.test.ts
@@ -156,12 +156,25 @@ describe("js-exec ESM modules", () => {
       );
 
       expect(result.stdout).toBe("");
-      expect(result.stderr).toBe(
-        "\njs-exec: execution timeout exceeded\njs-exec: Execution timeout: exceeded 200ms limit\n",
+      expect(result.stderr).toMatch(
+        /^(?:\njs-exec: execution timeout exceeded\n)?js-exec: Execution timeout: exceeded 200ms limit\n$/,
       );
       expect(result.exitCode).toBe(124);
     },
   );
+
+  it("should report rejected top-level await", async () => {
+    const env = new Bash({ javascript: true });
+    const result = await env.exec(
+      `js-exec -m -c "await Promise.reject(new Error('top-level await rejected'))"`,
+    );
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "at <anonymous> (-c:1:31): top-level await rejected\n",
+    );
+    expect(result.exitCode).toBe(1);
+  });
 
   it("should handle transitive imports", async () => {
     const env = new Bash({

--- a/packages/just-bash/src/commands/js-exec/js-exec.esm.test.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.esm.test.ts
@@ -143,6 +143,26 @@ describe("js-exec ESM modules", () => {
     expect(r3.exitCode).toBe(0);
   });
 
+  it(
+    "should time out unresolved top-level await",
+    { timeout: 30000 },
+    async () => {
+      const env = new Bash({
+        javascript: true,
+        executionLimits: { maxJsTimeoutMs: 200 },
+      });
+      const result = await env.exec(
+        `js-exec -m -c "await new Promise(() => {})"`,
+      );
+
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "\njs-exec: execution timeout exceeded\njs-exec: Execution timeout: exceeded 200ms limit\n",
+      );
+      expect(result.exitCode).toBe(124);
+    },
+  );
+
   it("should handle transitive imports", async () => {
     const env = new Bash({
       javascript: true,

--- a/packages/just-bash/src/commands/js-exec/js-exec.test.ts
+++ b/packages/just-bash/src/commands/js-exec/js-exec.test.ts
@@ -173,6 +173,15 @@ describe("js-exec", () => {
       expect(result.exitCode).toBe(1);
       expect(result.stdout).toBe("");
     });
+
+    it("should report a user-thrown legacy exit sentinel", async () => {
+      const env = new Bash({ javascript: true });
+      const result = await env.exec(`js-exec -c "throw new Error('__EXIT__')"`);
+
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("at <eval> (-c:1:16): __EXIT__\n");
+      expect(result.exitCode).toBe(1);
+    });
   });
 
   describe("process.argv", () => {


### PR DESCRIPTION
## Problem

`js-exec` runs ES modules inside QuickJS. Modules with top-level `await` return a promise for their exports, but the worker drained queued work once and exited without waiting for that promise.

A module that finishes after a dynamic import could report exit 0 while its final work was still missing. A rejected top-level await could also go unreported.

## Changes

The worker now drains QuickJS jobs, converts module evaluation to the native host promise bridge, and awaits fulfillment or rejection before reporting completion. It keeps the existing parent-side timeout and abort termination for unresolved awaits and retains the one-pass job drain for scripts.

Every evaluation and completion handle is disposed at its owner. The process-exit signal is now an opaque per-context marker, so a user error named `__EXIT__` is reported normally.