### PR TITLE
fix(expansion): preserve leading IFS boundaries

### DIFF
--- a/.changeset/leading-ifs-array-defaults.md
+++ b/.changeset/leading-ifs-array-defaults.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Preserve argument boundaries when unquoted array default expansions begin with an IFS delimiter.

--- a/packages/just-bash/src/interpreter/array-state-integrity.test.ts
+++ b/packages/just-bash/src/interpreter/array-state-integrity.test.ts
@@ -78,6 +78,21 @@ describe("structured array state integrity", () => {
     });
   });
 
+  it("preserves a leading IFS boundary after an array default expansion", async () => {
+    const result = await new Bash().exec(`
+      values=('' x)
+      set -- prefix=\${values[@]-fallback}
+      printf 'count=%s\n' "$#"
+      for value; do printf 'arg=<%s>\n' "$value"; done
+    `);
+
+    expect(result).toMatchObject({
+      stdout: "count=2\narg=<prefix=>\narg=<x>\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it.each([
     ["export", "readonly x=old; export x=new"],
     ["export -n", "readonly x=old; export -n x=new"],

--- a/packages/just-bash/src/interpreter/array-state-integrity.test.ts
+++ b/packages/just-bash/src/interpreter/array-state-integrity.test.ts
@@ -183,6 +183,39 @@ describe("structured array state integrity", () => {
     });
   });
 
+  it("preserves leading IFS boundaries from mixed operation words", async () => {
+    const result = await new Bash().exec(`
+      x=' b'
+      unset value
+      set -- prefix=\${value:-""$x}
+      printf 'default=<%s>|<%s>\n' "$1" "$2"
+      value=set
+      set -- prefix=\${value:+""$x}
+      printf 'alternative=<%s>|<%s>\n' "$1" "$2"
+    `);
+
+    expect(result).toMatchObject({
+      stdout: "default=<prefix=>|<b>\nalternative=<prefix=>|<b>\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("preserves trailing IFS boundaries from mixed operation words", async () => {
+    const result = await new Bash().exec(`
+      x='b '
+      unset value
+      set -- prefix=\${value:-$x""}suffix
+      printf '<%s>|<%s>\n' "$1" "$2"
+    `);
+
+    expect(result).toMatchObject({
+      stdout: "<prefix=b>|<suffix>\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("preserves associative nameref subscripts", async () => {
     const result = await new Bash().exec(`
       declare -A values=([key]=value)

--- a/packages/just-bash/src/interpreter/array-state-integrity.test.ts
+++ b/packages/just-bash/src/interpreter/array-state-integrity.test.ts
@@ -93,6 +93,27 @@ describe("structured array state integrity", () => {
     });
   });
 
+  it("does not add an empty field after a flushed prefix", async () => {
+    const result = await new Bash().exec(`
+      values=('' x y)
+      set -- p""\${values[@]-fallback}
+      printf 'quoted-count=%s\n' "$#"
+      for value; do printf 'quoted=<%s>\n' "$value"; done
+      IFS=' :'
+      value=' :b'
+      set -- a$value
+      printf 'ifs-count=%s\n' "$#"
+      for value; do printf 'ifs=<%s>\n' "$value"; done
+    `);
+
+    expect(result).toMatchObject({
+      stdout:
+        "quoted-count=3\nquoted=<p>\nquoted=<x>\nquoted=<y>\nifs-count=2\nifs=<a>\nifs=<b>\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it.each([
     ["export", "readonly x=old; export x=new"],
     ["export -n", "readonly x=old; export -n x=new"],

--- a/packages/just-bash/src/interpreter/expansion/word-split.ts
+++ b/packages/just-bash/src/interpreter/expansion/word-split.ts
@@ -409,30 +409,39 @@ export async function smartWordSplit(
         ctx.limits.maxArrayElements,
       );
 
-      if (hadLeadingDelimiter && currentWord !== "") {
+      const flushedLeadingDelimiter = hadLeadingDelimiter && currentWord !== "";
+      if (flushedLeadingDelimiter) {
         pushSplitWord(ctx, words, currentWord);
         currentWord = "";
         hasProducedWord = true;
       }
 
+      const splitParts =
+        flushedLeadingDelimiter && parts[0] === "" ? parts.slice(1) : parts;
+
       // If the previous segment was a quoted empty and this splittable segment
       // has leading IFS delimiter, the quoted empty should anchor an empty word
-      if (prevWasQuotedEmpty && hadLeadingDelimiter && currentWord === "") {
+      if (
+        prevWasQuotedEmpty &&
+        hadLeadingDelimiter &&
+        !flushedLeadingDelimiter &&
+        currentWord === ""
+      ) {
         pushSplitWord(ctx, words, "");
         hasProducedWord = true;
       }
 
-      if (parts.length === 0) {
+      if (splitParts.length === 0) {
         // Empty expansion produces nothing - continue building current word
         // This happens for empty string or all-whitespace with default IFS
         // BUT if there was a trailing delimiter (e.g., "   "), mark pending word break
         if (hadTrailingDelimiter) {
           pendingWordBreak = true;
         }
-      } else if (parts.length === 1) {
+      } else if (splitParts.length === 1) {
         // Single result: just append to current word
         // Note: parts[0] might be empty string (e.g., IFS='_' and var='_' produces [""])
-        currentWord += parts[0];
+        currentWord += splitParts[0];
         hasProducedWord = true;
         // If there was a trailing delimiter, mark pending word break for next segment
         pendingWordBreak = hadTrailingDelimiter;
@@ -441,17 +450,17 @@ export async function smartWordSplit(
         // - First part joins with current word
         // - Middle parts become separate words
         // - Last part starts the new current word
-        currentWord += parts[0];
+        currentWord += splitParts[0];
         pushSplitWord(ctx, words, currentWord);
         hasProducedWord = true;
 
         // Add middle parts as separate words
-        for (let i = 1; i < parts.length - 1; i++) {
-          pushSplitWord(ctx, words, parts[i]);
+        for (let i = 1; i < splitParts.length - 1; i++) {
+          pushSplitWord(ctx, words, splitParts[i]);
         }
 
         // Last part becomes the new current word
-        currentWord = parts[parts.length - 1];
+        currentWord = splitParts[splitParts.length - 1];
         // If there was a trailing delimiter, mark pending word break for next segment
         pendingWordBreak = hadTrailingDelimiter;
       }

--- a/packages/just-bash/src/interpreter/expansion/word-split.ts
+++ b/packages/just-bash/src/interpreter/expansion/word-split.ts
@@ -308,7 +308,17 @@ export async function smartWordSplit(
           split.value,
         );
       }
-      const splitParts = split.words;
+      const flushedLeadingDelimiter =
+        split.hadLeadingDelimiter && currentWord !== "";
+      if (flushedLeadingDelimiter) {
+        pushSplitWord(ctx, words, currentWord);
+        currentWord = "";
+        hasProducedWord = true;
+      }
+      const splitParts =
+        flushedLeadingDelimiter && split.words[0] === ""
+          ? split.words.slice(1)
+          : split.words;
 
       if (splitParts.length === 0) {
         // Empty expansion produces nothing
@@ -327,8 +337,7 @@ export async function smartWordSplit(
 
         currentWord = splitParts[splitParts.length - 1];
       }
-      // Reset pending word break after processing mixed default parts
-      pendingWordBreak = false;
+      pendingWordBreak = split.hadTrailingDelimiter;
       prevWasQuotedEmpty = false;
     } else {
       // Splittable: split by IFS using extended version that tracks trailing delimiters
@@ -434,7 +443,12 @@ async function smartWordSplitWithUnquotedLiterals(
   ifsChars: string,
   _ifsPattern: string,
   expandPartFn: ExpandPartFn,
-): Promise<{ words: string[]; value: string }> {
+): Promise<{
+  words: string[];
+  value: string;
+  hadLeadingDelimiter: boolean;
+  hadTrailingDelimiter: boolean;
+}> {
   // Expand all parts and track if they are splittable
   // In this context, Literal parts ARE splittable
   type Segment = { value: string; isSplittable: boolean };
@@ -458,6 +472,7 @@ async function smartWordSplitWithUnquotedLiterals(
   let currentWord = "";
   let hasProducedWord = false;
   let pendingWordBreak = false;
+  let hadLeadingDelimiter = false;
 
   for (const segment of segments) {
     if (!segment.isSplittable) {
@@ -488,11 +503,23 @@ async function smartWordSplitWithUnquotedLiterals(
       }
 
       // Split by IFS using extended version
-      const { words: parts, hadTrailingDelimiter } = splitByIfsForExpansionEx(
+      const {
+        words: parts,
+        hadLeadingDelimiter: segmentHadLeadingDelimiter,
+        hadTrailingDelimiter,
+      } = splitByIfsForExpansionEx(
         segment.value,
         ifsChars,
         ctx.limits.maxArrayElements,
       );
+
+      if (
+        words.length === 0 &&
+        currentWord === "" &&
+        segmentHadLeadingDelimiter
+      ) {
+        hadLeadingDelimiter = true;
+      }
 
       if (parts.length === 0) {
         // Empty expansion produces nothing
@@ -525,5 +552,10 @@ async function smartWordSplitWithUnquotedLiterals(
     pushSplitWord(ctx, words, "");
   }
 
-  return { words, value: segments.map((segment) => segment.value).join("") };
+  return {
+    words,
+    value: segments.map((segment) => segment.value).join(""),
+    hadLeadingDelimiter,
+    hadTrailingDelimiter: pendingWordBreak,
+  };
 }

--- a/packages/just-bash/src/interpreter/expansion/word-split.ts
+++ b/packages/just-bash/src/interpreter/expansion/word-split.ts
@@ -409,6 +409,12 @@ export async function smartWordSplit(
         ctx.limits.maxArrayElements,
       );
 
+      if (hadLeadingDelimiter && currentWord !== "") {
+        pushSplitWord(ctx, words, currentWord);
+        currentWord = "";
+        hasProducedWord = true;
+      }
+
       // If the previous segment was a quoted empty and this splittable segment
       // has leading IFS delimiter, the quoted empty should anchor an empty word
       if (prevWasQuotedEmpty && hadLeadingDelimiter && currentWord === "") {

--- a/packages/just-bash/src/spec-tests/bash/cases/var-op-test.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/var-op-test.test.sh
@@ -311,7 +311,7 @@ v=foo
 #### array and - and +
 case $SH in dash) exit ;; esac
 
-shopt -s compat_array  # to refer to array as scalar
+case ${SH##*/} in osh) shopt -s compat_array ;; esac
 
 empty=()
 a1=('')
@@ -378,6 +378,7 @@ a3=plus
 ['3', '4']
 ['plus']
 ## END
+## stderr-json: ""
 ## N-I dash stdout-json: ""
 ## N-I zsh STDOUT:
 empty=

--- a/packages/just-bash/src/spec-tests/bash/cases/var-op-test.test.sh
+++ b/packages/just-bash/src/spec-tests/bash/cases/var-op-test.test.sh
@@ -309,7 +309,6 @@ v=foo
 ## END
 
 #### array and - and +
-## SKIP (unimplementable): shopt compat_array not implemented (OSH-specific), empty string in unquoted array expansion loses space
 case $SH in dash) exit ;; esac
 
 shopt -s compat_array  # to refer to array as scalar


### PR DESCRIPTION
## Problem

Unquoted array default expansion can begin with an empty element. When it followed literal text, the word splitter dropped the resulting boundary: `prefix=${values[@]-fallback}` could merge `prefix=` and the next array element into one argument. Commands then received different arguments from Bash.

## Changes

The splitter now commits preceding literal text when the next unquoted expansion begins with an IFS delimiter. The change preserves the intended argument boundary and enables the matching Oils conformance case.

Stack position: child of #366; prerequisite for the structured-extglob repair.
