### PR TITLE
fix(curl): don't build the stdout string when writing the body to a file

### DIFF
--- a/.changeset/curly-donkeys-brake.md
+++ b/.changeset/curly-donkeys-brake.md
@@ -1,0 +1,12 @@
+---
+"just-bash": patch
+---
+
+curl: don't build the stdout string when the body is written to a file
+
+`curl -o FILE URL` (and `-O`) stringified the entire response body for stdout
+and then immediately discarded it, holding a full UTF-16 copy of the payload in
+memory alongside the bytes being written. Large downloads could exhaust memory
+(a browser-hosted embedder OOM'd its renderer on a 250 MB download). The stdout
+string is now skipped entirely on that path; `-v`, `--write-out`, `-I/--head`
+and all other behaviour are unchanged.

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -364,10 +364,17 @@ export const curlCommand: RuntimeCommand = {
         };
       }
 
-      let output = buildOutput(options, result, url);
+      // When the body goes to a file and we're not verbose, the block below
+      // overwrites `output` unconditionally (with "" or the -D - header block),
+      // so building it first would stringify the whole response body just to
+      // throw the string away — a full UTF-16 copy of the payload on top of the
+      // bytes we write out. Skip buildOutput entirely on that path.
+      const writesToFile = Boolean(options.outputFile || options.useRemoteName);
+      const skipStdoutBody = writesToFile && !options.verbose;
+      let output = skipStdoutBody ? "" : buildOutput(options, result, url);
 
       // Write body to file when -o/-O is set
-      if (options.outputFile || options.useRemoteName) {
+      if (writesToFile) {
         const filename = options.outputFile || extractFilename(url);
         const filePath = ctx.fs.resolvePath(ctx.cwd, filename);
         await ctx.fs.writeFile(filePath, options.headOnly ? "" : result.body);

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -320,18 +320,19 @@ export const curlCommand: RuntimeCommand = {
         return { stdout: "", stderr, exitCode: 22 };
       }
 
-      let output = buildOutput(options, result, url);
+      // When the body goes to a file and we're not verbose, stdout stays empty,
+      // so building it would stringify the whole response body just to throw the
+      // string away — a full UTF-16 copy of the payload on top of the bytes we
+      // write out. Skip buildOutput entirely on that path.
+      const writesToFile = Boolean(options.outputFile || options.useRemoteName);
+      const skipStdoutBody = writesToFile && !options.verbose;
+      let output = skipStdoutBody ? "" : buildOutput(options, result, url);
 
       // Write to file
-      if (options.outputFile || options.useRemoteName) {
+      if (writesToFile) {
         const filename = options.outputFile || extractFilename(url);
         const filePath = ctx.fs.resolvePath(ctx.cwd, filename);
         await ctx.fs.writeFile(filePath, options.headOnly ? "" : result.body);
-
-        // When writing to file, don't output body to stdout unless verbose
-        if (!options.verbose) {
-          output = "";
-        }
 
         // Add write-out after file write
         if (options.writeOut) {

--- a/packages/just-bash/src/commands/curl/tests/output-file-memory.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/output-file-memory.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Regression tests for curl -o/-O: the response body must not be stringified
+ * for stdout when it is only going to be written to a file.
+ *
+ * Building the stdout string materialises the whole payload as a JS string
+ * (UTF-16, so up to ~2x the byte size) on top of the Uint8Array that gets
+ * written to the filesystem. On the -o path without -v that string is
+ * discarded immediately, so a large download would double-count memory for
+ * nothing — enough to OOM a browser renderer on a few hundred MB.
+ */
+
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { Bash } from "../../../Bash.js";
+import * as encoding from "../../../fs/encoding.js";
+
+const originalFetch = global.fetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BODY_SIZE = 1024 * 1024;
+
+function stubFetchWithLargeBody(): Uint8Array {
+  const body = new Uint8Array(BODY_SIZE).fill(0x61);
+  global.fetch = vi.fn(async () => {
+    // Fresh copy per request so the assertion below identifies the body by
+    // size, not by reference to a shared buffer.
+    return new Response(new Uint8Array(body), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as typeof fetch;
+  return body;
+}
+
+/** Counts conversions of a buffer the size of the response body to a string. */
+function spyOnBodyStringification(): { count: () => number } {
+  const spy = vi.spyOn(encoding, "fromBuffer");
+  return {
+    count: () =>
+      spy.mock.calls.filter(
+        (call) =>
+          call[0] instanceof Uint8Array && call[0].byteLength === BODY_SIZE,
+      ).length,
+  };
+}
+
+function makeBash(): Bash {
+  return new Bash({
+    network: { allowedUrlPrefixes: ["https://api.example.com"] },
+  });
+}
+
+describe("curl -o does not materialise the body for stdout", () => {
+  it("writes the file without stringifying the body", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec(
+      "curl -s -o /big.bin https://api.example.com/big",
+    );
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+
+  it("does not stringify the body for -O either", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec("curl -s -O https://api.example.com/big.bin");
+
+    expect(result.stdout).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+
+  it("still writes the body to stdout when no output file is given", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec("curl -s https://api.example.com/big");
+
+    expect(result.stdout.length).toBe(BODY_SIZE);
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(1);
+  });
+
+  it("still builds verbose output for -o -v", async () => {
+    stubFetchWithLargeBody();
+
+    const env = makeBash();
+    const result = await env.exec(
+      "curl -s -v -o /big.bin https://api.example.com/big",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("> GET https://api.example.com/big");
+    expect(result.stdout).toContain("< HTTP/1.1 200");
+    // Verbose keeps the pre-existing behaviour of also echoing the body.
+    expect(result.stdout.length).toBeGreaterThan(BODY_SIZE);
+  });
+
+  it("still emits the -D - header block on the -o path without stringifying the body", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec(
+      "curl -s -o /big.bin -D - https://api.example.com/big",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("HTTP/1.1 200");
+    expect(result.stdout).toContain("content-type: application/octet-stream");
+    expect(result.stdout.length).toBeLessThan(BODY_SIZE);
+    expect(bodyStrings.count()).toBe(0);
+  });
+
+  it("still applies --write-out on the -o path", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec(
+      'curl -s -o /big.bin -w "%{http_code} %{size_download}" https://api.example.com/big',
+    );
+
+    expect(result.stdout).toBe(`200 ${BODY_SIZE}`);
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/curl/tests/output-file-memory.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/output-file-memory.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Regression tests for curl -o/-O: the response body must not be stringified
+ * for stdout when it is only going to be written to a file.
+ *
+ * Building the stdout string materialises the whole payload as a JS string
+ * (UTF-16, so up to ~2x the byte size) on top of the Uint8Array that gets
+ * written to the filesystem. On the -o path without -v that string is
+ * discarded immediately, so a large download would double-count memory for
+ * nothing — enough to OOM a browser renderer on a few hundred MB.
+ */
+
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { Bash } from "../../../Bash.js";
+import * as encoding from "../../../fs/encoding.js";
+
+const originalFetch = global.fetch;
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const BODY_SIZE = 1024 * 1024;
+
+function stubFetchWithLargeBody(): Uint8Array {
+  const body = new Uint8Array(BODY_SIZE).fill(0x61);
+  global.fetch = vi.fn(async () => {
+    // Fresh copy per request so the assertion below identifies the body by
+    // size, not by reference to a shared buffer.
+    return new Response(new Uint8Array(body), {
+      status: 200,
+      headers: { "content-type": "application/octet-stream" },
+    });
+  }) as typeof fetch;
+  return body;
+}
+
+/** Counts conversions of a buffer the size of the response body to a string. */
+function spyOnBodyStringification(): { count: () => number } {
+  const spy = vi.spyOn(encoding, "fromBuffer");
+  return {
+    count: () =>
+      spy.mock.calls.filter(
+        (call) =>
+          call[0] instanceof Uint8Array && call[0].byteLength === BODY_SIZE,
+      ).length,
+  };
+}
+
+function makeBash(): Bash {
+  return new Bash({
+    network: { allowedUrlPrefixes: ["https://api.example.com"] },
+  });
+}
+
+describe("curl -o does not materialise the body for stdout", () => {
+  it("writes the file without stringifying the body", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec(
+      "curl -s -o /big.bin https://api.example.com/big",
+    );
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+
+  it("does not stringify the body for -O either", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec("curl -s -O https://api.example.com/big.bin");
+
+    expect(result.stdout).toBe("");
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+
+  it("still writes the body to stdout when no output file is given", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec("curl -s https://api.example.com/big");
+
+    expect(result.stdout.length).toBe(BODY_SIZE);
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(1);
+  });
+
+  it("still builds verbose output for -o -v", async () => {
+    stubFetchWithLargeBody();
+
+    const env = makeBash();
+    const result = await env.exec(
+      "curl -s -v -o /big.bin https://api.example.com/big",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("> GET https://api.example.com/big");
+    expect(result.stdout).toContain("< HTTP/1.1 200");
+    // Verbose keeps the pre-existing behaviour of also echoing the body.
+    expect(result.stdout.length).toBeGreaterThan(BODY_SIZE);
+  });
+
+  it("still applies --write-out on the -o path", async () => {
+    stubFetchWithLargeBody();
+    const bodyStrings = spyOnBodyStringification();
+
+    const env = makeBash();
+    const result = await env.exec(
+      'curl -s -o /big.bin -w "%{http_code} %{size_download}" https://api.example.com/big',
+    );
+
+    expect(result.stdout).toBe(`200 ${BODY_SIZE}`);
+    expect(result.exitCode).toBe(0);
+    expect(bodyStrings.count()).toBe(0);
+  });
+});


### PR DESCRIPTION
## The bug

`packages/just-bash/src/commands/curl/curl.ts` builds the stdout string *before* deciding whether stdout is even used:

```ts
let output = buildOutput(options, result, url);   // stringifies the ENTIRE response body

if (options.outputFile || options.useRemoteName) {
  // ... writeFile(filePath, result.body)
  // ... and then `output` is unconditionally overwritten, so the giant string is thrown away
}
```

`buildOutput()` appends `fetchBodyToStdoutString(result.body)`, i.e. `fromBuffer(body, "binary")` — one JS character per byte of the response. So `curl -o FILE URL` materialises a full string copy of the payload and discards it a few lines later.

## Why it matters

That transient string is the whole payload as a JS string — UTF-16, so potentially ~2x the byte size — held **on top of** the `Uint8Array` that is being written to the filesystem. It is short-lived, but it has to be allocated in full before it can be collected.

This is not theoretical. SLICC, a browser-hosted agent runtime that embeds just-bash, reproducibly crashed its renderer with `Inspector.targetCrashed` on:

```
curl -s -o /tmp/big.bin "https://speed.cloudflare.com/__down?bytes=250000000"
```

~60 MB downloads were fine; 250 MB killed the renderer. Downstream is currently carrying a `patch-package` patch that rewrites this line across five minified `dist` bundles — clearly unsustainable, hence this PR. Once this ships they can drop the patch.

## The fix

Skip `buildOutput()` entirely when the body is going to a file and we're not verbose:

```ts
const writesToFile = Boolean(options.outputFile || options.useRemoteName);
const skipStdoutBody = writesToFile && !options.verbose;
let output = skipStdoutBody ? "" : buildOutput(options, result, url);
```

Behaviour is preserved exactly. On the `writesToFile && !verbose` path the existing code already overwrites `output` unconditionally — with `""`, or with the `-D -` header block — so its previous value was never observable:

- **`-o`/`-O` without `-v`** — stdout was already being discarded, so this is a pure allocation win. (Note this path also already drops `-i`/`--include` headers; that pre-existing behaviour is deliberately unchanged here.)
- **`-o`/`-O` with `-v`** — verbose output is still built as before, body included.
- **`-D -` with `-o`** — still emits the header block; the `-D` composition logic from #389 is untouched.
- **`--write-out`** — still applied after the file write, as before.
- **`-I`/`--head`, `--fail`, redirects, exit codes** — untouched.

Rebased onto current `main`, on top of #389 (`-D/--dump-header`), which rewrote this same block.

## Other paths considered

- **`-I`/`--head`**: not affected. `buildOutput()` already branches on `options.headOnly` and never stringifies the body, it only formats headers.
- **No `wget`** in this package, so there's no sibling downloader with the same shape.
- The other `ctx.fetch` consumers (`python3`, `js-exec`) only hand the fetch function to a worker for HTTPFS; they don't build-then-discard a body string. Nothing to fix there.

So `curl -o` is the only instance of this pattern I found.

## Tests

New `packages/just-bash/src/commands/curl/tests/output-file-memory.test.ts`. A pure memory regression is hard to assert deterministically, so the test spies on `fromBuffer` and asserts the response-sized buffer is **never** stringified on the `-o` path:

- `-o` and `-O` without `-v`: stdout is `""` and the body is never converted to a string.
- no output file: body *is* converted exactly once and reaches stdout (guards against over-eager skipping).
- `-o -v`: verbose markers and the body are still present.
- `-o -D -`: the header block is still emitted, and the body is still never stringified.
- `-o -w`: `--write-out` output is still produced, still without stringifying the body.

Four of the six fail against current `main`; all six pass with the fix.

## Verification

- `pnpm typecheck` — clean
- `pnpm lint` (incl. `lint:banned`, workflow security check) — clean
- `pnpm knip` — clean
- `pnpm test:run` — 15404 passed. 7 failures, all in python/WASM sandbox suites (`security/sandbox/*`, `security/attacks/*`, the bundled-binary CPython lazy-load test); these reproduce identically on a clean checkout of `main` on this machine and are unrelated to this change.
- `src/commands/curl/` specifically: 240 passed / 20 files.

A patch changeset is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
