### PR TITLE
fix(ln): report a refused symlink as a symlink failure

### DIFF
--- a/.changeset/ln-symlink-eperm-message.md
+++ b/.changeset/ln-symlink-eperm-message.md
@@ -1,0 +1,9 @@
+---
+"just-bash": patch
+---
+
+ln: report a refused symlink as a symlink failure, not as a hard link on a directory
+
+`ln -s` against a filesystem constructed without symlink support failed with `ln: 'file.txt': hard link not allowed for directory`. Nothing in that sentence is true of the call: `-s` asks for a symbolic link rather than a hard one, and the named operand is the target rather than the directory the message blames.
+
+Both link kinds shared one `EPERM` branch, which carried the hard-link wording unconditionally. `link` reports `EPERM` only for a directory, so that wording is right there and is kept. `symlink` reports it when the filesystem allows no symlinks at all, which is a different condition with a different remedy, and it now reads `ln: failed to create symbolic link 'link': Operation not permitted`, matching the shape GNU `ln` uses and the shape this command already uses for `File exists`.

--- a/packages/just-bash/src/commands/ln/ln.error-forwarding.test.ts
+++ b/packages/just-bash/src/commands/ln/ln.error-forwarding.test.ts
@@ -43,6 +43,42 @@ describe("ln command error forwarding", () => {
     expect(result.exitCode).toBe(1);
   });
 
+  // A filesystem that does not allow symlinks reports EPERM from `symlink`,
+  // which is neither a hard link nor a statement about the target.
+  it("reports a refused symlink as a symlink failure", async () => {
+    const fs = withInjectedFsError(
+      new InMemoryFs({ "/target.txt": "ok\n" }),
+      "symlink",
+      "EPERM: operation not permitted, symlink '/link'",
+    );
+    const env = new Bash({ fs });
+
+    const result = await env.exec("ln -s target.txt link");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "ln: failed to create symbolic link 'link': Operation not permitted\n",
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("still reports a refused hard link against a directory", async () => {
+    const fs = withInjectedFsError(
+      new InMemoryFs({ "/dir/file.txt": "ok\n" }),
+      "link",
+      "EPERM: operation not permitted, link '/dir'",
+    );
+    const env = new Bash({ fs });
+
+    const result = await env.exec("ln /dir /link");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "ln: '/dir': hard link not allowed for directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
   it("sanitizes hard-link error strings before forwarding", async () => {
     const fs = withInjectedFsError(
       new InMemoryFs({ "/target.txt": "ok\n" }),

--- a/packages/just-bash/src/commands/ln/ln.ts
+++ b/packages/just-bash/src/commands/ln/ln.ts
@@ -124,9 +124,14 @@ export const lnCommand: RuntimeCommand = {
     } catch (e) {
       const err = e as Error;
       if (err.message.includes("EPERM")) {
+        // Only `link` reports EPERM for a directory. `symlink` reports it on a
+        // filesystem that does not allow symlinks at all, where naming a hard
+        // link and a directory describes neither the operation nor the target.
         return {
           stdout: "",
-          stderr: `ln: '${target}': hard link not allowed for directory\n`,
+          stderr: symbolic
+            ? `ln: failed to create symbolic link '${linkName}': Operation not permitted\n`
+            : `ln: '${target}': hard link not allowed for directory\n`,
           exitCode: 1,
         };
       }


### PR DESCRIPTION
## Problem

```bash
# InMemoryFs, or any filesystem constructed without symlink support
ln -s target.txt link
# ln: 'target.txt': hard link not allowed for directory
```

Three things in that sentence are wrong for the call that produced it. `-s` asked for a symbolic link rather than a hard one. The operand it names is the target, not a directory. And no directory is involved at all: `target.txt` is a regular file.

This lands hardest on an agent driving the shell, which has only the message to reason from. Told the target is a directory, the reasonable next moves are all about the target, and none of them can work. The actual condition is a filesystem that permits no symlinks whatsoever, which no wording here hints at.

## Cause

`ln.ts` runs both link kinds through one `try`, then decides the message from the error alone:

```ts
if (err.message.includes("EPERM")) {
  return {
    stdout: "",
    stderr: `ln: '${target}': hard link not allowed for directory\n`,
    exitCode: 1,
  };
}
```

Two different conditions arrive here. `link` reports `EPERM` only for a directory (`InMemoryFs` throws it on `entry.type !== "file"`, and `ReadWriteFs` forwards the OS's), so the wording is correct on that path. `symlink` reports `EPERM` when the filesystem was built without symlink support, which `ReadWriteFs` and `OverlayFs` both raise before touching the disk.

The existing `ln.error-forwarding.test.ts` covers both paths, but injects non-`EPERM` messages to exercise `sanitizeErrorMessage`, so they fall through this branch rather than into it.

## Fix

Pick the message from `symbolic`. The hard-link path is unchanged. The symlink path now reads `ln: failed to create symbolic link 'link': Operation not permitted`, which is the shape GNU `ln` uses and the shape this command already uses two branches up for `File exists`.

## Scope

Unchanged: the hard-link `EPERM` wording, the `sanitizeErrorMessage` fall-through for every other error, and all success paths.

Not addressed, deliberately: whether a filesystem should allow symlinks. That is a construction-time choice and this is only about describing the refusal accurately.

## Tests

Two cases added to `ln.error-forwarding.test.ts`, injecting a real `EPERM` string into each path: `ln -s` asserts the new symlink wording, and `ln` against a directory asserts the hard-link wording is untouched. Verified the first fails against `main` by reverting only the ternary and re-running.

They assert wording, not filesystem behavior. The `EPERM` is injected, so they do not prove `ReadWriteFs` or `OverlayFs` raise it where I claim; I read those call sites rather than exercising them.

Unit suite: 541 files, 14,653 passed, 98 skipped. Lint and typecheck clean. No pre-existing failures on this branch, verified by running the suite before the change as well as after.

---

Authored with Claude Opus 5
