### PR TITLE
feat(curl): implement -D/--dump-header

### DIFF
--- a/.changeset/curl-dump-header.md
+++ b/.changeset/curl-dump-header.md
@@ -2,4 +2,4 @@
 "just-bash": patch
 ---
 
-Implement `curl -D` / `--dump-header` so response headers can be written to a file or stdout (`-D -`)
+Implement `curl -D` / `--dump-header` (file, `-`, `--dump-header=`, redirect hops, `-f` dumps). `curl -I` header blocks now end with a blank line (`\r\n\r\n`), matching real curl.

--- a/.changeset/curl-dump-header.md
+++ b/.changeset/curl-dump-header.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Implement `curl -D` / `--dump-header` so response headers can be written to a file or stdout (`-D -`)

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -20,7 +20,7 @@ import { parseOptions } from "./parse.js";
 import {
   applyWriteOut,
   extractFilename,
-  formatHeaders,
+  formatHeaderBlock,
 } from "./response-formatting.js";
 import type { CurlOptions } from "./types.js";
 
@@ -208,9 +208,11 @@ function buildOutput(
 
   // Include headers with -i/--include
   if (options.includeHeaders && !options.verbose) {
-    output += `HTTP/1.1 ${result.status} ${result.statusText}\r\n`;
-    output += formatHeaders(result.headers);
-    output += "\r\n\r\n";
+    output += formatHeaderBlock(
+      result.status,
+      result.statusText,
+      result.headers,
+    );
   }
 
   // Add body (unless head-only mode)
@@ -220,9 +222,11 @@ function buildOutput(
     // For HEAD, we already showed headers
   } else {
     // HEAD without -i shows headers
-    output += `HTTP/1.1 ${result.status} ${result.statusText}\r\n`;
-    output += formatHeaders(result.headers);
-    output += "\r\n";
+    output += formatHeaderBlock(
+      result.status,
+      result.statusText,
+      result.headers,
+    );
   }
 
   // Write-out format
@@ -320,28 +324,50 @@ export const curlCommand: RuntimeCommand = {
         return { stdout: "", stderr, exitCode: 22 };
       }
 
+      const headerBlock = formatHeaderBlock(
+        result.status,
+        result.statusText,
+        result.headers,
+      );
+
+      // -D/--dump-header FILE writes headers to a file (`-` means stdout)
+      if (options.dumpHeader !== undefined && options.dumpHeader !== "-") {
+        const dumpPath = ctx.fs.resolvePath(ctx.cwd, options.dumpHeader);
+        await ctx.fs.writeFile(dumpPath, headerBlock);
+      }
+
       let output = buildOutput(options, result, url);
 
-      // Write to file
+      // Write body to file when -o/-O is set
       if (options.outputFile || options.useRemoteName) {
         const filename = options.outputFile || extractFilename(url);
         const filePath = ctx.fs.resolvePath(ctx.cwd, filename);
         await ctx.fs.writeFile(filePath, options.headOnly ? "" : result.body);
 
-        // When writing to file, don't output body to stdout unless verbose
-        if (!options.verbose) {
+        // Body goes to the file; stdout keeps verbose chatter, or just the
+        // header block for `-D -` (real curl), otherwise empty.
+        if (options.verbose) {
+          // keep verbose output — pre-existing behavior
+        } else if (options.dumpHeader === "-") {
+          output = headerBlock;
+        } else {
           output = "";
         }
 
-        // Add write-out after file write
         if (options.writeOut) {
-          output = applyWriteOut(options.writeOut, {
-            status: result.status,
-            headers: result.headers,
-            url: result.url,
-            bodyLength: result.body.byteLength,
-          });
+          output =
+            (options.dumpHeader === "-" ? headerBlock : "") +
+            applyWriteOut(options.writeOut, {
+              status: result.status,
+              headers: result.headers,
+              url: result.url,
+              bodyLength: result.body.byteLength,
+            });
         }
+      } else if (options.dumpHeader === "-") {
+        // No -o: prepend the dump block. When -i/-I/verbose already emitted
+        // headers, this doubles them the way real `curl -D - -i` does.
+        output = headerBlock + output;
       }
 
       // The response body is a latin1-shaped byte buffer (see

--- a/packages/just-bash/src/commands/curl/curl.ts
+++ b/packages/just-bash/src/commands/curl/curl.ts
@@ -302,6 +302,13 @@ export const curlCommand: RuntimeCommand = {
       );
       const headers = prepareHeaders(options, contentType);
 
+      // Real curl truncates the dump file when the transfer starts, so a
+      // failed connection does not leave stale headers from a prior run.
+      if (options.dumpHeader !== undefined && options.dumpHeader !== "-") {
+        const dumpPath = ctx.fs.resolvePath(ctx.cwd, options.dumpHeader);
+        await ctx.fs.writeFile(dumpPath, "");
+      }
+
       const result = await ctx.fetch(url, {
         method: options.method,
         headers,
@@ -315,25 +322,46 @@ export const curlCommand: RuntimeCommand = {
       // Save cookies if requested
       await saveCookies(options, result.headers, ctx);
 
+      const finalHeaderBlock = formatHeaderBlock(
+        result.status,
+        result.statusText,
+        result.headers,
+      );
+      // Concatenate intermediate redirect hops then the final response, matching
+      // real `curl -D` / `-L` dumps.
+      let headerBlock = "";
+      if (result.redirectChain) {
+        for (const hop of result.redirectChain) {
+          headerBlock += formatHeaderBlock(
+            hop.status,
+            hop.statusText,
+            hop.headers,
+          );
+        }
+      }
+      headerBlock += finalHeaderBlock;
+
+      // -D/--dump-header FILE writes headers even when -f fails the transfer
+      // (real curl still dumps 4xx/5xx response headers).
+      if (options.dumpHeader !== undefined && options.dumpHeader !== "-") {
+        const dumpPath = ctx.fs.resolvePath(ctx.cwd, options.dumpHeader);
+        await ctx.fs.writeFile(dumpPath, headerBlock);
+      }
+
       // Check for HTTP errors with -f/--fail
       if (options.failSilently && result.status >= 400) {
         const stderr =
           options.showError || !options.silent
             ? `curl: (22) The requested URL returned error: ${result.status}\n`
             : "";
-        return { stdout: "", stderr, exitCode: 22 };
-      }
-
-      const headerBlock = formatHeaderBlock(
-        result.status,
-        result.statusText,
-        result.headers,
-      );
-
-      // -D/--dump-header FILE writes headers to a file (`-` means stdout)
-      if (options.dumpHeader !== undefined && options.dumpHeader !== "-") {
-        const dumpPath = ctx.fs.resolvePath(ctx.cwd, options.dumpHeader);
-        await ctx.fs.writeFile(dumpPath, headerBlock);
+        // -D - still emits headers on stdout under -f (real curl).
+        const stdout = options.dumpHeader === "-" ? headerBlock : "";
+        return {
+          stdout,
+          stderr,
+          exitCode: 22,
+          stdoutKind: stdout ? "bytes" : undefined,
+        };
       }
 
       let output = buildOutput(options, result, url);
@@ -344,10 +372,13 @@ export const curlCommand: RuntimeCommand = {
         const filePath = ctx.fs.resolvePath(ctx.cwd, filename);
         await ctx.fs.writeFile(filePath, options.headOnly ? "" : result.body);
 
-        // Body goes to the file; stdout keeps verbose chatter, or just the
-        // header block for `-D -` (real curl), otherwise empty.
+        // Body goes to the file. stdout composition:
+        // - `-D -` always emits the raw header block (even with `-v`)
+        // - `-v` keeps its verbose chatter (real curl sends verbose to stderr;
+        //   we keep it on stdout as before, after the dump block)
+        // - otherwise empty, then optional `-w`
         if (options.verbose) {
-          // keep verbose output — pre-existing behavior
+          output = (options.dumpHeader === "-" ? headerBlock : "") + output;
         } else if (options.dumpHeader === "-") {
           output = headerBlock;
         } else {
@@ -355,14 +386,20 @@ export const curlCommand: RuntimeCommand = {
         }
 
         if (options.writeOut) {
-          output =
-            (options.dumpHeader === "-" ? headerBlock : "") +
-            applyWriteOut(options.writeOut, {
-              status: result.status,
-              headers: result.headers,
-              url: result.url,
-              bodyLength: result.body.byteLength,
-            });
+          const writeOut = applyWriteOut(options.writeOut, {
+            status: result.status,
+            headers: result.headers,
+            url: result.url,
+            bodyLength: result.body.byteLength,
+          });
+          if (options.verbose) {
+            // Preserve verbose + optional -D - block, then append -w
+            output += writeOut;
+          } else if (options.dumpHeader === "-") {
+            output = headerBlock + writeOut;
+          } else {
+            output = writeOut;
+          }
         }
       } else if (options.dumpHeader === "-") {
         // No -o: prepend the dump block. When -i/-I/verbose already emitted

--- a/packages/just-bash/src/commands/curl/help.ts
+++ b/packages/just-bash/src/commands/curl/help.ts
@@ -28,6 +28,7 @@ export const curlHelp: {
     "-T, --upload-file FILE  Upload file (PUT)",
     "-o, --output FILE     Write output to file",
     "-O, --remote-name     Write to file named from URL",
+    "-D, --dump-header FILE  Write response headers to FILE (`-` for stdout)",
     "-I, --head            Show headers only (HEAD request)",
     "-i, --include         Include response headers in output",
     "-s, --silent          Silent mode (no progress)",

--- a/packages/just-bash/src/commands/curl/parse.ts
+++ b/packages/just-bash/src/commands/curl/parse.ts
@@ -261,6 +261,17 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
         };
       }
       options.dumpHeader = value;
+    } else if (arg.startsWith("--dump-header=")) {
+      const value = arg.slice(14);
+      if (value === "") {
+        return {
+          stdout: "",
+          stderr:
+            "curl: option --dump-header: blank argument where content is expected\n",
+          exitCode: 1,
+        };
+      }
+      options.dumpHeader = value;
     } else if (arg.startsWith("-D") && arg.length > 2) {
       // Real curl accepts `-Dfile` (attached path, including `-D-` for stdout)
       options.dumpHeader = arg.slice(2);

--- a/packages/just-bash/src/commands/curl/parse.ts
+++ b/packages/just-bash/src/commands/curl/parse.ts
@@ -244,6 +244,26 @@ export function parseOptions(args: string[]): CurlOptions | ExecResult {
       options.outputFile = args[++i];
     } else if (arg.startsWith("--output=")) {
       options.outputFile = arg.slice(9);
+    } else if (arg === "-D" || arg === "--dump-header") {
+      const value = args[++i];
+      if (value === undefined) {
+        return {
+          stdout: "",
+          stderr: `curl: option ${arg}: requires parameter\n`,
+          exitCode: 1,
+        };
+      }
+      if (value === "") {
+        return {
+          stdout: "",
+          stderr: `curl: option ${arg}: blank argument where content is expected\n`,
+          exitCode: 1,
+        };
+      }
+      options.dumpHeader = value;
+    } else if (arg.startsWith("-D") && arg.length > 2) {
+      // Real curl accepts `-Dfile` (attached path, including `-D-` for stdout)
+      options.dumpHeader = arg.slice(2);
     } else if (arg === "-O" || arg === "--remote-name") {
       options.useRemoteName = true;
     } else if (arg === "-I" || arg === "--head") {

--- a/packages/just-bash/src/commands/curl/response-formatting.ts
+++ b/packages/just-bash/src/commands/curl/response-formatting.ts
@@ -5,10 +5,21 @@
 /**
  * Format response headers for output
  */
-export function formatHeaders(headers: Record<string, string>): string {
+function formatHeaders(headers: Record<string, string>): string {
   return Object.entries(headers)
     .map(([name, value]) => `${name}: ${value}`)
     .join("\r\n");
+}
+
+/**
+ * Status line + headers + trailing blank line, matching `-i` / `-D` layout.
+ */
+export function formatHeaderBlock(
+  status: number,
+  statusText: string,
+  headers: Record<string, string>,
+): string {
+  return `HTTP/1.1 ${status} ${statusText}\r\n${formatHeaders(headers)}\r\n\r\n`;
 }
 
 /**

--- a/packages/just-bash/src/commands/curl/tests/dump-header.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/dump-header.test.ts
@@ -15,7 +15,38 @@ import { Bash } from "../../../Bash.js";
 
 const originalFetch = global.fetch;
 
-const mockFetch = vi.fn(async (_url: string, _options?: RequestInit) => {
+const mockFetch = vi.fn(async (url: string, _options?: RequestInit) => {
+  const href = String(url);
+  if (href.includes("/redirect")) {
+    return new Response("", {
+      status: 302,
+      statusText: "Found",
+      headers: {
+        location: "https://api.example.com/final",
+        "x-hop": "1",
+      },
+    });
+  }
+  if (href.includes("/final")) {
+    return new Response('{"ok":true}', {
+      status: 200,
+      statusText: "OK",
+      headers: {
+        "content-type": "application/json",
+        "x-custom": "yes",
+      },
+    });
+  }
+  if (href.includes("/fail")) {
+    return new Response("nope", {
+      status: 404,
+      statusText: "Not Found",
+      headers: {
+        "content-type": "text/plain",
+        "x-error": "missing",
+      },
+    });
+  }
   return new Response('{"ok":true}', {
     status: 200,
     statusText: "OK",
@@ -76,6 +107,16 @@ describe("curl -D/--dump-header", () => {
     );
   });
 
+  it("accepts --dump-header=FILE", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s --dump-header=/tmp/h-eq.txt -o /dev/null https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+    const headers = await env.exec("cat /tmp/h-eq.txt");
+    expect(headers.stdout).toContain("x-custom: yes");
+  });
+
   it("accepts attached -Dfile form", async () => {
     const env = createEnv();
     const result = await env.exec(
@@ -100,6 +141,74 @@ describe("curl -D/--dump-header", () => {
 
     const body = await env.exec("cat /tmp/body-only.json");
     expect(body.stdout).toBe('{"ok":true}');
+  });
+
+  it("emits -D - header block even with -v -o", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -v -D - -o /tmp/body-v.json https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.startsWith("HTTP/1.1 200 OK\r\n")).toBe(true);
+    expect(result.stdout).toContain("x-custom: yes");
+    expect(result.stdout).toContain("> GET");
+    const body = await env.exec("cat /tmp/body-v.json");
+    expect(body.stdout).toBe('{"ok":true}');
+  });
+
+  it("dumps 4xx headers with -f -D before failing", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -f -D /tmp/fail-headers.txt -o /dev/null https://api.example.com/fail",
+    );
+    expect(result.exitCode).toBe(22);
+    expect(result.stdout).toBe("");
+    const headers = await env.exec("cat /tmp/fail-headers.txt");
+    expect(headers.stdout).toBe(
+      "HTTP/1.1 404 Not Found\r\ncontent-type: text/plain\r\nx-error: missing\r\n\r\n",
+    );
+  });
+
+  it("clears a stale dump file on the same VFS when the request fails", async () => {
+    const env = createEnv();
+    await env.exec("printf 'STALE' > /tmp/stale2.txt");
+    // Override fetch to throw after the dump file was truncated.
+    const boom = vi.fn(async () => {
+      throw new Error("connect failed");
+    });
+    const prev = global.fetch;
+    global.fetch = boom as typeof fetch;
+    try {
+      const result = await env.exec(
+        "curl -s -D /tmp/stale2.txt -o /dev/null https://api.example.com/test",
+      );
+      expect(result.exitCode).not.toBe(0);
+      const dumped = await env.exec("cat /tmp/stale2.txt");
+      expect(dumped.stdout).toBe("");
+    } finally {
+      global.fetch = prev;
+    }
+  });
+
+  it("dumps intermediate redirect headers with -D -L", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -L -D /tmp/redir.txt -o /dev/null https://api.example.com/redirect",
+    );
+    expect(result.exitCode).toBe(0);
+    const headers = await env.exec("cat /tmp/redir.txt");
+    expect(headers.stdout).toContain("HTTP/1.1 302 Found\r\n");
+    expect(headers.stdout).toContain(
+      "location: https://api.example.com/final\r\n",
+    );
+    expect(headers.stdout).toContain("x-hop: 1\r\n");
+    expect(headers.stdout).toContain(
+      "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-custom: yes\r\n\r\n",
+    );
+    // Intermediate hop then final response, in order
+    expect(headers.stdout.indexOf("302")).toBeLessThan(
+      headers.stdout.indexOf("200 OK"),
+    );
   });
 
   it("prepends headers before the body with -D - and no -o", async () => {

--- a/packages/just-bash/src/commands/curl/tests/dump-header.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/dump-header.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for curl -D/--dump-header
+ */
+
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { Bash } from "../../../Bash.js";
+
+const originalFetch = global.fetch;
+
+const mockFetch = vi.fn(async (_url: string, _options?: RequestInit) => {
+  return new Response('{"ok":true}', {
+    status: 200,
+    statusText: "OK",
+    headers: {
+      "content-type": "application/json",
+      "x-custom": "yes",
+    },
+  });
+});
+
+beforeAll(() => {
+  global.fetch = mockFetch as typeof fetch;
+});
+
+afterAll(() => {
+  global.fetch = originalFetch;
+});
+
+const createEnv = () =>
+  new Bash({
+    network: { allowedUrlPrefixes: ["https://api.example.com"] },
+  });
+
+describe("curl -D/--dump-header", () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it("writes headers to a file with -D", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -D /tmp/headers.txt -o /tmp/body.json https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("");
+
+    const headers = await env.exec("cat /tmp/headers.txt");
+    expect(headers.stdout).toBe(
+      "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-custom: yes\r\n\r\n",
+    );
+
+    const body = await env.exec("cat /tmp/body.json");
+    expect(body.stdout).toBe('{"ok":true}');
+  });
+
+  it("accepts --dump-header FILE", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s --dump-header /tmp/h2.txt https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe('{"ok":true}');
+
+    const headers = await env.exec("cat /tmp/h2.txt");
+    expect(headers.stdout).toBe(
+      "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-custom: yes\r\n\r\n",
+    );
+  });
+
+  it("accepts attached -Dfile form", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -D/tmp/h3.txt -o /dev/null https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+
+    const headers = await env.exec("cat /tmp/h3.txt");
+    expect(headers.stdout).toContain("x-custom: yes");
+  });
+
+  it("writes headers to stdout with -D -", async () => {
+    const env = createEnv();
+    const result = await env.exec(
+      "curl -s -D - -o /tmp/body-only.json https://api.example.com/test",
+    );
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-custom: yes\r\n\r\n",
+    );
+    expect(result.stderr).toBe("");
+
+    const body = await env.exec("cat /tmp/body-only.json");
+    expect(body.stdout).toBe('{"ok":true}');
+  });
+
+  it("prepends headers before the body with -D - and no -o", async () => {
+    const env = createEnv();
+    const result = await env.exec("curl -s -D - https://api.example.com/test");
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      'HTTP/1.1 200 OK\r\ncontent-type: application/json\r\nx-custom: yes\r\n\r\n{"ok":true}',
+    );
+  });
+
+  it("rejects missing -D argument", async () => {
+    const env = createEnv();
+    const result = await env.exec("curl -s -D");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe("curl: option -D: requires parameter\n");
+    expect(result.stdout).toBe("");
+  });
+
+  it("rejects blank -D argument", async () => {
+    const env = createEnv();
+    const result = await env.exec("curl -s -D '' https://api.example.com/test");
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toBe(
+      "curl: option -D: blank argument where content is expected\n",
+    );
+  });
+});

--- a/packages/just-bash/src/commands/curl/types.ts
+++ b/packages/just-bash/src/commands/curl/types.ts
@@ -54,6 +54,11 @@ export interface CurlOptions {
   uploadFile?: string;
   cookieJar?: string;
   outputFile?: string;
+  /**
+   * `-D` / `--dump-header` destination. `"-"` writes headers to stdout;
+   * any other string is a VFS path. Undefined when the flag was not given.
+   */
+  dumpHeader?: string;
   useRemoteName: boolean;
   headOnly: boolean;
   includeHeaders: boolean;

--- a/packages/just-bash/src/network/dns-pin-fetch.test.ts
+++ b/packages/just-bash/src/network/dns-pin-fetch.test.ts
@@ -79,6 +79,15 @@ describe("secureFetch behavior", () => {
     expect(result.status).toBe(200);
     expect(new TextDecoder().decode(result.body)).toBe("final");
     expect(result.url).toBe("https://example.com/final");
+    expect(result.redirectChain).toEqual([
+      {
+        status: 302,
+        statusText: "",
+        headers: expect.objectContaining({
+          location: "https://example.com/final",
+        }),
+      },
+    ]);
   });
 
   it("respects maxRedirects cap", async () => {

--- a/packages/just-bash/src/network/fetch.ts
+++ b/packages/just-bash/src/network/fetch.ts
@@ -434,6 +434,7 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
 
       let currentUrl = url;
       let redirectCount = 0;
+      const redirectChain: NonNullable<FetchResult["redirectChain"]> = [];
 
       // Redirects update method, body, and user credentials per hop.
       let currentMethod = method;
@@ -532,8 +533,16 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
               currentUrl,
               maxResponseSize,
               combinedAbort.signal,
+              redirectChain,
             );
           }
+
+          // Record this hop for curl -D before discarding the body.
+          redirectChain.push({
+            status: response.status,
+            statusText: response.statusText,
+            headers: headersToRecord(response.headers),
+          });
 
           const redirectUrl = new URL(location, currentUrl).href;
           // Do not leave a redirect body live while reviewing the next address.
@@ -590,6 +599,7 @@ export function createSecureFetch(config: NetworkConfig): SecureFetch {
           currentUrl,
           maxResponseSize,
           combinedAbort.signal,
+          redirectChain,
         );
       }
     } finally {
@@ -663,6 +673,17 @@ function buildMergedHeaders(
 }
 
 /**
+ * Snapshot response headers into a null-prototype record (lowercase keys).
+ */
+function headersToRecord(headers: Headers): Record<string, string> {
+  const out: Record<string, string> = Object.create(null);
+  headers.forEach((value, key) => {
+    out[key.toLowerCase()] = value;
+  });
+  return out;
+}
+
+/**
  * Converts a Response to a FetchResult, enforcing response size limits.
  */
 async function responseToResult(
@@ -670,12 +691,10 @@ async function responseToResult(
   url: string,
   maxResponseSize: number,
   signal?: AbortSignal,
+  redirectChain?: FetchResult["redirectChain"],
 ): Promise<FetchResult> {
   // Use null-prototype to prevent prototype pollution via malicious response headers
-  const headers: Record<string, string> = Object.create(null);
-  response.headers.forEach((value, key) => {
-    headers[key.toLowerCase()] = value;
-  });
+  const headers = headersToRecord(response.headers);
 
   // Fast path: check Content-Length header
   if (maxResponseSize > 0) {
@@ -727,11 +746,15 @@ async function responseToResult(
     body = new Uint8Array(ab);
   }
 
-  return {
+  const result: FetchResult = {
     status: response.status,
     statusText: response.statusText,
     headers,
     body,
     url,
   };
+  if (redirectChain && redirectChain.length > 0) {
+    result.redirectChain = redirectChain;
+  }
+  return result;
 }

--- a/packages/just-bash/src/network/types.ts
+++ b/packages/just-bash/src/network/types.ts
@@ -163,6 +163,16 @@ export interface FetchResult {
   /** Raw response bytes (never decoded as UTF-8 text). */
   body: Uint8Array;
   url: string;
+  /**
+   * Intermediate redirect responses in hop order (excluding the final
+   * response). Populated when redirects were followed so callers like
+   * `curl -D` can dump every status/header block the way real curl does.
+   */
+  redirectChain?: Array<{
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+  }>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Implements `curl -D` / `--dump-header` (including `-D -` for stdout and the attached `-Dfile` form), matching real curl's write-headers-to-file behavior.
- Addresses the loud missing-option half of #388. The silent header-truncation half does **not** reproduce in stock Node just-bash (full CSP/HSTS/X-Frame-Options etc. are returned); that is a SLICC `/api/fetch-proxy` CORS `Access-Control-Expose-Headers` issue and will be fixed separately there.

## Test plan
- [x] `pnpm test:run src/commands/curl/tests/dump-header.test.ts`
- [x] Related curl option/verbose/writeout tests
- [x] `pnpm typecheck` / biome / knip
- [ ] Manual: `curl -s -D /tmp/h.txt -o /dev/null https://example.com` writes a header block to `/tmp/h.txt`

Fixes #388 (partial: `-D` only)


Made with [Cursor](https://cursor.com)