### PR TITLE
Fix jq to_entries on arrays and tonumber on empty strings

### DIFF
--- a/.changeset/jq-to-entries-array-tonumber-empty.md
+++ b/.changeset/jq-to-entries-array-tonumber-empty.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Match real jq behavior for `to_entries` on arrays (numeric-key entries instead of null) and `tonumber` on empty or whitespace-only strings (error instead of 0).

--- a/packages/just-bash/src/commands/jq/jq.functions.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.functions.test.ts
@@ -217,7 +217,7 @@ describe("jq builtin functions", () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it("should iterate array entries", async () => {
+    it("should support to_entries[] iteration over an array", async () => {
       const env = new Bash();
       const result = await env.exec(
         "echo '[10,20]' | jq -c '[to_entries[] | .key]'",

--- a/packages/just-bash/src/commands/jq/jq.functions.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.functions.test.ts
@@ -206,6 +206,25 @@ describe("jq builtin functions", () => {
       );
     });
 
+    it("should convert an array to entries with numeric keys", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "echo '[\"a\",\"b\"]' | jq -c 'to_entries'",
+      );
+      expect(result.stdout).toBe(
+        '[{"key":0,"value":"a"},{"key":1,"value":"b"}]\n',
+      );
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should iterate array entries", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        "echo '[10,20]' | jq -c '[to_entries[] | .key]'",
+      );
+      expect(result.stdout).toBe("[0,1]\n");
+    });
+
     it("should convert from entries", async () => {
       const env = new Bash();
       const result = await env.exec(

--- a/packages/just-bash/src/commands/jq/jq.operators.test.ts
+++ b/packages/just-bash/src/commands/jq/jq.operators.test.ts
@@ -174,5 +174,19 @@ describe("jq operators", () => {
       const result = await env.exec("echo '\"42\"' | jq 'tonumber'");
       expect(result.stdout).toBe("42\n");
     });
+
+    it("should reject tonumber on an empty string", async () => {
+      const env = new Bash();
+      const result = await env.exec("echo '\"\"' | jq 'tonumber'");
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("cannot be parsed as a number");
+    });
+
+    it("should reject tonumber on a whitespace-only string", async () => {
+      const env = new Bash();
+      const result = await env.exec("echo '\" \"' | jq 'tonumber'");
+      expect(result.exitCode).not.toBe(0);
+      expect(result.stderr).toContain("cannot be parsed as a number");
+    });
   });
 });

--- a/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
+++ b/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
@@ -23,6 +23,13 @@ function maxResultElements(ctx: EvalContext): number {
   return ctx.limits.maxArrayElements;
 }
 
+function makeEntry(key: string | number, value: unknown): Record<string, unknown> {
+  const entry: Record<string, unknown> = Object.create(null);
+  safeSet(entry, "key", key);
+  safeSet(entry, "value", value);
+  return entry;
+}
+
 function assertResultPush(ctx: EvalContext, length: number): void {
   const limit = maxResultElements(ctx);
   if (length >= limit) {
@@ -126,14 +133,7 @@ export function evalObjectBuiltin(
             "array_elements",
           );
         }
-        return [
-          value.map((item, index) => {
-            const entry: Record<string, unknown> = Object.create(null);
-            safeSet(entry, "key", index);
-            safeSet(entry, "value", item);
-            return entry;
-          }),
-        ];
+        return [value.map((item, index) => makeEntry(index, item))];
       }
       const toEntriesObj = asQueryRecord(value);
       if (toEntriesObj) {
@@ -144,14 +144,7 @@ export function evalObjectBuiltin(
             "array_elements",
           );
         }
-        return [
-          keys.map((key) => {
-            const entry: Record<string, unknown> = Object.create(null);
-            safeSet(entry, "key", key);
-            safeSet(entry, "value", toEntriesObj[key]);
-            return entry;
-          }),
-        ];
+        return [keys.map((key) => makeEntry(key, toEntriesObj[key]))];
       }
       return [null];
     }
@@ -192,9 +185,7 @@ export function evalObjectBuiltin(
         }
         const mapped: QueryValue[] = [];
         for (const key of keys) {
-          const entry: Record<string, unknown> = Object.create(null);
-          safeSet(entry, "key", key);
-          safeSet(entry, "value", withEntriesObj[key]);
+          const entry = makeEntry(key, withEntriesObj[key]);
           const values = evaluate(entry, args[0], ctx);
           if (mapped.length > maxResultElements(ctx) - values.length) {
             throw new ExecutionLimitError(

--- a/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
+++ b/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
@@ -23,7 +23,10 @@ function maxResultElements(ctx: EvalContext): number {
   return ctx.limits.maxArrayElements;
 }
 
-function makeEntry(key: string | number, value: unknown): Record<string, unknown> {
+function makeEntry(
+  key: string | number,
+  value: unknown,
+): Record<string, unknown> {
   const entry: Record<string, unknown> = Object.create(null);
   safeSet(entry, "key", key);
   safeSet(entry, "value", value);

--- a/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
+++ b/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
@@ -127,8 +127,6 @@ export function evalObjectBuiltin(
     }
 
     case "to_entries": {
-      // jq: to_entries is keys_unsorted-based, so arrays yield numeric keys
-      // (matching the array support in "keys" above).
       if (Array.isArray(value)) {
         if (value.length > maxResultElements(ctx)) {
           throw new ExecutionLimitError(
@@ -300,7 +298,6 @@ export function evalObjectBuiltin(
     case "tonumber":
       if (typeof value === "number") return [value];
       if (typeof value === "string") {
-        // Number("") and Number("  ") are 0, but jq rejects them.
         const n = value.trim() === "" ? Number.NaN : Number(value);
         if (Number.isNaN(n)) {
           throw new Error(

--- a/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
+++ b/packages/just-bash/src/commands/query-engine/builtins/object-builtins.ts
@@ -117,6 +117,24 @@ export function evalObjectBuiltin(
     }
 
     case "to_entries": {
+      // jq: to_entries is keys_unsorted-based, so arrays yield numeric keys
+      // (matching the array support in "keys" above).
+      if (Array.isArray(value)) {
+        if (value.length > maxResultElements(ctx)) {
+          throw new ExecutionLimitError(
+            `query result element limit exceeded (${maxResultElements(ctx)})`,
+            "array_elements",
+          );
+        }
+        return [
+          value.map((item, index) => {
+            const entry: Record<string, unknown> = Object.create(null);
+            safeSet(entry, "key", index);
+            safeSet(entry, "value", item);
+            return entry;
+          }),
+        ];
+      }
       const toEntriesObj = asQueryRecord(value);
       if (toEntriesObj) {
         const keys = Object.keys(toEntriesObj);
@@ -288,7 +306,8 @@ export function evalObjectBuiltin(
     case "tonumber":
       if (typeof value === "number") return [value];
       if (typeof value === "string") {
-        const n = Number(value);
+        // Number("") and Number("  ") are 0, but jq rejects them.
+        const n = value.trim() === "" ? Number.NaN : Number(value);
         if (Number.isNaN(n)) {
           throw new Error(
             `${JSON.stringify(value)} cannot be parsed as a number`,


### PR DESCRIPTION
## Summary

Two silent divergences from real jq in the query engine, both discovered while tracing an AI agent doing CSV analysis in the sandbox (same "silently no-op" family as #266):

**1. `to_entries` on an array returns `null` → `to_entries[]` silently emits nothing (exit 0)**

```bash
$ echo '["A","B"]' | jq -r 'to_entries[] | "\(.key): \(.value)"'
# just-bash: empty output, exit 0
# real jq:   0: A
#            1: B
```

Real jq's `to_entries` is `keys_unsorted`-based, so arrays yield numeric-key entries — and this engine's own `keys`/`keys_unsorted` builtins already support arrays exactly that way (`object-builtins.ts`), so this also removes an internal inconsistency. The array path reuses the existing `maxArrayElements` limit guard.

**2. `tonumber` on `""` / whitespace-only strings returns `0`**

```bash
$ echo '["2","","4"]' | jq '[.[] | tonumber] | add'
# just-bash: 6
# real jq:   jq: error: "" cannot be parsed as a number
```

`Number("")` is `0` in JS, so empty cells silently coerce to zero. For agents aggregating tabular data this masks data-quality problems — a sum over a column with missing values just looks like a valid total. Real jq rejects it; now the existing `cannot be parsed as a number` error fires.

## Tests

- `jq.functions.test.ts`: array → numeric-key entries; `to_entries[]` iteration over an array
- `jq.operators.test.ts`: `tonumber` rejects `""` and `" "` with non-zero exit
- Full `src/commands/jq`, `src/commands/yq`, `src/commands/query-engine` suites pass (34 files, 656 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)