### PR TITLE
fix(limits): enforce maxExecutionTimeMs inside data-command row loops

### DIFF
--- a/.changeset/row-loop-deadlines.md
+++ b/.changeset/row-loop-deadlines.md
@@ -1,0 +1,30 @@
+---
+"just-bash": patch
+---
+
+Enforce `maxExecutionTimeMs` and `ExecOptions.signal` inside the data-command row loops
+
+`ExecutionScope.throwIfAborted` was only reached at statement boundaries
+(`chargeCommand` → `consume` → `assertUsable`), so the deadline could not bound a
+single long-running statement. A `grep`/`jq`/`awk`/`sed` scan over a large input
+ran to completion and *then* reported exit 124, having already spent the full
+wall-clock cost. Because the builtins are synchronous, the host's own
+`AbortController` timer could not fire during the scan either, so an external
+`signal` had no observable effect until the interpreter came back up for air.
+
+The record loops now consult the scope directly: `awk` per input record, `sed`
+per pattern-space line, the query evaluator (`jq`, `yq`) in `chargeQueryWork`,
+and the search engine (`grep`, `rg`) in `chargeWork`. Cancellation latency is
+bounded by `DEADLINE_CHECK_STRIDE` (1024) rows rather than by the length of the
+whole scan.
+
+The check is strided off the hot path — reusing a counter each loop already
+maintains, so the added work per row is one integer compare against a local or
+already-loaded field, not a call through the `CommandExecutionBudget` facade. On
+a 99k-row JSONL input, `grep -c`, `jq -s 'map(.value) | add'`, `awk '{ t +=
+length($0) }'` and `sed s///g` are unchanged within measurement noise.
+
+**Residual gap**: a single record whose own evaluation is unbounded (an `awk`
+rule with a long inner `while`, one pathological regex) is still not
+interruptible, and `sort` compares inside `Array.prototype.sort` remain outside
+the deadline. Those need per-construct checks rather than per-row ones.

--- a/.changeset/row-loop-deadlines.md
+++ b/.changeset/row-loop-deadlines.md
@@ -2,21 +2,21 @@
 "just-bash": patch
 ---
 
-Enforce `maxExecutionTimeMs` and `ExecOptions.signal` inside the data-command row loops
+Enforce `maxExecutionTimeMs` inside the data-command row loops
 
 `ExecutionScope.throwIfAborted` was only reached at statement boundaries
 (`chargeCommand` → `consume` → `assertUsable`), so the deadline could not bound a
 single long-running statement. A `grep`/`jq`/`awk`/`sed` scan over a large input
 ran to completion and *then* reported exit 124, having already spent the full
-wall-clock cost. Because the builtins are synchronous, the host's own
-`AbortController` timer could not fire during the scan either, so an external
-`signal` had no observable effect until the interpreter came back up for air.
+wall-clock cost.
 
 The record loops now consult the scope directly: `awk` per input record, `sed`
 per pattern-space line, the query evaluator (`jq`, `yq`) in `chargeQueryWork`,
-and the search engine (`grep`, `rg`) in `chargeWork`. Cancellation latency is
-bounded by `DEADLINE_CHECK_STRIDE` (1024) rows rather than by the length of the
-whole scan.
+and the search engine (`grep`, `rg`) in `chargeWork`, plus `grep`'s whole-file
+prefilter on a miss. Cancellation latency is bounded by `DEADLINE_CHECK_STRIDE`
+(1024) rows rather than by the length of the whole scan. The query evaluator's
+`try`/`catch`, `?` and comma recovery paths now rethrow the deadline abort along
+with the other fatal execution errors instead of converting it to a value.
 
 The check is strided off the hot path — reusing a counter each loop already
 maintains, so the added work per row is one integer compare against a local or
@@ -24,7 +24,9 @@ already-loaded field, not a call through the `CommandExecutionBudget` facade. On
 a 99k-row JSONL input, `grep -c`, `jq -s 'map(.value) | add'`, `awk '{ t +=
 length($0) }'` and `sed s///g` are unchanged within measurement noise.
 
-**Residual gap**: a single record whose own evaluation is unbounded (an `awk`
-rule with a long inner `while`, one pathological regex) is still not
-interruptible, and `sort` compares inside `Array.prototype.sort` remain outside
-the deadline. Those need per-construct checks rather than per-row ones.
+**Not changed**: `ExecOptions.signal`. The loops stay synchronous and never
+yield, so a host `AbortController` fired from a timer is still only observed
+once the command returns; only the wall-clock deadline (a `Date.now()` poll) can
+fire mid-scan. A single record whose own evaluation is unbounded (an `awk` rule
+with a long inner `while`, one pathological regex) is still not interruptible,
+and `sort` compares inside `Array.prototype.sort` remain outside the deadline.

--- a/packages/just-bash/src/commands/awk/awk2.ts
+++ b/packages/just-bash/src/commands/awk/awk2.ts
@@ -159,6 +159,7 @@ export const awkCommand2: RuntimeCommand = {
         ctx.limits.maxOutputSize,
       ),
       maxArrayElements: ctx.limits.maxArrayElements,
+      executionScope: ctx.executionScope,
       fs: awkFs,
       cwd: ctx.cwd,
       // Wrap ctx.exec to match the expected signature for command pipe getline

--- a/packages/just-bash/src/commands/awk/interpreter/context.ts
+++ b/packages/just-bash/src/commands/awk/interpreter/context.ts
@@ -4,6 +4,7 @@
  * Holds all state for AWK program execution.
  */
 
+import type { CommandExecutionBudget } from "../../../execution-scope.js";
 import { ConstantRegex, type RegexLike } from "../../../regex/index.js";
 import type { FeatureCoverageWriter } from "../../../types.js";
 import type { AwkFunctionDef } from "../ast.js";
@@ -100,6 +101,8 @@ export interface AwkRuntimeContext {
 
   // Defense context invariant flag propagated from RuntimeCommandContext
   requireDefenseContext?: boolean;
+  /** Shared accounting; supplies the wall-clock deadline during record loops. */
+  executionScope?: CommandExecutionBudget;
 }
 
 export interface CreateContextOptions {
@@ -115,6 +118,7 @@ export interface CreateContextOptions {
   ) => Promise<{ stdout: string; stderr: string; exitCode: number }>;
   coverage?: FeatureCoverageWriter;
   requireDefenseContext?: boolean;
+  executionScope?: CommandExecutionBudget;
 }
 
 export function createRuntimeContext(
@@ -168,6 +172,7 @@ export function createRuntimeContext(
     maxRecursionDepth,
     maxOutputSize,
     maxArrayElements,
+    executionScope: options.executionScope,
     arrayElementCount: 0,
     recordsProcessed: 0,
     currentRecursionDepth: 0,

--- a/packages/just-bash/src/commands/awk/interpreter/interpreter.ts
+++ b/packages/just-bash/src/commands/awk/interpreter/interpreter.ts
@@ -4,6 +4,7 @@
  * Main interpreter class that orchestrates AWK program execution.
  */
 
+import { DEADLINE_CHECK_STRIDE } from "../../../execution-scope.js";
 import { ExecutionLimitError } from "../../../interpreter/errors.js";
 import {
   assertDefenseContext as assertDefenseContextInvariant,
@@ -83,6 +84,9 @@ export class AwkInterpreter {
     this.assertDefenseContext("line execution entry");
     if (!this.program || this.ctx.shouldExit) return;
 
+    if (this.ctx.recordsProcessed % DEADLINE_CHECK_STRIDE === 0) {
+      this.ctx.executionScope?.throwIfAborted("awk");
+    }
     this.ctx.recordsProcessed++;
     if (this.ctx.recordsProcessed > this.ctx.maxIterations) {
       throw new ExecutionLimitError(

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -508,6 +508,7 @@ export const grepCommand: RuntimeCommand = {
         maxWork: getMatcherWorkLimit(ctx),
         maxMatches: ctx.limits.maxArrayElements,
         signal: ctx.signal,
+        budget: ctx.executionScope,
       });
       if (quietMode) {
         return { stdout: "", stderr: "", exitCode: result.matched ? 0 : 1 };
@@ -736,6 +737,7 @@ export const grepCommand: RuntimeCommand = {
               maxWork: getMatcherWorkLimit(ctx),
               maxMatches: ctx.limits.maxArrayElements,
               signal: ctx.signal,
+              budget: ctx.executionScope,
             });
 
             return { file, result };

--- a/packages/just-bash/src/commands/grep/grep.ts
+++ b/packages/just-bash/src/commands/grep/grep.ts
@@ -705,6 +705,7 @@ export const grepCommand: RuntimeCommand = {
                 ? content.toLowerCase()
                 : content;
               if (!preFilter.needles.some((n) => haystack.includes(n))) {
+                ctx.executionScope?.throwIfAborted("grep");
                 if (countOnly) {
                   const countStr = showFilename ? `${file}:0` : "0";
                   return {

--- a/packages/just-bash/src/commands/jq/jq.ts
+++ b/packages/just-bash/src/commands/jq/jq.ts
@@ -489,7 +489,8 @@ export const jqCommand: RuntimeCommand = {
         positionalArgs,
         coverage: ctx.coverage,
         requireDefenseContext: ctx.requireDefenseContext,
-        budget: { operations: 0, callDepth: 0 },
+        budget: { operations: 0, callDepth: 0, deadlineCheckAt: 0 },
+        executionScope: ctx.executionScope,
       };
       const appendValues = (target: QueryValue[], next: QueryValue[]): void => {
         if (next.length > ctx.limits.maxQueryElements - target.length) {

--- a/packages/just-bash/src/commands/query-engine/evaluator.ts
+++ b/packages/just-bash/src/commands/query-engine/evaluator.ts
@@ -6,6 +6,10 @@
  */
 
 import { BoundedStringBuilder } from "../../bounded-builder.js";
+import {
+  type CommandExecutionBudget,
+  DEADLINE_CHECK_STRIDE,
+} from "../../execution-scope.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import { assertDefenseContext } from "../../security/defense-context.js";
@@ -141,11 +145,15 @@ export interface EvalContext {
   coverage?: FeatureCoverageWriter;
   /** Shared across every recursive evaluation and builtin invocation. */
   budget: QueryEvaluationBudget;
+  /** Shared accounting; supplies the wall-clock deadline during evaluation. */
+  executionScope?: CommandExecutionBudget;
 }
 
 export interface QueryEvaluationBudget {
   operations: number;
   callDepth: number;
+  /** Operation count at which the next deadline check is due. */
+  deadlineCheckAt: number;
 }
 
 function queryLimitError(
@@ -156,6 +164,10 @@ function queryLimitError(
 }
 
 export function chargeQueryWork(ctx: EvalContext, count = 1): void {
+  if (ctx.budget.operations >= ctx.budget.deadlineCheckAt) {
+    ctx.budget.deadlineCheckAt = ctx.budget.operations + DEADLINE_CHECK_STRIDE;
+    ctx.executionScope?.throwIfAborted("query evaluation");
+  }
   if (
     !Number.isSafeInteger(count) ||
     count < 0 ||
@@ -238,7 +250,12 @@ function createContext(options?: EvaluateOptions): EvalContext {
     coverage: options?.coverage,
     requireDefenseContext: options?.requireDefenseContext,
     defenseContextChecked: false,
-    budget: options?.budget ?? { operations: 0, callDepth: 0 },
+    budget: options?.budget ?? {
+      operations: 0,
+      callDepth: 0,
+      deadlineCheckAt: 0,
+    },
+    executionScope: options?.executionScope,
   };
 }
 
@@ -263,6 +280,7 @@ function withVar(
     labels: ctx.labels,
     coverage: ctx.coverage,
     budget: ctx.budget,
+    executionScope: ctx.executionScope,
   };
 }
 
@@ -466,6 +484,7 @@ export interface EvaluateOptions {
   requireDefenseContext?: boolean;
   /** Reuse across multiple input documents to enforce one command budget. */
   budget?: QueryEvaluationBudget;
+  executionScope?: CommandExecutionBudget;
 }
 
 /**

--- a/packages/just-bash/src/commands/query-engine/evaluator.ts
+++ b/packages/just-bash/src/commands/query-engine/evaluator.ts
@@ -10,6 +10,7 @@ import {
   type CommandExecutionBudget,
   DEADLINE_CHECK_STRIDE,
 } from "../../execution-scope.js";
+import { rethrowFatalExecutionError } from "../../fatal-execution-error.js";
 import { mapToRecord } from "../../helpers/env.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import { assertDefenseContext } from "../../security/defense-context.js";
@@ -503,8 +504,7 @@ function evaluateWithPartialResults(
       const left = evaluate(value, ast.left, ctx);
       appendQueryResults(ctx, results, left);
     } catch (e) {
-      // Always re-throw execution limit errors - they must not be suppressed
-      if (e instanceof ExecutionLimitError) throw e;
+      rethrowFatalExecutionError(e);
       // Left side errored, check if we have any results
       if (results.length > 0) return results;
       throw new Error("evaluation failed");
@@ -513,8 +513,7 @@ function evaluateWithPartialResults(
       const right = evaluate(value, ast.right, ctx);
       appendQueryResults(ctx, results, right);
     } catch (e) {
-      // Always re-throw execution limit errors
-      if (e instanceof ExecutionLimitError) throw e;
+      rethrowFatalExecutionError(e);
       // Right side errored, return what we have from left
       return results;
     }
@@ -818,7 +817,7 @@ function evaluateNode(
       try {
         return evaluate(value, ast.body, ctx);
       } catch (e) {
-        if (e instanceof ExecutionLimitError) throw e;
+        rethrowFatalExecutionError(e);
         if (ast.catch) {
           // jq: In catch handler, input is the error value (preserved if JqError)
           const errorVal =
@@ -952,7 +951,7 @@ function evaluateNode(
       try {
         return evaluate(value, ast.expr, ctx);
       } catch (error) {
-        if (error instanceof ExecutionLimitError) throw error;
+        rethrowFatalExecutionError(error);
         return [];
       }
     }

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -298,6 +298,7 @@ export async function executeSearch(
       maxWork: ctx.limits.maxLoopIterations,
       maxMatches: ctx.limits.maxArrayElements,
       signal: ctx.signal,
+      budget: ctx.executionScope,
     });
 
     if (options.quiet) {
@@ -1185,6 +1186,7 @@ async function searchFiles(
             maxWork: ctx.limits.maxLoopIterations,
             maxMatches: ctx.limits.maxArrayElements,
             signal: ctx.signal,
+            budget: ctx.executionScope,
           });
 
           // JSON formatting below needs the source after this task ends, so

--- a/packages/just-bash/src/commands/search-engine/matcher.ts
+++ b/packages/just-bash/src/commands/search-engine/matcher.ts
@@ -3,6 +3,10 @@
  */
 
 import {
+  type CommandExecutionBudget,
+  DEADLINE_CHECK_STRIDE,
+} from "../../execution-scope.js";
+import {
   ExecutionAbortedError,
   ExecutionLimitError,
 } from "../../interpreter/errors.js";
@@ -93,6 +97,8 @@ export interface SearchOptions {
   maxMatches?: number;
   /** Cooperative cancellation signal checked during long scans. */
   signal?: AbortSignal;
+  /** Shared accounting; supplies the wall-clock deadline during long scans. */
+  budget?: CommandExecutionBudget;
 }
 
 export interface SearchResult {
@@ -142,6 +148,7 @@ export function searchContent(
     maxWork,
     maxMatches,
     signal,
+    budget,
   } = options;
 
   // Multiline mode: search entire content as one string
@@ -165,12 +172,18 @@ export function searchContent(
       maxWork,
       maxMatches,
       signal,
+      budget,
     });
   }
 
   let work = 0;
+  let sinceDeadlineCheck = 0;
   const chargeWork = (amount = 1): void => {
     if (signal?.aborted) throw new ExecutionAbortedError();
+    if (++sinceDeadlineCheck >= DEADLINE_CHECK_STRIDE) {
+      sinceDeadlineCheck = 0;
+      budget?.throwIfAborted("search");
+    }
     work += amount;
     if (maxWork !== undefined && work > maxWork) {
       throw new ExecutionLimitError(
@@ -541,6 +554,7 @@ function searchContentMultiline(
     maxWork?: number;
     maxMatches?: number;
     signal?: AbortSignal;
+    budget?: CommandExecutionBudget;
   },
 ): SearchResult {
   const {
@@ -562,11 +576,17 @@ function searchContentMultiline(
     maxWork,
     maxMatches,
     signal,
+    budget,
   } = options;
 
   let work = 0;
+  let sinceDeadlineCheck = 0;
   const chargeWork = (amount = 1): void => {
     if (signal?.aborted) throw new ExecutionAbortedError();
+    if (++sinceDeadlineCheck >= DEADLINE_CHECK_STRIDE) {
+      sinceDeadlineCheck = 0;
+      budget?.throwIfAborted("search");
+    }
     work += amount;
     if (maxWork !== undefined && work > maxWork) {
       throw new ExecutionLimitError(

--- a/packages/just-bash/src/commands/sed/sed.ts
+++ b/packages/just-bash/src/commands/sed/sed.ts
@@ -1,4 +1,8 @@
 import { decodeBytesToUtf8 } from "../../encoding.js";
+import {
+  type CommandExecutionBudget,
+  DEADLINE_CHECK_STRIDE,
+} from "../../execution-scope.js";
 import { sanitizeErrorMessage } from "../../fs/sanitize-error.js";
 import { ExecutionLimitError } from "../../interpreter/errors.js";
 import type { ExecutionLimits } from "../../limits.js";
@@ -78,6 +82,8 @@ interface ProcessContentOptions {
   cwd?: string;
   coverage?: FeatureCoverageWriter;
   requireDefenseContext?: boolean;
+  /** Shared accounting; supplies the wall-clock deadline during the line loop. */
+  executionScope?: CommandExecutionBudget;
 }
 
 async function processContent(
@@ -86,8 +92,15 @@ async function processContent(
   silent: boolean,
   options: ProcessContentOptions = {},
 ): Promise<{ output: string; exitCode?: number; errorMessage?: string }> {
-  const { limits, filename, fs, cwd, coverage, requireDefenseContext } =
-    options;
+  const {
+    limits,
+    filename,
+    fs,
+    cwd,
+    coverage,
+    requireDefenseContext,
+    executionScope,
+  } = options;
   assertDefenseContext(requireDefenseContext, "sed", "processing entry");
   const withDefenseContext = <T>(
     phase: string,
@@ -141,6 +154,9 @@ async function processContent(
     : undefined;
 
   for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+    if (lineIndex % DEADLINE_CHECK_STRIDE === 0) {
+      executionScope?.throwIfAborted("sed");
+    }
     const state: SedState = {
       ...createInitialState(totalLines, filename, rangeStates),
       patternSpace: lines[lineIndex],
@@ -507,6 +523,7 @@ export const sedCommand: RuntimeCommand = {
               cwd: ctx.cwd,
               coverage: ctx.coverage,
               requireDefenseContext: ctx.requireDefenseContext,
+              executionScope: ctx.executionScope,
             }),
           );
           if (result.errorMessage) {
@@ -556,6 +573,7 @@ export const sedCommand: RuntimeCommand = {
             cwd: ctx.cwd,
             coverage: ctx.coverage,
             requireDefenseContext: ctx.requireDefenseContext,
+            executionScope: ctx.executionScope,
           }),
         );
         // sed emits text; the pipeline handles encoding.
@@ -639,6 +657,7 @@ export const sedCommand: RuntimeCommand = {
           cwd: ctx.cwd,
           coverage: ctx.coverage,
           requireDefenseContext: ctx.requireDefenseContext,
+          executionScope: ctx.executionScope,
         }),
       );
       return {

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -361,7 +361,7 @@ export const yqCommand: RuntimeCommand = {
         env: ctx.env,
         coverage: ctx.coverage,
         requireDefenseContext: ctx.requireDefenseContext,
-        budget: { operations: 0, callDepth: 0 },
+        budget: { operations: 0, callDepth: 0, deadlineCheckAt: 0 },
       };
       const dataLimits = {
         maxDepth: ctx.limits.maxQueryDepth,

--- a/packages/just-bash/src/commands/yq/yq.ts
+++ b/packages/just-bash/src/commands/yq/yq.ts
@@ -362,6 +362,7 @@ export const yqCommand: RuntimeCommand = {
         coverage: ctx.coverage,
         requireDefenseContext: ctx.requireDefenseContext,
         budget: { operations: 0, callDepth: 0, deadlineCheckAt: 0 },
+        executionScope: ctx.executionScope,
       };
       const dataLimits = {
         maxDepth: ctx.limits.maxQueryDepth,

--- a/packages/just-bash/src/execution-scope.ts
+++ b/packages/just-bash/src/execution-scope.ts
@@ -35,6 +35,12 @@ export interface CommandExecutionBudget {
 }
 
 type Cleanup = () => void | Promise<void>;
+
+/**
+ * Rows between deadline checks inside a data command's row loop: bounds
+ * cancellation latency without putting a check on the hot path.
+ */
+export const DEADLINE_CHECK_STRIDE = 1024;
 const OUTPUT_RELEASE_AUTHORITY = Object.freeze(Object.create(null) as object);
 
 /**

--- a/packages/just-bash/src/security/limits/row-loop-deadline.test.ts
+++ b/packages/just-bash/src/security/limits/row-loop-deadline.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+function makeRows(count: number): string {
+  const rows: string[] = [];
+  for (let index = 0; index < count; index++) {
+    rows.push(
+      JSON.stringify({ id: index, name: `name-${index}`, value: index * 3 }),
+    );
+  }
+  return rows.join("\n");
+}
+
+const ROWS = makeRows(99000);
+
+function bashWithDeadline(maxExecutionTimeMs: number): Bash {
+  return new Bash({
+    files: { "/work/rows.jsonl": ROWS },
+    cwd: "/work",
+    executionLimits: { maxExecutionTimeMs },
+  });
+}
+
+describe("execution deadline inside data-command row loops", () => {
+  it.each([
+    ["grep", `grep -c 'name-1' /work/rows.jsonl`],
+    ["jq", `jq -s 'map(.value) | add' /work/rows.jsonl`],
+    [
+      "awk",
+      `awk '{ total += length($0) } END { print total }' /work/rows.jsonl`,
+    ],
+    ["sed", `sed 's/name/NAME/g' /work/rows.jsonl`],
+  ])(
+    "stops %s once the deadline passes",
+    async (_name, script) => {
+      const started = Date.now();
+      const result = await bashWithDeadline(25).exec(script);
+      const elapsed = Date.now() - started;
+
+      expect(result.exitCode).toBe(124);
+      expect(result.stderr).toContain("execution deadline");
+      expect(elapsed).toBeLessThan(2000);
+    },
+    60000,
+  );
+
+  it.each([
+    ["grep", `grep -c 'name-1' /work/rows.jsonl`],
+    ["jq", `jq -s 'map(.value) | add' /work/rows.jsonl`],
+    [
+      "awk",
+      `awk '{ total += length($0) } END { print total }' /work/rows.jsonl`,
+    ],
+    ["sed", `sed 's/name/NAME/g' /work/rows.jsonl`],
+  ])(
+    "leaves %s unaffected when the deadline is generous",
+    async (_name, script) => {
+      const result = await bashWithDeadline(600000).exec(script);
+
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    },
+    60000,
+  );
+});

--- a/packages/just-bash/src/security/limits/row-loop-deadline.test.ts
+++ b/packages/just-bash/src/security/limits/row-loop-deadline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
 
 function makeRows(count: number): string {
@@ -59,6 +59,50 @@ describe("execution deadline inside data-command row loops", () => {
 
       expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(0);
+    },
+    60000,
+  );
+
+  // No input file: loading ROWS alone can outlast a 25ms deadline, which would
+  // trip the statement-level check before evaluation starts.
+  const HEAVY_REDUCE = `reduce range(0; 300000) as $i (0; . + ($i | tostring | length))`;
+  const queryBash = () =>
+    new Bash({ executionLimits: { maxExecutionTimeMs: 25 } });
+
+  // Cold module loading alone can spend the 25ms before evaluation starts.
+  beforeAll(async () => {
+    await new Bash().exec("jq -n 1; yq -n 1");
+  });
+
+  it.each([
+    ["jq", `jq -n '${HEAVY_REDUCE}'`],
+    ["yq", `yq -n '${HEAVY_REDUCE}'`],
+  ])(
+    "stops %s query evaluation once the deadline passes",
+    async (_name, script) => {
+      const result = await queryBash().exec(script);
+
+      expect(result.exitCode).toBe(124);
+      expect(result.stderr).toContain(
+        "query evaluation exceeded execution deadline",
+      );
+    },
+    60000,
+  );
+
+  it.each([
+    ["try/catch", `jq -n 'try (${HEAVY_REDUCE}) catch "swallowed"'`],
+    ["?", `jq -n '(${HEAVY_REDUCE})?'`],
+  ])(
+    "does not let jq %s suppress the deadline",
+    async (_name, script) => {
+      const result = await queryBash().exec(script);
+
+      expect(result.exitCode).toBe(124);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(
+        "query evaluation exceeded execution deadline",
+      );
     },
     60000,
   );


### PR DESCRIPTION
### Summary

`maxExecutionTimeMs` cannot bound a single data-processing statement. `ExecutionScope.throwIfAborted` is only reached at
statement boundaries (`chargeCommand` → `consume` → `assertUsable`), so a
`grep`/`jq`/`awk`/`sed` scan over a large input runs to completion and *then*
reports exit 124 — the deadline discards the result after paying its full
wall-clock cost rather than stopping the work.

This adds the deadline check inside the record loops themselves, strided so it
stays off the hot path.

### How we hit it

We embed just-bash as the sandboxed tool surface for an LLM agent in a
production Node service. The agent writes its own pipelines, so an oversized
input or an accidentally quadratic one-liner is routine rather than
exceptional, and `maxExecutionTimeMs` is our backstop for keeping one agent
turn from monopolising the event loop. It turned out not to be one.

Repro on `main` (`c9bd93e`), 300k-row JSONL:

```js
const bash = new Bash({
  files: { "/work/big.jsonl": rows },   // 300k JSON objects
  cwd: "/work",
  executionLimits: { maxExecutionTimeMs: 200 },
});
await bash.exec(`sed 's/name/NAME/g' /work/big.jsonl | tail -1`);
// → exitCode 124, "exceeded execution deadline (200ms)" … after 7.5 seconds
```

Same shape for `jq -s`, `grep -c`, `awk`. We also saw the fully silent case: `wc -l` over the same input with a 50ms
deadline returns **exit 0** after 196ms, because nothing charges the scope
after the command finishes.

### What changed

The record loops now consult the execution scope directly:

| site | file | granularity |
|---|---|---|
| `awk` | `commands/awk/interpreter/interpreter.ts` | per input record |
| `sed` | `commands/sed/sed.ts` | per pattern-space line |
| `jq`, `yq` | `commands/query-engine/evaluator.ts` (`chargeQueryWork`) | per evaluation op |
| `grep`, `rg` | `commands/search-engine/matcher.ts` (`chargeWork`) | per work unit |
| `grep` prefilter miss | `commands/grep/grep.ts` | once per file |

The query evaluator's `try`/`catch`, `?` and comma recovery paths previously
rethrew only `ExecutionLimitError`; they now go through
`rethrowFatalExecutionError`, so a filter cannot convert the deadline abort
into a value and buy itself another stride.

`executionScope` is threaded to the two interpreters that did not already
receive it (awk's runtime context, sed's `processContent` options); `grep` and
`rg` pass `ctx.executionScope` into `SearchOptions.budget`.

Checks are strided by `DEADLINE_CHECK_STRIDE` (1024, exported from
`execution-scope.ts`), so cancellation latency is bounded by 1024 rows rather
than by the length of the whole scan. The stride reuses a counter each loop
already maintains — `recordsProcessed` in awk, `lineIndex` in sed,
`budget.operations` in the query evaluator, a local in the search matcher — so
the added per-row work is one integer compare against a local or an
already-loaded field, **not** a call through the `CommandExecutionBudget`
facade. `QueryEvaluationBudget` gains a `deadlineCheckAt` field for this.

This is deliberately the cheap shape. An earlier revision of this patch called
a new `budget.checkpoint()` method per row instead, and that cost **+28–62% on
`grep`** — the facade call appears to make `chargeWork` non-inlinable and
deoptimise the surrounding loop. Given #218 and #248 went to some trouble on
exactly these loops, the stride is the point, not an optimisation detail.

### Effect

Time to actually stop, 300k-row JSONL, `maxExecutionTimeMs: 50`. (~200ms of
each figure is fixed VFS setup before the command runs, so ~200ms is the floor
this harness can show.)

| command | `main` | this PR |
|---|---|---|
| `sed 's/name/NAME/g'` | 7463ms | **216ms** |
| `rg -c` | 2595ms (exit 126, work limit — not the deadline) | **290ms** |
| `awk '{ t += length($0) }'` | 1100ms | **538ms** |
| `jq -s 'map(.value) \| add'` | 812ms | 703ms |
| `grep -c` | 775ms | **210ms** |

### Performance

No measurable regression. 99k-row JSONL, 7 runs per cell, `main` and this
branch **interleaved over 3 rounds** on the same machine to cancel thermal
drift (an earlier non-interleaved run showed baseline itself drifting ~4%,
which is why the numbers below are averaged across rounds):

| command | `main` min / p50 | this PR min / p50 | delta |
|---|---|---|---|
| `grep -c` | 97.7 / 101.7ms | 98.7 / 102.7ms | +1.0% |
| `jq -s` | 199.0 / 202.7ms | 198.0 / 203.7ms | −0.5% / +0.5% |
| `awk` | 629.7 / 639.0ms | 630.7 / 638.0ms | +0.2% / −0.2% |
| `sed` | 2826 / 2878ms | 2786 / 2836ms | −1.4% / −1.5% |

`grep` is the only consistent signal at +1.0% (99/98/99 vs 97/99/97 across
rounds); the rest are inside run-to-run noise.

### Tests

`src/security/limits/row-loop-deadline.test.ts` — for each of grep/jq/awk/sed
over 99k rows: a 25ms deadline yields exit 124 with `execution deadline` in
stderr and returns in under 2s, and a 600s deadline leaves exit code and
stderr untouched. The second half is the regression guard against a stride
that checks too eagerly. Two more groups on a file-less `Bash`: jq and yq each
stop a heavy `reduce` mid-evaluation with the evaluator's own deadline message
(the yq case fails without the `executionScope` wiring), and jq `try … catch`
and `?` around the same `reduce` still exit 124 with empty stdout.

Full suite: `pnpm lint`, `pnpm knip`, `tsc --noEmit`, and `pnpm test:run`
(15467 passed). One pre-existing failure, `src/package-contents.test.ts`,
which shells out to `npm pack` and is refused by the `packageManager` field —
it fails identically on unmodified `main` in this environment.

### Not covered

Deliberately out of scope, happy to fold any of these in if you'd prefer them
together:

- **`ExecOptions.signal`.** The loops are synchronous and never yield, so an
  `AbortController` fired from a host timer is still only observed once the
  command returns. Only the wall-clock deadline — a `Date.now()` poll — can
  fire mid-scan. Making `signal` interrupt a scan means yielding to the event
  loop inside these loops, which is an async refactor of sed/awk rather than a
  checkpoint.

- **Input ingestion.** The row loops are bounded but the phase that *builds*
  the rows is not — `jq -s` parsing 300k JSON documents and awk's record
  split both run before any row loop, which is why those two improve least
  above.
- **Sub-record pathologies.** One awk rule with a long inner `while`, or one
  catastrophic regex, is still a single uninterruptible unit.
- **`sort`.** The comparator runs inside `Array.prototype.sort`; that is the
  hottest path in the repo and I did not want to put a branch in it without
  discussing the tradeoff first.
- **Other whole-content passes** measured still overrunning at 50ms:
  `xan slice` 3303ms, `tr` 1588ms, `rev` 592ms. Each is a single pass with no
  row loop to hook, so each needs its own chunked check (~5–10 LOC apiece).

If you would rather see the deadline become a documented
best-effort/statement-boundary guarantee than have these checks added, that is
a reasonable call too — but the current docs for `signal` read as a stronger
promise than the implementation makes.



🤖 Generated with [Claude Code](https://claude.com/claude-code)

