### PR TITLE
fix(file): report gzip from its header instead of inflating it

### DIFF
--- a/.changeset/file-gzip-no-inflate.md
+++ b/.changeset/file-gzip-no-inflate.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Report gzip files from their header instead of inflating them. `file` no longer enters `file-type`'s nested gzip probe, which decompressed up to 16 MB of input to look for an inner tar and leaked an `AbortError` unhandled rejection after the command had already returned. Gzipped tar archives now read as `gzip compressed data` rather than `gzip archive data`, matching `file`.

--- a/packages/just-bash/src/commands/file/file.gzip.test.ts
+++ b/packages/just-bash/src/commands/file/file.gzip.test.ts
@@ -1,0 +1,126 @@
+import { gzipSync } from "node:zlib";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Bash } from "../../Bash.js";
+
+// A minimal ustar member followed by the two zero blocks that end an archive
+function tarArchive(name: string, data: Uint8Array): Uint8Array {
+  const header = new Uint8Array(512);
+  const write = (text: string, offset: number) => {
+    for (let i = 0; i < text.length; i++) {
+      header[offset + i] = text.charCodeAt(i);
+    }
+  };
+  write(name, 0);
+  write("0000644\0", 100);
+  write("0000000\0", 108);
+  write("0000000\0", 116);
+  write(`${data.length.toString(8).padStart(11, "0")}\0`, 124);
+  write("00000000000\0", 136);
+  write("        ", 148);
+  write("0", 156);
+  write("ustar\0", 257);
+  write("00", 263);
+  const checksum = header.reduce((total, byte) => total + byte, 0);
+  write(`${checksum.toString(8).padStart(6, "0")}\0 `, 148);
+
+  const padding = new Uint8Array((512 - (data.length % 512)) % 512);
+  const trailer = new Uint8Array(1024);
+  const archive = new Uint8Array(
+    header.length + data.length + padding.length + trailer.length,
+  );
+  archive.set(header, 0);
+  archive.set(data, header.length);
+  archive.set(trailer, header.length + data.length + padding.length);
+  return archive;
+}
+
+function gzip(data: Uint8Array): Uint8Array {
+  return new Uint8Array(gzipSync(data));
+}
+
+const plainGzip = gzip(new TextEncoder().encode("hello world\n"));
+const tarGzip = gzip(
+  tarArchive("payload.bin", new Uint8Array(64 * 1024).fill(0x41)),
+);
+
+describe("file gzip", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("should report gzip compressed data", async () => {
+    const env = new Bash();
+    await env.fs.writeFile("/tmp/payload.gz", plainGzip);
+    const result = await env.exec("file /tmp/payload.gz");
+    expect(result.stdout).toBe("/tmp/payload.gz: gzip compressed data\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should report gzip compressed data for an archive member", async () => {
+    const env = new Bash();
+    await env.fs.writeFile("/tmp/payload.tar.gz", tarGzip);
+    const result = await env.exec("file /tmp/payload.tar.gz");
+    expect(result.stdout).toBe("/tmp/payload.tar.gz: gzip compressed data\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should report the gzip MIME type with -i", async () => {
+    const env = new Bash();
+    await env.fs.writeFile("/tmp/payload.gz", plainGzip);
+    await env.fs.writeFile("/tmp/payload.tar.gz", tarGzip);
+    const result = await env.exec(
+      "file -i /tmp/payload.gz /tmp/payload.tar.gz",
+    );
+    expect(result.stdout).toBe(
+      "/tmp/payload.gz: application/gzip\n/tmp/payload.tar.gz: application/gzip\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should not decompress gzip input", async () => {
+    const constructed: string[] = [];
+    // An identity transform in place of the real thing: a regression fails the
+    // recorded-format assertion instead of inflating and hanging the suite
+    vi.stubGlobal(
+      "DecompressionStream",
+      class {
+        readable: ReadableStream<Uint8Array>;
+        writable: WritableStream<Uint8Array>;
+        constructor(format: string) {
+          constructed.push(format);
+          const { readable, writable } = new TransformStream<
+            Uint8Array,
+            Uint8Array
+          >();
+          this.readable = readable;
+          this.writable = writable;
+        }
+      },
+    );
+
+    const env = new Bash();
+    await env.fs.writeFile("/tmp/payload.gz", plainGzip);
+    await env.fs.writeFile("/tmp/payload.tar.gz", tarGzip);
+    const result = await env.exec("file /tmp/payload.gz /tmp/payload.tar.gz");
+
+    expect(constructed).toEqual([]);
+    expect(result.stdout).toBe(
+      "/tmp/payload.gz: gzip compressed data\n/tmp/payload.tar.gz: gzip compressed data\n",
+    );
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("should still consult file-type when the compression method is not deflate", async () => {
+    const env = new Bash();
+    const notGzip = new Uint8Array(plainGzip);
+    notGzip[2] = 0x00;
+    await env.fs.writeFile("/tmp/method-zero.bin", notGzip);
+    const result = await env.exec("file /tmp/method-zero.bin");
+    expect(result.stdout).toBe("/tmp/method-zero.bin: UTF-8 Unicode text\n");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/file/file.ts
+++ b/packages/just-bash/src/commands/file/file.ts
@@ -363,6 +363,14 @@ function detectTextType(content: string, filename: string): FileType {
   return { description: `ASCII text${lineEnding}`, mime: "text/plain" };
 }
 
+// gzip magic plus the deflate compression method, matching the header check
+// file-type uses to enter its nested gzip probe
+const GZIP_HEADER = [0x1f, 0x8b, 0x08];
+
+function isGzip(buffer: Uint8Array): boolean {
+  return GZIP_HEADER.every((byte, index) => buffer[index] === byte);
+}
+
 async function detectFileType(
   filename: string,
   buffer: Uint8Array,
@@ -370,6 +378,17 @@ async function detectFileType(
   // Empty file
   if (buffer.length === 0) {
     return { description: "empty", mime: "inode/x-empty" };
+  }
+
+  // file-type inflates gzip members to look for an inner tar, which decompresses
+  // up to 16 MB of untrusted input and cancels a Node-backed DecompressionStream
+  // whose synthesized AbortError escapes this call. file reports the container
+  // without decompressing, so answer from the header instead.
+  if (isGzip(buffer)) {
+    return {
+      description: generateDescription("gz", "application/gzip"),
+      mime: "application/gzip",
+    };
   }
 
   // Use file-type for binary detection (needs raw bytes)


### PR DESCRIPTION
## Problem

`file` on a gzip file leaks an `AbortError` unhandled rejection into the host process after the command has already returned exit code 0.

```js
const env = new Bash();
await env.fs.writeFile("/tmp/p.gz", new Uint8Array(gzipSync(new Uint8Array(64 * 1024).fill(0x41))));
const result = await env.exec("file /tmp/p.gz");
// result.exitCode === 0, result.stdout === "/tmp/p.gz: gzip compressed data\n"
// and then, after exec() has already resolved:
//   AbortError: The operation was aborted
//     at destroyer (node:internal/streams/destroy:328:11)
//     at Object.cancel (node:internal/webstreams/adapters:557:7)
//     at ... at ReadableStreamDefaultReader.cancel (node:internal/webstreams/readablestream:922:12)
//     at cancelSource (file-type/core.js:354:16)
```

The rejection arrives after `bash.exec()` resolves, so a `try`/`catch` around the call cannot see it and the tool result looks clean. In an embedding host it lands in whatever global `unhandledRejection` handler exists: Electron apps log and surface it as a crash-shaped error attributed to nothing in particular, and a plain Node runner with no handler exits. It is easy to misattribute to a canceled request or a failed tool call, because the agent turn that ran `find ... -exec file '{}' \;` completed normally.

## Cause

`detectFileType` hands raw bytes to `fileTypeFromBuffer`. For anything starting `1f 8b 08`, file-type 21.3.4 enters `detectGzip`, which inflates the member to look for an inner tar:

```js
const gzipHandler = new GzipHandler(tokenizer);
const limitedInflatedStream = createByteLimitedReadableStream(gzipHandler.inflate(), maximumNestedGzipDetectionSizeInBytes);
compressedFileType = await (probeParser ?? this).fromStream(limitedInflatedStream);
```

`GzipHandler.inflate()` is a source `pipeThrough(new DecompressionStream("gzip"))`, and Node builds `DecompressionStream` out of `zlib.createGunzip()` through `newReadableWritablePairFromDuplex`. When the inner detection finishes, `fromTokenizer`'s `finally { await tokenizer.close() }` cancels the limited stream with no reason:

```js
const cancelSource = async reason => {
	if (sourceDone || sourceCanceled) return;
	sourceCanceled = true;
	await reader.cancel(reason);   // reason === undefined
};
```

Node's adapter turns that into `destroy(streamReadable, undefined)`, and `destroyer` manufactures the error because the gunzip duplex has not finished:

```js
if (!err && !isFinished(stream)) {
  err = new AbortError();
}
```

Every link in that chain is inside file-type and Node, so there is no just-bash frame to catch it. Whether it escapes depends on whether the inflate pipe is still in flight when the cancel lands: a gzip of a 64 KB payload reproduces 3 out of 3 runs, with or without an inner tar; a gzip of `"hello world\n"` drains first and stays quiet, 0 out of 3. That is why this looks intermittent in production, and it is why the existing tests never saw it: `file.test.ts` had no gzip case at all.

Reported as "the HSM attestation file is special". It is not: any gzip member above roughly a page of decompressed output does it, and the attestation was simply the first one an agent pointed `find -exec file` at.

## Fix

Answer gzip from its header and never call into file-type for it. The guard matches the exact `[0x1F, 0x8B, 0x08]` check file-type uses to enter `detectGzip`, so it covers precisely the inputs that would have been inflated and nothing else.

This also drops up to 16 MB of decompression of untrusted input per gzip operand, which a sandbox that bounds compute everywhere else should not be doing for a `file` call.

The broader alternative is to stop trusting file-type's async lifetime in general, by running detection behind a per-call rejection trap. That is not here: it would swallow real errors, and gzip is the only place `createByteLimitedReadableStream` is used, so the narrow guard closes this stack completely. Say the word if you want the general trap instead.

## Scope

Unchanged: every non-gzip detection path, all flags, the `.gz` description and `application/gzip` MIME, and the extension and text fallbacks.

Behavior change, deliberate: gzipped tar archives now read as `gzip compressed data` instead of `gzip archive data`. That is a bug fix in its own right. `file` reports the container without decompressing, and `tar.gz` was falling off the end of `EXT_TO_DESCRIPTION` into the generic `application/*` branch, which saw `zip` inside `gzip` and produced `gzip archive data`. Real `file` on both a `.gz` and a `.tar.gz` says `gzip compressed data, ...`; it never reports tar without `-z`.

Not addressed, deliberately: `ZipHandler` also builds a `DecompressionStream("deflate-raw")` and file-type's `decompressDeflateRawWithLimit` cancels a reader on its size limit. Those are a different code path that does not produce this stack, and I have not reproduced an escape there. Worth a look separately rather than widening this diff.

No comparison test: just-bash's `file` deliberately emits a bare `gzip compressed data` with none of GNU file's `, from Unix, original size modulo 2^32 ...` detail, so a recorded-bash fixture would not match on any platform. Unit tests are the right level here.

## Tests

New `src/commands/file/file.gzip.test.ts`, 5 cases: plain gzip and gzipped tar both report `gzip compressed data`, `-i` reports `application/gzip` for both, `file` constructs zero `DecompressionStream`s while inspecting gzip operands (recorded through a stubbed global), and a header with a non-deflate compression method still falls through to file-type.

The archive-member case is the regression test for the rejection itself: with the guard removed it fails twice over, once on the `gzip archive data` assertion and once because vitest catches the unhandled `AbortError`, with the identical stack quoted above. Verified by flipping the guard off and re-running, not inferred, 3 out of 3 runs.

What the tests cannot prove: they pin that no decompression is attempted, which is the invariant that closes the stack, but they do not exercise the file-type internals themselves, so a future file-type version that inflates from a different entry point would not be caught here.

Suite: 568 files, 11425 passed, 96 skipped in `just-bash`, plus 4 files and 72 passed in `just-bash-executor`, excluding spec tests. `pnpm typecheck`, `pnpm lint:fix`, and `pnpm knip` are clean. One earlier run timed out in `find.perf.test.ts`, a wall-clock benchmark, while other work was saturating the machine; it passes standalone and the full suite is green on a quiet machine.

---

Authored with Claude Opus 5
