### PR TITLE
fix(fs): run lazy file providers in the defense-in-depth trusted scope

### DIFF
--- a/.changeset/lazy-provider-trusted-scope.md
+++ b/.changeset/lazy-provider-trusted-scope.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Run lazy file providers in the defense-in-depth trusted scope during materialization. Host-supplied providers doing real async I/O (`setTimeout`, `fetch`, `process.env`) previously tripped the blocked-globals traps when a script first read the file mid-exec, surfacing as a `SecurityViolationError` (formerly a silent empty read / ENOENT). Fixes #253.

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -303,11 +303,8 @@ export class InMemoryFs implements IFileSystem {
     path: string,
     entry: LazyFileEntry,
   ): Promise<FileEntry> {
-    // Lazy providers are host-supplied code, but materialization is triggered
-    // mid-script and inherits the defense-in-depth sandbox context. Real I/O
-    // (setTimeout, fetch/WeakRef, process.env) would trip the blocked-globals
-    // traps, so run the provider in a trusted scope like lazy command loading
-    // in registry.ts (see #253).
+    // Lazy providers are host-supplied; run them in the trusted scope so
+    // real async I/O doesn't trip the sandbox blocked-globals traps.
     const content = await DefenseInDepthBox.runTrustedAsync(async () =>
       entry.lazy(),
     );

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -3,6 +3,7 @@ import {
   unsafeBytesFromLatin1,
   utf8ByteLength,
 } from "../../encoding.js";
+import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
 import { fromBuffer, getEncoding, toBuffer } from "../encoding.js";
 import type {
   BufferEncoding,
@@ -302,7 +303,14 @@ export class InMemoryFs implements IFileSystem {
     path: string,
     entry: LazyFileEntry,
   ): Promise<FileEntry> {
-    const content = await entry.lazy();
+    // Lazy providers are host-supplied code, but materialization is triggered
+    // mid-script and inherits the defense-in-depth sandbox context. Real I/O
+    // (setTimeout, fetch/WeakRef, process.env) would trip the blocked-globals
+    // traps, so run the provider in a trusted scope like lazy command loading
+    // in registry.ts (see #253).
+    const content = await DefenseInDepthBox.runTrustedAsync(async () =>
+      entry.lazy(),
+    );
     const buffer =
       typeof content === "string" ? textEncoder.encode(content) : content;
     const materialized: FileEntry = {

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -303,8 +303,8 @@ export class InMemoryFs implements IFileSystem {
     path: string,
     entry: LazyFileEntry,
   ): Promise<FileEntry> {
-    // Lazy providers are host-supplied; run them in the trusted scope so
-    // real async I/O doesn't trip the sandbox blocked-globals traps.
+    // Providers are host-supplied code; without the trusted scope, real
+    // async I/O would trip the sandbox blocked-globals traps.
     const content = await DefenseInDepthBox.runTrustedAsync(async () =>
       entry.lazy(),
     );

--- a/packages/just-bash/src/fs/in-memory-fs/lazy-provider-defense.test.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/lazy-provider-defense.test.ts
@@ -1,10 +1,17 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { Bash } from "../../Bash.js";
-import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
+import { defineCommand } from "../../custom-commands.js";
+import {
+  DefenseInDepthBox,
+  SecurityViolationError,
+} from "../../security/defense-in-depth-box.js";
 import { InMemoryFs } from "./in-memory-fs.js";
 
 describe("lazy provider under defense-in-depth (#253)", () => {
-  afterEach(() => DefenseInDepthBox.resetInstance());
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    DefenseInDepthBox.resetInstance();
+  });
 
   it("materializes a provider that settles on a macrotask during exec", async () => {
     const bash = new Bash({
@@ -25,39 +32,51 @@ describe("lazy provider under defense-in-depth (#253)", () => {
   });
 
   it("materializes a provider that reads process.env during exec", async () => {
-    process.env.JUST_BASH_LAZY_TEST = "FROM_ENV";
-    try {
-      const bash = new Bash({
-        defenseInDepth: true,
-        files: {
-          "/env.md": async () => {
-            await new Promise((resolve) => setTimeout(resolve, 0));
-            return process.env.JUST_BASH_LAZY_TEST ?? "";
-          },
-        },
-      });
+    vi.stubEnv("JUST_BASH_LAZY_TEST", "FROM_ENV");
+    const bash = new Bash({
+      defenseInDepth: true,
+      files: {
+        "/env.md": async () => process.env.JUST_BASH_LAZY_TEST ?? "",
+      },
+    });
 
-      const result = await bash.exec("cat /env.md");
+    const result = await bash.exec("cat /env.md");
 
-      expect(result.stderr).toBe("");
-      expect(result.stdout).toBe("FROM_ENV");
-    } finally {
-      delete process.env.JUST_BASH_LAZY_TEST;
-    }
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("FROM_ENV");
   });
 
-  it("does not leave the trusted scope active after materialization", async () => {
+  it("keeps untrusted command execution blocked after materialization", async () => {
+    const probe = defineCommand(
+      "probe",
+      async () => {
+        try {
+          new Function("return 1");
+          return { stdout: "unblocked\n", stderr: "", exitCode: 0 };
+        } catch (error) {
+          if (error instanceof SecurityViolationError) {
+            return { stdout: "blocked\n", stderr: "", exitCode: 0 };
+          }
+          throw error;
+        }
+      },
+      { trusted: false },
+    );
     const fs = new InMemoryFs();
     fs.writeFileLazy("/late.md", async () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
       return "LATE";
     });
-    const bash = new Bash({ defenseInDepth: true, fs });
+    const bash = new Bash({
+      defenseInDepth: true,
+      fs,
+      customCommands: [probe],
+    });
 
-    const first = await bash.exec("cat /late.md");
-    expect(first.stdout).toBe("LATE");
+    const result = await bash.exec("cat /late.md && probe");
 
-    const box = DefenseInDepthBox.getInstance(true);
-    expect(box.getStats().refCount).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("LATEblocked\n");
+    expect(result.exitCode).toBe(0);
   });
 });

--- a/packages/just-bash/src/fs/in-memory-fs/lazy-provider-defense.test.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/lazy-provider-defense.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
+import { InMemoryFs } from "./in-memory-fs.js";
+
+describe("lazy provider under defense-in-depth (#253)", () => {
+  afterEach(() => DefenseInDepthBox.resetInstance());
+
+  it("materializes a provider that settles on a macrotask during exec", async () => {
+    const bash = new Bash({
+      defenseInDepth: true,
+      files: {
+        "/async.md": async () => {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          return "ASYNC_RESOLVED";
+        },
+      },
+    });
+
+    const result = await bash.exec("cat /async.md");
+
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("ASYNC_RESOLVED");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("materializes a provider that reads process.env during exec", async () => {
+    process.env.JUST_BASH_LAZY_TEST = "FROM_ENV";
+    try {
+      const bash = new Bash({
+        defenseInDepth: true,
+        files: {
+          "/env.md": async () => {
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            return process.env.JUST_BASH_LAZY_TEST ?? "";
+          },
+        },
+      });
+
+      const result = await bash.exec("cat /env.md");
+
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("FROM_ENV");
+    } finally {
+      delete process.env.JUST_BASH_LAZY_TEST;
+    }
+  });
+
+  it("does not leave the trusted scope active after materialization", async () => {
+    const fs = new InMemoryFs();
+    fs.writeFileLazy("/late.md", async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      return "LATE";
+    });
+    const bash = new Bash({ defenseInDepth: true, fs });
+
+    const first = await bash.exec("cat /late.md");
+    expect(first.stdout).toBe("LATE");
+
+    const box = DefenseInDepthBox.getInstance(true);
+    expect(box.getStats().refCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #253.

`InMemoryFs.materializeLazy` invokes the host-supplied `LazyFileProvider` directly, so the call inherits the defense-in-depth sandbox `AsyncLocalStorage` context from the running script. A provider that performs real async I/O trips the blocked-globals traps:

- `setTimeout` → blocked (any macrotask-settling provider)
- `fetch` → blocked transitively via undici's `WeakRef` construction
- `process.env` reads (e.g. AWS SDK credential resolution) → blocked

The provider throws `SecurityViolationError`, the file is never materialized, and the script sees an empty read (on ≤3.0.x this was a silent `ENOENT`; current versions surface the violation on stderr — the message even says "indicates a bug in just-bash").

## Fix

Wrap the provider call in `DefenseInDepthBox.runTrustedAsync`. Lazy providers are host-authored code registered at construction time — the same trust position as:

- lazy command loading, already wrapped in `runTrustedAsync` (`commands/registry.ts`)
- host-provided custom commands, which are **trusted by default** per the `Command.trusted` doc ("Host-provided commands are trusted by default for compatibility")

so this aligns lazy providers with the library's existing trust model for host callbacks rather than introducing a new policy.

## Tests

New `lazy-provider-defense.test.ts` (fails 3/3 without the fix, passes with it):

- macrotask-settling provider (`await setTimeout`) materializes during `exec` with `defenseInDepth: true`
- provider reading `process.env` materializes during `exec`
- adversarial probe: an untrusted custom command (`trusted: false`) still hits the blocked-globals trap in the same `exec` after a lazy materialization ran in the trusted scope

`pnpm typecheck` clean, `biome check` clean, `src/fs/` + `src/security/` suites: no new failures (the js-exec/worker WASM suites fail identically on a clean `main` checkout without build artifacts).

Verification table from the issue (repro'd against this branch):

| provider | before | after |
|---|---|---|
| eager string | `EAGER` | `EAGER` |
| sync | `SYNC` | `SYNC` |
| microtask (`Promise.resolve`) | `MICROTASK_PROMISE` | `MICROTASK_PROMISE` |
| macrotask (`await setTimeout`) | `""` + violation | `ASYNC_RESOLVED` |
