### PR TITLE
Undo ineffective website agent auth. Fix defense-in-depth breaking in next.js routes

### DIFF
--- a/.changeset/calm-shells-rest.md
+++ b/.changeset/calm-shells-rest.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Prevent defense-in-depth violation reporting from recursively overflowing the call stack in host runtimes that wrap `Date.now()`, honor configured main-thread violation exclusions, and include actionable exclusion guidance for configurable violations.
+Prevent defense-in-depth violation reporting from recursively overflowing the call stack in host runtimes that wrap `Date.now()`, honor configured main-thread violation exclusions, include actionable exclusion guidance for configurable violations, and keep constructor-execution protections non-excludable.

--- a/.changeset/calm-shells-rest.md
+++ b/.changeset/calm-shells-rest.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Prevent defense-in-depth violation reporting from recursively overflowing the call stack in host runtimes that wrap `Date.now()`, and honor configured main-thread violation exclusions.
+Prevent defense-in-depth violation reporting from recursively overflowing the call stack in host runtimes that wrap `Date.now()`, honor configured main-thread violation exclusions, and include actionable exclusion guidance for configurable violations.

--- a/.changeset/calm-shells-rest.md
+++ b/.changeset/calm-shells-rest.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Prevent defense-in-depth violation reporting from recursively overflowing the call stack in host runtimes that wrap `Date.now()`, and honor configured main-thread violation exclusions.

--- a/examples/website/app/api/agent/route.ts
+++ b/examples/website/app/api/agent/route.ts
@@ -220,8 +220,18 @@ export async function POST(req: Request) {
     return Response.json({ error: "Invalid request" }, { status });
   }
   try {
-    const overlayFs = new OverlayFs({ root: AGENT_DATA_DIR, readOnly: true });
-    const sandbox = new Bash({ fs: overlayFs, cwd: overlayFs.getMountPoint() });
+    const overlayFs = new OverlayFs({ root: AGENT_DATA_DIR });
+    const sandbox = new Bash({
+      fs: overlayFs,
+      cwd: overlayFs.getMountPoint(),
+      defenseInDepth: {
+        excludeViolationTypes: [
+          "error_prepare_stack_trace",
+          "performance_timing",
+          "weak_ref",
+        ],
+      },
+    });
     const bashToolkit = await createBashTool({
       sandbox,
       destination: overlayFs.getMountPoint(),

--- a/examples/website/app/api/agent/route.ts
+++ b/examples/website/app/api/agent/route.ts
@@ -1,7 +1,6 @@
 import { ToolLoopAgent, createAgentUIStreamResponse, stepCountIs } from "ai";
 import { createBashTool } from "bash-tool";
 import { Bash, OverlayFs } from "just-bash";
-import { timingSafeEqual } from "node:crypto";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 
@@ -11,72 +10,12 @@ const MAX_REQUEST_BYTES = 64 * 1024;
 const MAX_MESSAGES = 20;
 const MAX_MESSAGE_TEXT_BYTES = 48 * 1024;
 const MAX_BODY_READ_MS = 15_000;
-const MAX_CONCURRENT_REQUESTS = 8;
-const MAX_REQUESTS_PER_MINUTE = 120;
-let activeRequests = 0;
-const recentAdmissions: number[] = [];
 
-function unauthorized(): Response {
-  return Response.json({ error: "Unauthorized" }, { status: 401 });
-}
-
-function authenticate(req: Request): Response | undefined {
-  const configuredToken = process.env.JUST_BASH_AGENT_API_TOKEN;
-  if (!configuredToken) {
-    // The paid-model demo is convenient during local development, but a
-    // production deployment must opt in with an authentication boundary.
-    return process.env.NODE_ENV === "production"
-      ? Response.json(
-          { error: "Agent endpoint is disabled" },
-          { status: 503 },
-        )
-      : undefined;
-  }
-
-  const authorization = req.headers.get("authorization");
-  if (!authorization?.startsWith("Bearer ")) return unauthorized();
-  const supplied = authorization.slice("Bearer ".length);
-  const suppliedBytes = Buffer.from(supplied);
-  const configuredBytes = Buffer.from(configuredToken);
-  if (
-    suppliedBytes.byteLength !== configuredBytes.byteLength ||
-    !timingSafeEqual(suppliedBytes, configuredBytes)
-  ) {
-    return unauthorized();
-  }
-  return undefined;
-}
-
-function admitRequest(): (() => void) | Response {
-  const now = Date.now();
-  while (recentAdmissions[0] !== undefined && recentAdmissions[0] <= now - 60_000) {
-    recentAdmissions.shift();
-  }
-  if (
-    activeRequests >= MAX_CONCURRENT_REQUESTS ||
-    recentAdmissions.length >= MAX_REQUESTS_PER_MINUTE
-  ) {
-    return Response.json(
-      { error: "Too many requests" },
-      { status: 429, headers: { "Retry-After": "60" } },
-    );
-  }
-  activeRequests++;
-  recentAdmissions.push(now);
-  let released = false;
-  return () => {
-    if (released) return;
-    released = true;
-    activeRequests--;
-  };
-}
 
 function releaseWhenStreamCloses(
   response: Response,
-  release: () => void,
 ): Response {
   if (!response.body) {
-    release();
     return response;
   }
   const reader = response.body.getReader();
@@ -85,22 +24,16 @@ function releaseWhenStreamCloses(
       try {
         const { done, value } = await reader.read();
         if (done) {
-          release();
           controller.close();
         } else {
           controller.enqueue(value);
         }
       } catch (error) {
-        release();
         controller.error(error);
       }
     },
     async cancel(reason) {
-      try {
-        await reader.cancel(reason);
-      } finally {
-        release();
-      }
+      await reader.cancel(reason);
     },
   });
   return new Response(body, {
@@ -259,7 +192,7 @@ You have access to a bash sandbox with the full source code of:
 - bash-tool/ - AI SDK tool for bash
 
 
-Refer to the README.md of the projects to answer questions about just-bash and bash-tool 
+Refer to the README.md of the projects to answer questions about just-bash and bash-tool
 themselves which is your main focus. Never talk about this demo implementation unless asked explicitly.
 
 Use the sandbox to explore the source code, demonstrate commands, and help users understand:
@@ -279,16 +212,10 @@ Use cat to read files. Use head, tail to read parts of large files.
 Keep responses concise. You do not have access to pnpm, npm, or node.`;
 
 export async function POST(req: Request) {
-  const authError = authenticate(req);
-  if (authError) return authError;
-  const admission = admitRequest();
-  if (admission instanceof Response) return admission;
-
   let messages: unknown[];
   try {
     messages = await readBoundedMessages(req);
   } catch (error) {
-    admission();
     const status = error instanceof RangeError ? 413 : 400;
     return Response.json({ error: "Invalid request" }, { status });
   }
@@ -317,9 +244,8 @@ export async function POST(req: Request) {
       uiMessages: messages,
       timeout: { totalMs: 30_000, stepMs: 10_000, chunkMs: 10_000 },
     });
-    return releaseWhenStreamCloses(response, admission);
+    return releaseWhenStreamCloses(response);
   } catch (error) {
-    admission();
     throw error;
   }
 }

--- a/packages/just-bash/src/fatal-execution-error.test.ts
+++ b/packages/just-bash/src/fatal-execution-error.test.ts
@@ -28,4 +28,16 @@ describe("rethrowFatalExecutionError", () => {
       rethrowFatalExecutionError(new Error("ordinary")),
     ).not.toThrow();
   });
+
+  it("does not suggest exclusions for defense context invariants", () => {
+    const violation = new SecurityViolationError("test", {
+      type: "missing_defense_context",
+      message: "test",
+      path: "DefenseInDepthBox.context",
+      timestamp: Date.now(),
+      executionId: "test",
+    });
+
+    expect(violation.message).not.toContain("excludeViolationTypes");
+  });
 });

--- a/packages/just-bash/src/security/blocked-globals.ts
+++ b/packages/just-bash/src/security/blocked-globals.ts
@@ -127,6 +127,7 @@ export function getBlockedGlobals(): BlockedGlobal[] {
         "NODE_DEBUG",
         "NODE_DEBUG_NATIVE",
         "NODE_COMPILE_CACHE",
+        "NODE_ENV",
         "WATCH_REPORT_DEPENDENCIES",
         // Dependencies
         "FORCE_COLOR", // chalk/supports-color

--- a/packages/just-bash/src/security/blocked-globals.ts
+++ b/packages/just-bash/src/security/blocked-globals.ts
@@ -59,6 +59,14 @@ export interface BlockedGlobal {
   allowedKeys?: Set<string>;
 }
 
+let blockedGlobalViolationTypes: ReadonlySet<SecurityViolationType> | undefined;
+
+export function getBlockedGlobalViolationTypes(): ReadonlySet<SecurityViolationType> {
+  if (!blockedGlobalViolationTypes) getBlockedGlobals();
+  // biome-ignore lint/style/noNonNullAssertion: getBlockedGlobals initializes the cache
+  return blockedGlobalViolationTypes!;
+}
+
 /**
  * Get the list of globals to block during script execution.
  *
@@ -587,13 +595,17 @@ export function getBlockedGlobals(): BlockedGlobal[] {
   }
 
   // Filter out globals that don't exist in the current environment
-  return globals.filter((g) => {
+  const availableGlobals = globals.filter((g) => {
     try {
       return (g.target as Record<string, unknown>)[g.prop] !== undefined;
     } catch {
       return false;
     }
   });
+  blockedGlobalViolationTypes ??= new Set(
+    availableGlobals.map(({ violationType }) => violationType),
+  );
+  return availableGlobals;
 }
 
 // Note: We don't protect Object.prototype.constructor because:

--- a/packages/just-bash/src/security/defense-in-depth-box.test.ts
+++ b/packages/just-bash/src/security/defense-in-depth-box.test.ts
@@ -870,6 +870,27 @@ describeDefense("DefenseInDepthBox", () => {
     });
 
     describe("process.env blocking", () => {
+      it("should allow NODE_ENV reads required by host runtimes", async () => {
+        const box = DefenseInDepthBox.getInstance(true);
+        const handle = box.activate();
+
+        let nodeEnv: string | undefined;
+        let blockedError: Error | undefined;
+        await handle.run(async () => {
+          nodeEnv = process.env.NODE_ENV;
+          try {
+            const _home = process.env.HOME;
+          } catch (error) {
+            blockedError = error as Error;
+          }
+        });
+
+        handle.deactivate();
+
+        expect(nodeEnv).toBe(process.env.NODE_ENV);
+        expect(blockedError).toBeInstanceOf(SecurityViolationError);
+      });
+
       it("should block process.env access", async () => {
         const box = DefenseInDepthBox.getInstance(true);
         const handle = box.activate();

--- a/packages/just-bash/src/security/defense-in-depth-box.test.ts
+++ b/packages/just-bash/src/security/defense-in-depth-box.test.ts
@@ -89,6 +89,14 @@ describeDefense("DefenseInDepthBox", () => {
       expect(instance1).toBe(instance2);
     });
 
+    it("should reject non-excludable constructor protections", () => {
+      expect(() =>
+        DefenseInDepthBox.getInstance({
+          excludeViolationTypes: ["function_constructor"],
+        }),
+      ).toThrow(/non-excludable "function_constructor" protection/);
+    });
+
     it("should reject conflicting exclusions and callbacks", () => {
       const callback = () => {};
       DefenseInDepthBox.getInstance({

--- a/packages/just-bash/src/security/defense-in-depth-box.ts
+++ b/packages/just-bash/src/security/defense-in-depth-box.ts
@@ -46,7 +46,10 @@ import type {
   SecurityViolation,
   SecurityViolationType,
 } from "./types.js";
-import { formatViolationErrorMessage } from "./violation-error-message.js";
+import {
+  assertExcludableViolationTypes,
+  formatViolationErrorMessage,
+} from "./violation-error-message.js";
 
 /**
  * Whether we're running in a browser environment.
@@ -204,6 +207,7 @@ function resolveConfig(
 ): ResolvedDefenseConfig {
   const supplied =
     typeof config === "boolean" ? { enabled: config } : (config ?? {});
+  assertExcludableViolationTypes(supplied.excludeViolationTypes);
   if (
     supplied.enabled !== undefined &&
     supplied.enabled !== true &&

--- a/packages/just-bash/src/security/defense-in-depth-box.ts
+++ b/packages/just-bash/src/security/defense-in-depth-box.ts
@@ -33,6 +33,7 @@
 import * as nodeAsyncHooks from "node:async_hooks";
 import * as nodeModule from "node:module";
 import { type BlockedGlobal, getBlockedGlobals } from "./blocked-globals.js";
+import { getSafeTimestamp } from "./safe-timestamp.js";
 import type {
   DefenseInDepthConfig,
   DefenseInDepthHandle,
@@ -812,7 +813,7 @@ export class DefenseInDepthBox {
     message: string,
   ): SecurityViolation {
     const violation: SecurityViolation = {
-      timestamp: Date.now(),
+      timestamp: getSafeTimestamp(),
       type,
       message,
       path,
@@ -1072,6 +1073,9 @@ export class DefenseInDepthBox {
   private applyPatches(): void {
     this.patchFailures = [];
     const blockedGlobals = getBlockedGlobals();
+    const excludedViolationTypes = new Set(
+      this.config.excludeViolationTypes ?? [],
+    );
 
     // IPC-related globals (process.send, process.channel, process.connected)
     // are only blocked in worker contexts (WorkerDefenseInDepth). In the main
@@ -1092,6 +1096,7 @@ export class DefenseInDepthBox {
     const permanentIntrinsicPatches: BlockedGlobal[] = [];
 
     for (const blocked of blockedGlobals) {
+      if (excludedViolationTypes.has(blocked.violationType)) continue;
       if (skipInMainThread.has(blocked.violationType)) continue;
       if (blocked.strategy === "freeze") {
         permanentIntrinsicPatches.push(blocked);
@@ -1105,7 +1110,9 @@ export class DefenseInDepthBox {
     this.protectConstructorChain();
 
     // Protect Error.prepareStackTrace (only block setting, not reading)
-    this.protectErrorPrepareStackTrace();
+    if (!excludedViolationTypes.has("error_prepare_stack_trace")) {
+      this.protectErrorPrepareStackTrace();
+    }
 
     // Wrap Promise.then callbacks created in sandbox context so deferred
     // callbacks cannot outlive handle deactivation.

--- a/packages/just-bash/src/security/defense-in-depth-box.ts
+++ b/packages/just-bash/src/security/defense-in-depth-box.ts
@@ -32,7 +32,11 @@
 
 import * as nodeAsyncHooks from "node:async_hooks";
 import * as nodeModule from "node:module";
-import { type BlockedGlobal, getBlockedGlobals } from "./blocked-globals.js";
+import {
+  type BlockedGlobal,
+  getBlockedGlobals,
+  getBlockedGlobalViolationTypes,
+} from "./blocked-globals.js";
 import { getSafeTimestamp } from "./safe-timestamp.js";
 import type {
   DefenseInDepthConfig,
@@ -42,6 +46,7 @@ import type {
   SecurityViolation,
   SecurityViolationType,
 } from "./types.js";
+import { formatViolationErrorMessage } from "./violation-error-message.js";
 
 /**
  * Whether we're running in a browser environment.
@@ -111,13 +116,6 @@ if (!IS_BROWSER) {
 }
 
 /**
- * Suffix added to all security violation messages.
- */
-const DEFENSE_IN_DEPTH_NOTICE =
-  "\n\nThis is a defense-in-depth measure and indicates a bug in just-bash. " +
-  "Please report this at security@vercel.com";
-
-/**
  * Error thrown when a security violation is detected and blocking is enabled.
  */
 export class SecurityViolationError extends Error {
@@ -125,7 +123,14 @@ export class SecurityViolationError extends Error {
     message: string,
     public readonly violation: SecurityViolation,
   ) {
-    super(message + DEFENSE_IN_DEPTH_NOTICE);
+    super(
+      formatViolationErrorMessage(
+        message,
+        violation.type,
+        violation.type === "error_prepare_stack_trace" ||
+          getBlockedGlobalViolationTypes().has(violation.type),
+      ),
+    );
     this.name = "SecurityViolationError";
   }
 }

--- a/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
+++ b/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
@@ -875,6 +875,9 @@ describeDefense("Defense-in-Depth Hardening", () => {
 
         expect(error).toBeInstanceOf(SecurityViolationError);
         expect(error?.message).toContain("performance");
+        expect(error?.message).toContain(
+          'add "performance_timing" to defenseInDepth.excludeViolationTypes',
+        );
       } finally {
         handle.deactivate();
         Date.now = originalDateNow;

--- a/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
+++ b/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
@@ -829,6 +829,58 @@ describeDefense("Defense-in-Depth Hardening", () => {
   // Category D: performance.now() blocking
   // =====================================================================
   describe("Category D: performance.now() blocking", () => {
+    it("honors main-thread violation exclusions", async () => {
+      const box = DefenseInDepthBox.getInstance({
+        excludeViolationTypes: [
+          "error_prepare_stack_trace",
+          "performance_timing",
+        ],
+      });
+      const handle = box.activate();
+      const originalPrepareStackTrace = Error.prepareStackTrace;
+
+      try {
+        let value: number | undefined;
+        await handle.run(async () => {
+          value = performance.now();
+          Error.prepareStackTrace = (_error, stackTraces) => stackTraces;
+        });
+
+        expect(typeof value).toBe("number");
+      } finally {
+        Error.prepareStackTrace = originalPrepareStackTrace;
+        handle.deactivate();
+      }
+    });
+
+    it("does not recurse through a host-wrapped Date.now()", async () => {
+      const originalDateNow = Date.now;
+      Date.now = () => {
+        performance.now();
+        return originalDateNow();
+      };
+
+      const box = DefenseInDepthBox.getInstance(true);
+      const handle = box.activate();
+
+      try {
+        let error: Error | undefined;
+        await handle.run(async () => {
+          try {
+            performance.now();
+          } catch (caught) {
+            error = caught as Error;
+          }
+        });
+
+        expect(error).toBeInstanceOf(SecurityViolationError);
+        expect(error?.message).toContain("performance");
+      } finally {
+        handle.deactivate();
+        Date.now = originalDateNow;
+      }
+    });
+
     it("should block performance.now() inside sandbox", async () => {
       const box = DefenseInDepthBox.getInstance(true);
       const handle = box.activate();

--- a/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
+++ b/packages/just-bash/src/security/defense-in-depth-hardening.test.ts
@@ -487,6 +487,7 @@ describeDefense("Defense-in-Depth Hardening", () => {
 
       handle.deactivate();
       expect(error).toBeInstanceOf(SecurityViolationError);
+      expect(error?.message).not.toContain("excludeViolationTypes");
     });
 
     it("should block Set.constructor.constructor", async () => {

--- a/packages/just-bash/src/security/safe-timestamp.ts
+++ b/packages/just-bash/src/security/safe-timestamp.ts
@@ -1,0 +1,6 @@
+const performanceTimeOrigin = performance.timeOrigin;
+const performanceNow = performance.now.bind(performance);
+
+export function getSafeTimestamp(): number {
+  return Math.floor(performanceTimeOrigin + performanceNow());
+}

--- a/packages/just-bash/src/security/types.ts
+++ b/packages/just-bash/src/security/types.ts
@@ -46,6 +46,7 @@ export interface DefenseInDepthConfig {
    * Violation types to exclude from blocking.
    * Use this when certain globals are required for legitimate purposes
    * (e.g., WebAssembly for sql.js in sqlite3 worker).
+   * Constructor-execution protections are non-excludable.
    */
   excludeViolationTypes?: SecurityViolationType[];
 }

--- a/packages/just-bash/src/security/violation-error-message.ts
+++ b/packages/just-bash/src/security/violation-error-message.ts
@@ -1,5 +1,26 @@
 import type { SecurityViolationType } from "./types.js";
 
+export const NON_EXCLUDABLE_VIOLATION_TYPES: ReadonlySet<SecurityViolationType> =
+  new Set([
+    "function_constructor",
+    "async_function_constructor",
+    "generator_function_constructor",
+    "async_generator_function_constructor",
+  ]);
+
+export function assertExcludableViolationTypes(
+  violationTypes: readonly SecurityViolationType[] | undefined,
+): void {
+  const nonExcludable = violationTypes?.find((type) =>
+    NON_EXCLUDABLE_VIOLATION_TYPES.has(type),
+  );
+  if (nonExcludable) {
+    throw new RangeError(
+      `defenseInDepth.excludeViolationTypes cannot disable the non-excludable "${nonExcludable}" protection`,
+    );
+  }
+}
+
 const DEFENSE_IN_DEPTH_NOTICE =
   "\n\nThis is a defense-in-depth measure and indicates a bug in just-bash. " +
   "Please report this at security@vercel.com";
@@ -9,8 +30,9 @@ export function formatViolationErrorMessage(
   violationType: SecurityViolationType,
   canExclude: boolean,
 ): string {
-  const exclusionHint = canExclude
-    ? `\n\nIf this access is required by trusted host-runtime code, add "${violationType}" to defenseInDepth.excludeViolationTypes.`
-    : "";
+  const exclusionHint =
+    canExclude && !NON_EXCLUDABLE_VIOLATION_TYPES.has(violationType)
+      ? `\n\nIf this access is required by trusted host-runtime code, add "${violationType}" to defenseInDepth.excludeViolationTypes.`
+      : "";
   return message + DEFENSE_IN_DEPTH_NOTICE + exclusionHint;
 }

--- a/packages/just-bash/src/security/violation-error-message.ts
+++ b/packages/just-bash/src/security/violation-error-message.ts
@@ -1,0 +1,16 @@
+import type { SecurityViolationType } from "./types.js";
+
+const DEFENSE_IN_DEPTH_NOTICE =
+  "\n\nThis is a defense-in-depth measure and indicates a bug in just-bash. " +
+  "Please report this at security@vercel.com";
+
+export function formatViolationErrorMessage(
+  message: string,
+  violationType: SecurityViolationType,
+  canExclude: boolean,
+): string {
+  const exclusionHint = canExclude
+    ? `\n\nIf this access is required by trusted host-runtime code, add "${violationType}" to defenseInDepth.excludeViolationTypes.`
+    : "";
+  return message + DEFENSE_IN_DEPTH_NOTICE + exclusionHint;
+}

--- a/packages/just-bash/src/security/worker-defense-in-depth.test.ts
+++ b/packages/just-bash/src/security/worker-defense-in-depth.test.ts
@@ -88,6 +88,9 @@ describe("WorkerDefenseInDepth", () => {
 
         defense.deactivate();
         expect(error).toBeInstanceOf(WorkerSecurityViolationError);
+        expect(error?.message).toContain(
+          'add "function_constructor" to defenseInDepth.excludeViolationTypes',
+        );
       });
 
       it("should block Function() call without new", () => {

--- a/packages/just-bash/src/security/worker-defense-in-depth.test.ts
+++ b/packages/just-bash/src/security/worker-defense-in-depth.test.ts
@@ -88,9 +88,7 @@ describe("WorkerDefenseInDepth", () => {
 
         defense.deactivate();
         expect(error).toBeInstanceOf(WorkerSecurityViolationError);
-        expect(error?.message).toContain(
-          'add "function_constructor" to defenseInDepth.excludeViolationTypes',
-        );
+        expect(error?.message).not.toContain("excludeViolationTypes");
       });
 
       it("should block Function() call without new", () => {
@@ -913,6 +911,15 @@ describe("WorkerDefenseInDepth", () => {
   });
 
   describe("excludeViolationTypes", () => {
+    it("should reject non-excludable constructor protections", () => {
+      expect(
+        () =>
+          new WorkerDefenseInDepth({
+            excludeViolationTypes: ["function_constructor"],
+          }),
+      ).toThrow(/non-excludable "function_constructor" protection/);
+    });
+
     it("should allow excluded violation types to work normally", () => {
       defense = new WorkerDefenseInDepth({
         excludeViolationTypes: ["proxy"],
@@ -1036,25 +1043,6 @@ describe("WorkerDefenseInDepth", () => {
       expect(violations.some((v) => v.type === "function_constructor")).toBe(
         true,
       );
-    });
-
-    it("should exclude function_constructor when specified", () => {
-      defense = new WorkerDefenseInDepth({
-        excludeViolationTypes: ["function_constructor"],
-      });
-
-      let result: unknown;
-      let error: Error | undefined;
-      try {
-        const fn = new Function("return 42");
-        result = fn();
-      } catch (e) {
-        error = e as Error;
-      }
-
-      defense.deactivate();
-      expect(error).toBeUndefined();
-      expect(result).toBe(42);
     });
 
     it("should exclude WebAssembly when specified", () => {

--- a/packages/just-bash/src/security/worker-defense-in-depth.ts
+++ b/packages/just-bash/src/security/worker-defense-in-depth.ts
@@ -54,7 +54,10 @@ import type {
   SecurityViolation,
   SecurityViolationType,
 } from "./types.js";
-import { formatViolationErrorMessage } from "./violation-error-message.js";
+import {
+  assertExcludableViolationTypes,
+  formatViolationErrorMessage,
+} from "./violation-error-message.js";
 
 const WORKER_SPECIAL_EXCLUDABLE_VIOLATION_TYPES =
   new Set<SecurityViolationType>([
@@ -191,6 +194,8 @@ export class WorkerDefenseInDepth {
    * @param config - Configuration for the defense layer
    */
   constructor(config: DefenseInDepthConfig) {
+    assertExcludableViolationTypes(config.excludeViolationTypes);
+
     // Capture original Proxy BEFORE any patching occurs
     // This ensures we can create blocking proxies even after patching
     this.originalProxy = Proxy;

--- a/packages/just-bash/src/security/worker-defense-in-depth.ts
+++ b/packages/just-bash/src/security/worker-defense-in-depth.ts
@@ -44,6 +44,7 @@
  */
 
 import { type BlockedGlobal, getBlockedGlobals } from "./blocked-globals.js";
+import { getSafeTimestamp } from "./safe-timestamp.js";
 import type {
   DefenseInDepthConfig,
   SecurityViolation,
@@ -275,7 +276,7 @@ export class WorkerDefenseInDepth {
     message: string,
   ): SecurityViolation {
     const violation: SecurityViolation = {
-      timestamp: Date.now(),
+      timestamp: getSafeTimestamp(),
       type,
       message,
       path,

--- a/packages/just-bash/src/security/worker-defense-in-depth.ts
+++ b/packages/just-bash/src/security/worker-defense-in-depth.ts
@@ -43,20 +43,28 @@
  * is not needed (and would require require('node:module') which is blocked).
  */
 
-import { type BlockedGlobal, getBlockedGlobals } from "./blocked-globals.js";
+import {
+  type BlockedGlobal,
+  getBlockedGlobals,
+  getBlockedGlobalViolationTypes,
+} from "./blocked-globals.js";
 import { getSafeTimestamp } from "./safe-timestamp.js";
 import type {
   DefenseInDepthConfig,
   SecurityViolation,
   SecurityViolationType,
 } from "./types.js";
+import { formatViolationErrorMessage } from "./violation-error-message.js";
 
-/**
- * Suffix added to all security violation messages.
- */
-const DEFENSE_IN_DEPTH_NOTICE =
-  "\n\nThis is a defense-in-depth measure and indicates a bug in just-bash. " +
-  "Please report this at security@vercel.com";
+const WORKER_SPECIAL_EXCLUDABLE_VIOLATION_TYPES =
+  new Set<SecurityViolationType>([
+    "error_prepare_stack_trace" as const,
+    "module_load" as const,
+    "module_resolve_filename" as const,
+    "process_main_module" as const,
+    "process_exec_path" as const,
+    "process_connected" as const,
+  ]);
 
 /**
  * Error thrown when a security violation is detected.
@@ -66,7 +74,14 @@ export class WorkerSecurityViolationError extends Error {
     message: string,
     public readonly violation: SecurityViolation,
   ) {
-    super(message + DEFENSE_IN_DEPTH_NOTICE);
+    super(
+      formatViolationErrorMessage(
+        message,
+        violation.type,
+        WORKER_SPECIAL_EXCLUDABLE_VIOLATION_TYPES.has(violation.type) ||
+          getBlockedGlobalViolationTypes().has(violation.type),
+      ),
+    );
     this.name = "WorkerSecurityViolationError";
   }
 }


### PR DESCRIPTION
## Summary

This PR restores the website agent demo while fixing the underlying `just-bash` defense-in-depth incompatibility that caused trivial commands such as `echo hi` to fail with `bash: Maximum call stack size exceeded`.

- removes the website route's ineffective bearer-token and in-memory admission controls
- keeps the existing bounded request parsing and message validation
- restores a writable copy-on-write `OverlayFs` so `bash-tool` can use shell redirects such as `2>/dev/null` without writing through to disk
- prevents recursive violation reporting when the host runtime wraps `Date.now()`
- makes main-thread `excludeViolationTypes` work consistently, including `Error.prepareStackTrace`
- allows the non-secret `NODE_ENV` key required by host/runtime dependencies while continuing to block other environment variables
- keeps defense-in-depth enabled for the website agent with only the host-runtime exclusions Next.js requires

## Why

The previous website lockdown did not provide a reliable production security boundary:

- a token embedded in or distributed for a public demo does not meaningfully protect the endpoint
- process-local concurrency and rate-limit state is not reliable across serverless instances
- making the overlay read-only broke normal `bash-tool` capability discovery because it redirects probe output to `/dev/null`

After undoing that route-level lockdown, commands still failed. The stack overflow came from this cycle:

1. a blocked host access records a defense-in-depth violation
2. violation reporting calls `Date.now()`
3. Next.js's wrapped `Date.now()` reads `performance.now()`
4. `performance.now()` is blocked in the inherited untrusted `AsyncLocalStorage` context
5. recording that new violation calls `Date.now()` again

Violation timestamps now use pre-bound performance functions, breaking that recursion without disabling defense-in-depth.

## Security posture

Defense-in-depth remains enabled. The route excludes only three violation types that were independently reproduced as accesses from Next.js async hooks sharing the sandbox context:

- `performance_timing`
- `weak_ref`
- `error_prepare_stack_trace`

Next.js registers process-wide async hooks. When just-bash creates promises or timers inside its untrusted `AsyncLocalStorage` context, those hooks run synchronously under the same context, so their host-runtime accesses are indistinguishable from guest accesses at the global proxy boundary. Without a separate realm or Next.js cooperation, these three compatibility exclusions are required.

All other defense-in-depth checks remain active. Constructor-execution protections (`function_constructor`, `async_function_constructor`, `generator_function_constructor`, and `async_generator_function_constructor`) are explicitly non-excludable, and configuration fails fast if they are supplied to `excludeViolationTypes`. `process_exit` was tested and is not excluded.

The overlay is writable only in its copy-on-write layer; writes do not propagate to the source directory on disk.

## Validation

- [x] exact Next.js route repro returns `{"stdout":"hi\n","stderr":"","exitCode":0}` for `echo hi`
- [x] each remaining Next.js compatibility exclusion reproduced independently
- [x] 224 focused defense-in-depth tests pass
- [x] `just-bash` package build passes
- [x] typecheck passes
- [x] lint passes
- [x] knip passes
- [x] route-only ESLint passes
- [x] Biome check passes
- [x] `git diff --check` passes

