### PR TITLE
fix(parser): preserve unterminated heredocs

### DIFF
--- a/.changeset/tidy-heredocs-finish.md
+++ b/.changeset/tidy-heredocs-finish.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Preserve whether a here-document ended at its delimiter or at end-of-input. Unterminated final body lines now receive Bash's trailing newline, backslash-newline continuations are removed during expansion, and serializing their AST no longer manufactures a closing delimiter.
+Preserve whether a here-document ended at its delimiter or at end-of-input. Unterminated final body lines now receive Bash's trailing newline, backslash-newline continuations are removed during expansion, and serialization rejects unterminated documents rather than manufacturing a closing delimiter.

--- a/.changeset/tidy-heredocs-finish.md
+++ b/.changeset/tidy-heredocs-finish.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Preserve whether a here-document ended at its delimiter or at end-of-input. Unterminated final body lines now receive Bash's trailing newline, and serializing their AST no longer manufactures a closing delimiter.

--- a/.changeset/tidy-heredocs-finish.md
+++ b/.changeset/tidy-heredocs-finish.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Preserve whether a here-document ended at its delimiter or at end-of-input. Unterminated final body lines now receive Bash's trailing newline, and serializing their AST no longer manufactures a closing delimiter.
+Preserve whether a here-document ended at its delimiter or at end-of-input. Unterminated final body lines now receive Bash's trailing newline, backslash-newline continuations are removed during expansion, and serializing their AST no longer manufactures a closing delimiter.

--- a/packages/just-bash/src/ast/types.ts
+++ b/packages/just-bash/src/ast/types.ts
@@ -292,6 +292,8 @@ export interface HereDocNode extends ASTNode {
   stripTabs: boolean;
   /** Quoted delimiter means no expansion */
   quoted: boolean;
+  /** Whether parsing consumed the closing delimiter. Undefined for legacy ASTs. */
+  terminated?: boolean;
 }
 
 // =============================================================================
@@ -1011,8 +1013,19 @@ export const AST = {
     content: WordNode,
     stripTabs = false,
     quoted = false,
+    terminated?: boolean,
   ): HereDocNode {
-    return { type: "HereDoc", delimiter, content, stripTabs, quoted };
+    const node: HereDocNode = {
+      type: "HereDoc",
+      delimiter,
+      content,
+      stripTabs,
+      quoted,
+    };
+    if (terminated !== undefined) {
+      node.terminated = terminated;
+    }
+    return node;
   },
 
   ifNode(

--- a/packages/just-bash/src/parser/expansion-parser.ts
+++ b/packages/just-bash/src/parser/expansion-parser.ts
@@ -949,7 +949,9 @@ export function parseWordParts(
         ? "*?[]\\".includes(next)
         : "*?[]\\(){}.^+".includes(next);
       if (isEscapable) {
-        literal += next;
+        if (next !== "\n") {
+          literal += next;
+        }
       } else if (isGlobMetaOrBackslash) {
         // Create an Escaped node for glob metacharacters and backslash
         flushLiteral();

--- a/packages/just-bash/src/parser/heredoc-termination.test.ts
+++ b/packages/just-bash/src/parser/heredoc-termination.test.ts
@@ -58,6 +58,31 @@ describe("heredoc termination", () => {
     });
   });
 
+  it("recognizes a delimiter split by an unquoted continuation", () => {
+    expect(parseHeredoc("cat <<EOF\nEO\\\nF")).toMatchObject({
+      terminated: true,
+      content: { parts: [] },
+    });
+  });
+
+  it("does not recognize a delimiter after an unquoted continuation", () => {
+    expect(parseHeredoc("cat <<EOF\nbody\\\nEOF")).toMatchObject({
+      terminated: false,
+      content: {
+        parts: [{ type: "Literal", value: "bodyEOF\n" }],
+      },
+    });
+  });
+
+  it("does not fold continuations in quoted heredocs", () => {
+    expect(parseHeredoc("cat <<'EOF'\nEO\\\nF")).toMatchObject({
+      terminated: false,
+      content: {
+        parts: [{ type: "Literal", value: "EO\\\nF\n" }],
+      },
+    });
+  });
+
   it("records missing quoted and tab-stripping delimiters", () => {
     expect(parseHeredoc("cat <<'EOF'\nbody").terminated).toBe(false);
     expect(parseHeredoc("cat <<-EOF\n\tbody").terminated).toBe(false);

--- a/packages/just-bash/src/parser/heredoc-termination.test.ts
+++ b/packages/just-bash/src/parser/heredoc-termination.test.ts
@@ -49,6 +49,15 @@ describe("heredoc termination", () => {
     });
   });
 
+  it("removes an unquoted trailing backslash continuation", () => {
+    expect(parseHeredoc("cat <<EOF\nbody\\")).toMatchObject({
+      terminated: false,
+      content: {
+        parts: [{ type: "Literal", value: "body" }],
+      },
+    });
+  });
+
   it("records missing quoted and tab-stripping delimiters", () => {
     expect(parseHeredoc("cat <<'EOF'\nbody").terminated).toBe(false);
     expect(parseHeredoc("cat <<-EOF\n\tbody").terminated).toBe(false);

--- a/packages/just-bash/src/parser/heredoc-termination.test.ts
+++ b/packages/just-bash/src/parser/heredoc-termination.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import type { HereDocNode } from "../ast/types.js";
+import { parse } from "./parser.js";
+
+const parseHeredoc = (source: string): HereDocNode => {
+  const command = parse(source).statements[0]?.pipelines[0]?.commands[0];
+  if (command?.type !== "SimpleCommand") {
+    throw new Error("Expected a simple command");
+  }
+  const target = command.redirections[0]?.target;
+  if (target?.type !== "HereDoc") {
+    throw new Error("Expected a here-document");
+  }
+  return target;
+};
+
+describe("heredoc termination", () => {
+  it("records a consumed delimiter", () => {
+    expect(parseHeredoc("cat <<EOF\nbody\nEOF").terminated).toBe(true);
+  });
+
+  it("records end-of-input after a newline-terminated body", () => {
+    expect(parseHeredoc("cat <<EOF\nbody\n").terminated).toBe(false);
+  });
+
+  it("records end-of-input immediately after the delimiter word", () => {
+    expect(parseHeredoc("cat <<EOF").terminated).toBe(false);
+  });
+
+  it("finalizes every pending heredoc at end-of-input", () => {
+    const command = parse("cat <<FIRST <<SECOND").statements[0].pipelines[0]
+      .commands[0];
+    if (command.type !== "SimpleCommand") throw new Error("expected command");
+    expect(
+      command.redirections.map((redirection) =>
+        redirection.target.type === "HereDoc"
+          ? redirection.target.terminated
+          : undefined,
+      ),
+    ).toEqual([false, false]);
+  });
+
+  it("completes a partial final body line", () => {
+    expect(parseHeredoc("cat <<EOF\nbody")).toMatchObject({
+      terminated: false,
+      content: {
+        parts: [{ type: "Literal", value: "body\n" }],
+      },
+    });
+  });
+
+  it("records missing quoted and tab-stripping delimiters", () => {
+    expect(parseHeredoc("cat <<'EOF'\nbody").terminated).toBe(false);
+    expect(parseHeredoc("cat <<-EOF\n\tbody").terminated).toBe(false);
+  });
+
+  it("accepts a tab-indented delimiter for <<-", () => {
+    expect(parseHeredoc("cat <<-EOF\n\tbody\n\tEOF").terminated).toBe(true);
+  });
+});

--- a/packages/just-bash/src/parser/heredoc-termination.test.ts
+++ b/packages/just-bash/src/parser/heredoc-termination.test.ts
@@ -83,6 +83,14 @@ describe("heredoc termination", () => {
     });
   });
 
+  it("does not fold an even number of unquoted trailing backslashes", () => {
+    expect(parseHeredoc("cat <<EOF\nbody\\\\\nEOF").terminated).toBe(true);
+  });
+
+  it("strips tabs after joining an unquoted continuation", () => {
+    expect(parseHeredoc("cat <<-EOF\n\tEO\\\n\tF").terminated).toBe(false);
+  });
+
   it("records missing quoted and tab-stripping delimiters", () => {
     expect(parseHeredoc("cat <<'EOF'\nbody").terminated).toBe(false);
     expect(parseHeredoc("cat <<-EOF\n\tbody").terminated).toBe(false);

--- a/packages/just-bash/src/parser/lexer.ts
+++ b/packages/just-bash/src/parser/lexer.ts
@@ -1985,13 +1985,14 @@ export class Lexer {
             this.column++;
           }
 
-          const currentLine = heredoc.stripTabs
-            ? line.replace(/^\t+/, "")
-            : line;
-          lineToCheck += currentLine;
+          let trailingBackslashes = 0;
+          for (let index = line.length - 1; line[index] === "\\"; index -= 1) {
+            trailingBackslashes += 1;
+          }
+          lineToCheck += line;
           if (
             heredoc.quoted ||
-            !currentLine.endsWith("\\") ||
+            trailingBackslashes % 2 === 0 ||
             this.pos + 1 >= this.input.length
           ) {
             break;
@@ -2005,7 +2006,10 @@ export class Lexer {
         }
 
         // Check for delimiter
-        if (lineToCheck === heredoc.delimiter) {
+        const delimiterLine = heredoc.stripTabs
+          ? lineToCheck.replace(/^\t+/, "")
+          : lineToCheck;
+        if (delimiterLine === heredoc.delimiter) {
           terminated = true;
           // Consume the newline
           if (this.pos < this.input.length && this.input[this.pos] === "\n") {

--- a/packages/just-bash/src/parser/lexer.ts
+++ b/packages/just-bash/src/parser/lexer.ts
@@ -113,6 +113,8 @@ export interface Token {
   singleQuoted?: boolean;
   /** Quote-removed value for a here-document delimiter token. */
   heredocDelimiter?: string;
+  /** Whether a here-document content token ended at its delimiter. */
+  heredocTerminated?: boolean;
 }
 
 /**
@@ -341,6 +343,10 @@ export class Lexer {
       if (token) {
         tokens.push(token);
       }
+    }
+
+    if (pendingHeredocs.length > 0) {
+      this.readHeredocContent();
     }
 
     // Add EOF token
@@ -1958,6 +1964,7 @@ export class Lexer {
       const startLine = this.line;
       const startColumn = this.column;
       let content = "";
+      let terminated = false;
 
       // Read until we find the delimiter on its own line
       while (this.pos < this.input.length) {
@@ -1973,6 +1980,7 @@ export class Lexer {
         // Check for delimiter
         const lineToCheck = heredoc.stripTabs ? line.replace(/^\t+/, "") : line;
         if (lineToCheck === heredoc.delimiter) {
+          terminated = true;
           // Consume the newline
           if (this.pos < this.input.length && this.input[this.pos] === "\n") {
             this.pos++;
@@ -1983,6 +1991,15 @@ export class Lexer {
         }
 
         content += line;
+        if (this.pos < this.input.length && this.input[this.pos] === "\n") {
+          content += "\n";
+          this.pos++;
+          this.line++;
+          this.column = 1;
+        } else if (line.length > 0) {
+          // Bash completes a partial final heredoc line before executing it.
+          content += "\n";
+        }
         // Check heredoc size limit to prevent memory exhaustion
         if (content.length > this.maxHeredocSize) {
           throw new LexerError(
@@ -1990,12 +2007,6 @@ export class Lexer {
             startLine,
             startColumn,
           );
-        }
-        if (this.pos < this.input.length && this.input[this.pos] === "\n") {
-          content += "\n";
-          this.pos++;
-          this.line++;
-          this.column = 1;
         }
       }
 
@@ -2006,6 +2017,7 @@ export class Lexer {
         end: this.pos,
         line: startLine,
         column: startColumn,
+        heredocTerminated: terminated,
       });
     }
   }

--- a/packages/just-bash/src/parser/lexer.ts
+++ b/packages/just-bash/src/parser/lexer.ts
@@ -302,6 +302,7 @@ export class Lexer {
   private pendingHeredocs: {
     delimiter: string;
     stripTabs: boolean;
+    quoted: boolean;
   }[] = [];
   private pendingHeredocDelimiterMode: boolean | undefined;
   // Track depth inside (( )) for C-style for loops and arithmetic commands
@@ -1969,16 +1970,41 @@ export class Lexer {
       // Read until we find the delimiter on its own line
       while (this.pos < this.input.length) {
         let line = "";
+        let continuationContent = "";
+        let lineToCheck = "";
 
-        // Read one line
-        while (this.pos < this.input.length && this.input[this.pos] !== "\n") {
-          line += this.input[this.pos];
+        // Bash removes unquoted backslash-newline continuations before matching a delimiter.
+        while (true) {
+          line = "";
+          while (
+            this.pos < this.input.length &&
+            this.input[this.pos] !== "\n"
+          ) {
+            line += this.input[this.pos];
+            this.pos++;
+            this.column++;
+          }
+
+          const currentLine = heredoc.stripTabs
+            ? line.replace(/^\t+/, "")
+            : line;
+          lineToCheck += currentLine;
+          if (
+            heredoc.quoted ||
+            !currentLine.endsWith("\\") ||
+            this.pos + 1 >= this.input.length
+          ) {
+            break;
+          }
+
+          lineToCheck = lineToCheck.slice(0, -1);
+          continuationContent += `${line}\n`;
           this.pos++;
-          this.column++;
+          this.line++;
+          this.column = 1;
         }
 
         // Check for delimiter
-        const lineToCheck = heredoc.stripTabs ? line.replace(/^\t+/, "") : line;
         if (lineToCheck === heredoc.delimiter) {
           terminated = true;
           // Consume the newline
@@ -1990,6 +2016,7 @@ export class Lexer {
           break;
         }
 
+        content += continuationContent;
         content += line;
         if (this.pos < this.input.length && this.input[this.pos] === "\n") {
           content += "\n";
@@ -2069,7 +2096,7 @@ export class Lexer {
     this.pos = endPos;
     this.line = currentLine;
     this.column = currentColumn;
-    this.pendingHeredocs.push({ delimiter, stripTabs });
+    this.pendingHeredocs.push({ delimiter, stripTabs, quoted });
 
     return {
       type: TokenType.WORD,

--- a/packages/just-bash/src/parser/parser.ts
+++ b/packages/just-bash/src/parser/parser.ts
@@ -331,6 +331,7 @@ export class Parser {
           contentWord,
           heredoc.stripTabs,
           heredoc.quoted,
+          content.heredocTerminated ?? false,
         );
       }
     }
@@ -398,6 +399,9 @@ export class Parser {
       const stmt = this.parseStatement();
       if (stmt) {
         statements.push(stmt);
+      }
+      if (this.check(TokenType.HEREDOC_CONTENT)) {
+        this.processHeredocs();
       }
       // Don't skip case terminators (;;, ;&, ;;&) at script level - they're syntax errors
       this.skipSeparators(false);

--- a/packages/just-bash/src/syntax/here-document.test.ts
+++ b/packages/just-bash/src/syntax/here-document.test.ts
@@ -124,6 +124,24 @@ EOF`);
     expect(result.exitCode).toBe(0);
   });
 
+  it("should preserve a delimiter after an even number of backslashes", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<EOF\nbody\\\\\nEOF");
+
+    expect(result.stdout).toBe("body\\\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should preserve tabs within an unquoted continuation", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<-EOF\n\tEO\\\n\tF");
+
+    expect(result.stdout).toBe("EO\tF\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("should work in pipes", async () => {
     const env = new Bash();
     const result = await env.exec(`cat <<EOF | grep hello

--- a/packages/just-bash/src/syntax/here-document.test.ts
+++ b/packages/just-bash/src/syntax/here-document.test.ts
@@ -106,6 +106,24 @@ EOF`);
     expect(result.exitCode).toBe(0);
   });
 
+  it("should remove an unquoted trailing backslash continuation", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<EOF\nbody\\");
+
+    expect(result.stdout).toBe("body");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should preserve a quoted trailing backslash", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<'EOF'\nbody\\");
+
+    expect(result.stdout).toBe("body\\\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("should work in pipes", async () => {
     const env = new Bash();
     const result = await env.exec(`cat <<EOF | grep hello

--- a/packages/just-bash/src/syntax/here-document.test.ts
+++ b/packages/just-bash/src/syntax/here-document.test.ts
@@ -88,6 +88,24 @@ EOF`);
     expect(result.exitCode).toBe(0);
   });
 
+  it("should complete an unterminated final body line", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<EOF\nbody");
+
+    expect(result.stdout).toBe("body\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should execute an unterminated empty heredoc", async () => {
+    const env = new Bash();
+    const result = await env.exec("cat <<EOF");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("should work in pipes", async () => {
     const env = new Bash();
     const result = await env.exec(`cat <<EOF | grep hello

--- a/packages/just-bash/src/syntax/quoted-multiline-whitespace.test.ts
+++ b/packages/just-bash/src/syntax/quoted-multiline-whitespace.test.ts
@@ -25,6 +25,14 @@ describe("multi-line quoted string whitespace", () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it("removes a backslash-newline continuation inside double quotes", async () => {
+    const env = new Bash();
+    const result = await env.exec('printf "%s" "first\\\nsecond"');
+
+    expect(result.stdout).toBe("firstsecond");
+    expect(result.exitCode).toBe(0);
+  });
+
   it("preserves indentation through a variable assignment and expansion", async () => {
     const env = new Bash();
     const result = await env.exec(

--- a/packages/just-bash/src/syntax/quoted-multiline-whitespace.test.ts
+++ b/packages/just-bash/src/syntax/quoted-multiline-whitespace.test.ts
@@ -25,14 +25,6 @@ describe("multi-line quoted string whitespace", () => {
     expect(result.exitCode).toBe(0);
   });
 
-  it("removes a backslash-newline continuation inside double quotes", async () => {
-    const env = new Bash();
-    const result = await env.exec('printf "%s" "first\\\nsecond"');
-
-    expect(result.stdout).toBe("firstsecond");
-    expect(result.exitCode).toBe(0);
-  });
-
   it("preserves indentation through a variable assignment and expansion", async () => {
     const env = new Bash();
     const result = await env.exec(

--- a/packages/just-bash/src/transform/serialize.test.ts
+++ b/packages/just-bash/src/transform/serialize.test.ts
@@ -415,13 +415,12 @@ describe("serialize", () => {
     it("heredoc with tabs", () => roundTrip("cat <<EOF\n\ttabbed\nEOF"));
     it("heredoc fed to command", () =>
       roundTrip("grep pattern <<EOF\nfoo pattern bar\nEOF"));
-    it("unterminated heredoc", () => {
-      const source = "cat <<EOF\nbody";
-      expect(serialize(parse(source))).toBe("cat <<EOF\nbody\n");
-      roundTrip(source);
-    });
-    it("unterminated empty heredoc", () => {
-      expect(serialize(parse("cat <<EOF"))).toBe("cat <<EOF\n");
+    it("rejects unterminated heredocs", () => {
+      for (const source of ["cat <<EOF\nbody", "cat <<EOF", "cat <<A <<B"]) {
+        expect(() => serialize(parse(source))).toThrow(
+          "Cannot serialize an unterminated here-document",
+        );
+      }
     });
     it("legacy heredoc without termination evidence", () => {
       const source = "cat <<EOF\nbody\nEOF";

--- a/packages/just-bash/src/transform/serialize.test.ts
+++ b/packages/just-bash/src/transform/serialize.test.ts
@@ -424,7 +424,11 @@ describe("serialize", () => {
     });
     it("recognizes unquoted continuations before checking heredoc delimiters", () => {
       expect(() => serialize(parse("cat <<EOF\nEO\\\nF"))).not.toThrow();
+      expect(() => serialize(parse("cat <<EOF\nbody\\\\\nEOF"))).not.toThrow();
       expect(() => serialize(parse("cat <<EOF\nbody\\\nEOF"))).toThrow(
+        "Cannot serialize an unterminated here-document",
+      );
+      expect(() => serialize(parse("cat <<-EOF\n\tEO\\\n\tF"))).toThrow(
         "Cannot serialize an unterminated here-document",
       );
     });

--- a/packages/just-bash/src/transform/serialize.test.ts
+++ b/packages/just-bash/src/transform/serialize.test.ts
@@ -422,6 +422,12 @@ describe("serialize", () => {
         );
       }
     });
+    it("recognizes unquoted continuations before checking heredoc delimiters", () => {
+      expect(() => serialize(parse("cat <<EOF\nEO\\\nF"))).not.toThrow();
+      expect(() => serialize(parse("cat <<EOF\nbody\\\nEOF"))).toThrow(
+        "Cannot serialize an unterminated here-document",
+      );
+    });
     it("legacy heredoc without termination evidence", () => {
       const source = "cat <<EOF\nbody\nEOF";
       const ast = parse(source);

--- a/packages/just-bash/src/transform/serialize.test.ts
+++ b/packages/just-bash/src/transform/serialize.test.ts
@@ -415,6 +415,24 @@ describe("serialize", () => {
     it("heredoc with tabs", () => roundTrip("cat <<EOF\n\ttabbed\nEOF"));
     it("heredoc fed to command", () =>
       roundTrip("grep pattern <<EOF\nfoo pattern bar\nEOF"));
+    it("unterminated heredoc", () => {
+      const source = "cat <<EOF\nbody";
+      expect(serialize(parse(source))).toBe("cat <<EOF\nbody\n");
+      roundTrip(source);
+    });
+    it("unterminated empty heredoc", () => {
+      expect(serialize(parse("cat <<EOF"))).toBe("cat <<EOF\n");
+    });
+    it("legacy heredoc without termination evidence", () => {
+      const source = "cat <<EOF\nbody\nEOF";
+      const ast = parse(source);
+      const command = ast.statements[0].pipelines[0].commands[0];
+      if (command.type !== "SimpleCommand") throw new Error("expected command");
+      const target = command.redirections[0].target;
+      if (target.type !== "HereDoc") throw new Error("expected heredoc");
+      delete target.terminated;
+      expect(serialize(ast)).toBe(source);
+    });
   });
 
   describe("complex scripts", () => {

--- a/packages/just-bash/src/transform/serialize.ts
+++ b/packages/just-bash/src/transform/serialize.ts
@@ -375,12 +375,14 @@ function serializeRedirection(node: RedirectionNode): string {
 
   if (node.operator === "<<" || node.operator === "<<-") {
     const heredoc = node.target as HereDocNode;
+    if (heredoc.terminated === false) {
+      throw new Error("Cannot serialize an unterminated here-document");
+    }
     const delimStr = heredoc.quoted
       ? `'${heredoc.delimiter}'`
       : heredoc.delimiter;
     const content = serializeHeredocContent(heredoc.content, heredoc.quoted);
-    const terminator = heredoc.terminated === false ? "" : heredoc.delimiter;
-    return `${fdStr}${node.operator}${delimStr}\n${content}${terminator}`;
+    return `${fdStr}${node.operator}${delimStr}\n${content}${heredoc.delimiter}`;
   }
 
   if (node.operator === "<<<") {

--- a/packages/just-bash/src/transform/serialize.ts
+++ b/packages/just-bash/src/transform/serialize.ts
@@ -379,7 +379,8 @@ function serializeRedirection(node: RedirectionNode): string {
       ? `'${heredoc.delimiter}'`
       : heredoc.delimiter;
     const content = serializeHeredocContent(heredoc.content, heredoc.quoted);
-    return `${fdStr}${node.operator}${delimStr}\n${content}${heredoc.delimiter}`;
+    const terminator = heredoc.terminated === false ? "" : heredoc.delimiter;
+    return `${fdStr}${node.operator}${delimStr}\n${content}${terminator}`;
   }
 
   if (node.operator === "<<<") {

--- a/packages/just-bash/src/transform/transform.test.ts
+++ b/packages/just-bash/src/transform/transform.test.ts
@@ -18,6 +18,22 @@ describe("transform", () => {
     expect(() => bash.transform("echo ok")).not.toThrow();
   });
 
+  it("executes EOF-terminated heredocs but rejects them from transform APIs", async () => {
+    const script = "cat <<EOF\nbody";
+    const bash = new Bash();
+    const result = await bash.exec(script);
+
+    expect(result.stdout).toBe("body\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(() => bash.transform(script)).toThrow(
+      "Cannot serialize an unterminated here-document",
+    );
+    expect(() => new BashTransformPipeline().transform(script)).toThrow(
+      "Cannot serialize an unterminated here-document",
+    );
+  });
+
   describe("no plugins", () => {
     it("returns original script unchanged", () => {
       const bash = new Bash();


### PR DESCRIPTION
## Problem

Here-documents ended by end-of-input were indistinguishable from documents closed by their delimiter. This lost information produced two visible compatibility bugs: `cat <<EOF\nbody` returned `body` without Bash's trailing newline, and a delimiter-only `cat <<EOF` failed parsing instead of executing with empty input.

AST transforms also silently changed malformed source. Serializing an unterminated heredoc always manufactured its closing delimiter, so parse/serialize could turn an EOF-terminated document into a completed one.

## Changes

Here-document AST nodes now carry optional `terminated` evidence. Parser-produced nodes always report whether the lexer consumed the delimiter; the optional shape keeps older and synthetic ASTs compatible.

EOF completes a partial final body line with a newline, matching Bash execution. The shared expansion parser now removes Bash backslash-newline continuations in unquoted heredocs and double-quoted words, while quoted heredocs remain literal.

Serialization rejects `terminated: false` rather than manufacturing a delimiter or allowing later transformed syntax to become heredoc content. Legacy ASTs that omit the field preserve the historical completed form.

This PR does not add the missing-delimiter warning emitted by newer Bash versions. That requires a separate parse-warning pipeline because Bash reports the warning even when control flow never executes the heredoc.
