### PR TITLE
fix(fs): require existing destination parents for cp and mv

### DIFF
--- a/.changeset/strict-destination-parents.md
+++ b/.changeset/strict-destination-parents.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Require `cp` and `mv` destination parent directories to exist, matching standard Unix utility behavior.

--- a/packages/just-bash/src/commands/cp/cp.destination-parent.test.ts
+++ b/packages/just-bash/src/commands/cp/cp.destination-parent.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+
+class PlainDestinationErrorFs extends InMemoryFs {
+  override async cp(): Promise<void> {
+    throw new Error("ENOENT: no such file or directory, cp destination");
+  }
+}
+
+describe("cp destination parents", () => {
+  it("rejects a missing destination parent without creating it", async () => {
+    const env = new Bash({
+      files: { "/work/source.txt": "content" },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("cp source.txt missing/copied.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create regular file 'missing/copied.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+    expect((await env.exec("test -e /work/missing")).exitCode).toBe(1);
+  });
+
+  it("rejects a missing destination parent for recursive copies", async () => {
+    const env = new Bash({
+      files: { "/work/source/file.txt": "content" },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("cp -r source missing/copied");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create directory 'missing/copied': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source/file.txt")).toBe("content");
+    expect((await env.exec("test -e /work/missing")).exitCode).toBe(1);
+  });
+
+  it("rejects a destination parent that is not a directory", async () => {
+    const env = new Bash({
+      files: {
+        "/work/source.txt": "content",
+        "/work/not-a-directory": "content",
+      },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("cp source.txt not-a-directory/copied.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create regular file 'not-a-directory/copied.txt': Not a directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+  });
+
+  it("rejects a nested destination ancestor that is not a directory", async () => {
+    const env = new Bash({
+      files: {
+        "/work/source.txt": "content",
+        "/work/not-a-directory": "content",
+      },
+      cwd: "/work",
+    });
+
+    const result = await env.exec(
+      "cp source.txt not-a-directory/nested/copied.txt",
+    );
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create regular file 'not-a-directory/nested/copied.txt': Not a directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+  });
+
+  it("rejects missing destination components before resolving dot-dot", async () => {
+    const env = new Bash({
+      files: { "/work/source.txt": "content" },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("cp source.txt missing/../copied.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create regular file 'missing/../copied.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+    expect((await env.exec("test -e /work/copied.txt")).exitCode).toBe(1);
+  });
+
+  it("reports missing destination parents from custom filesystems", async () => {
+    const filesystem = new PlainDestinationErrorFs({
+      "/work/source.txt": "content",
+    });
+    const env = new Bash({ fs: filesystem, cwd: "/work" });
+
+    const result = await env.exec("cp source.txt missing/copied.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "cp: cannot create regular file 'missing/copied.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await filesystem.readFile("/work/source.txt")).toBe("content");
+  });
+});

--- a/packages/just-bash/src/commands/cp/cp.ts
+++ b/packages/just-bash/src/commands/cp/cp.ts
@@ -1,3 +1,7 @@
+import {
+  assertDestinationParentDirectory,
+  DestinationParentError,
+} from "../../fs/destination-parent.js";
 import { isSameOrDescendantPath } from "../../fs/path-utils.js";
 import {
   compareCanonicalContainment,
@@ -101,15 +105,22 @@ export const cpCommand: RuntimeCommand = {
     }
 
     for (const src of sources) {
+      let sourceIsDirectory = false;
+      let targetDisplayPath = dest;
       try {
         const srcPath = ctx.fs.resolvePath(ctx.cwd, src);
         const srcStat = await ctx.fs.stat(srcPath);
+        sourceIsDirectory = srcStat.isDirectory;
 
         let targetPath = destPath;
         if (destIsDir) {
           const basename = src.split("/").pop() || src;
           targetPath =
             destPath === "/" ? `/${basename}` : `${destPath}/${basename}`;
+          targetDisplayPath =
+            dest === "/"
+              ? `/${basename}`
+              : `${dest}${dest.endsWith("/") ? "" : "/"}${basename}`;
         }
 
         if (srcStat.isDirectory && !recursive) {
@@ -138,6 +149,12 @@ export const cpCommand: RuntimeCommand = {
             continue;
           }
         }
+
+        await assertDestinationParentDirectory(
+          ctx.fs,
+          targetDisplayPath,
+          ctx.cwd,
+        );
 
         // A no-clobber skip performs no destructive operation and therefore
         // does not require proving the identity of the existing target.
@@ -196,11 +213,22 @@ export const cpCommand: RuntimeCommand = {
         ) {
           throw error;
         }
-        const message = getErrorMessage(error);
-        if (message.includes("ENOENT") || message.includes("no such file")) {
-          stderr += `cp: cannot stat '${src}': No such file or directory\n`;
+        if (error instanceof DestinationParentError) {
+          const destinationKind = sourceIsDirectory
+            ? "directory"
+            : "regular file";
+          const description =
+            error.code === "ENOENT"
+              ? "No such file or directory"
+              : "Not a directory";
+          stderr += `cp: cannot create ${destinationKind} '${targetDisplayPath}': ${description}\n`;
         } else {
-          stderr += `cp: cannot copy '${src}': ${message}\n`;
+          const message = getErrorMessage(error);
+          if (message.includes("ENOENT") || message.includes("no such file")) {
+            stderr += `cp: cannot stat '${src}': No such file or directory\n`;
+          } else {
+            stderr += `cp: cannot copy '${src}': ${message}\n`;
+          }
         }
         exitCode = 1;
       }

--- a/packages/just-bash/src/commands/mv/mv.destination-parent.test.ts
+++ b/packages/just-bash/src/commands/mv/mv.destination-parent.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+
+class PlainDestinationErrorFs extends InMemoryFs {
+  override async mv(): Promise<void> {
+    throw new Error("ENOENT: no such file or directory, mv destination");
+  }
+}
+
+describe("mv destination parents", () => {
+  it("rejects a missing destination parent without moving the source", async () => {
+    const env = new Bash({
+      files: { "/worldbanc/public/key.txt": "secret" },
+      cwd: "/worldbanc/public",
+    });
+
+    const result = await env.exec("mv key.txt worldbanc/key.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'key.txt' to 'worldbanc/key.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/worldbanc/public/key.txt")).toBe("secret");
+    expect(
+      (await env.exec("test -e /worldbanc/public/worldbanc")).exitCode,
+    ).toBe(1);
+  });
+
+  it("rejects a missing destination parent for directory moves", async () => {
+    const env = new Bash({
+      files: { "/work/source/file.txt": "content" },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("mv source missing/moved");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'source' to 'missing/moved': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source/file.txt")).toBe("content");
+    expect((await env.exec("test -e /work/missing")).exitCode).toBe(1);
+  });
+
+  it("rejects a destination parent that is not a directory", async () => {
+    const env = new Bash({
+      files: {
+        "/work/source.txt": "content",
+        "/work/not-a-directory": "content",
+      },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("mv source.txt not-a-directory/moved.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'source.txt' to 'not-a-directory/moved.txt': Not a directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+  });
+
+  it("rejects a nested destination ancestor that is not a directory", async () => {
+    const env = new Bash({
+      files: {
+        "/work/source.txt": "content",
+        "/work/not-a-directory": "content",
+      },
+      cwd: "/work",
+    });
+
+    const result = await env.exec(
+      "mv source.txt not-a-directory/nested/moved.txt",
+    );
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'source.txt' to 'not-a-directory/nested/moved.txt': Not a directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+  });
+
+  it("rejects missing destination components before resolving dot-dot", async () => {
+    const env = new Bash({
+      files: { "/work/source.txt": "content" },
+      cwd: "/work",
+    });
+
+    const result = await env.exec("mv source.txt missing/../moved.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'source.txt' to 'missing/../moved.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await env.readFile("/work/source.txt")).toBe("content");
+    expect((await env.exec("test -e /work/moved.txt")).exitCode).toBe(1);
+  });
+
+  it("reports missing destination parents from custom filesystems", async () => {
+    const filesystem = new PlainDestinationErrorFs({
+      "/work/source.txt": "content",
+    });
+    const env = new Bash({ fs: filesystem, cwd: "/work" });
+
+    const result = await env.exec("mv source.txt missing/moved.txt");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe(
+      "mv: cannot move 'source.txt' to 'missing/moved.txt': No such file or directory\n",
+    );
+    expect(result.exitCode).toBe(1);
+    expect(await filesystem.readFile("/work/source.txt")).toBe("content");
+  });
+});

--- a/packages/just-bash/src/commands/mv/mv.ts
+++ b/packages/just-bash/src/commands/mv/mv.ts
@@ -1,3 +1,7 @@
+import {
+  assertDestinationParentDirectory,
+  DestinationParentError,
+} from "../../fs/destination-parent.js";
 import { isSameOrDescendantPath } from "../../fs/path-utils.js";
 import {
   compareCanonicalContainment,
@@ -104,6 +108,7 @@ export const mvCommand: RuntimeCommand = {
     }
 
     for (const src of sources) {
+      let targetDisplayPath = dest;
       try {
         const srcPath = ctx.fs.resolvePath(ctx.cwd, src);
         const srcStat = await ctx.fs.stat(srcPath);
@@ -113,6 +118,10 @@ export const mvCommand: RuntimeCommand = {
           const basename = src.split("/").pop() || src;
           targetPath =
             destPath === "/" ? `/${basename}` : `${destPath}/${basename}`;
+          targetDisplayPath =
+            dest === "/"
+              ? `/${basename}`
+              : `${dest}${dest.endsWith("/") ? "" : "/"}${basename}`;
         }
         if (srcStat.isDirectory) {
           const containment = await compareCanonicalContainment(
@@ -135,6 +144,13 @@ export const mvCommand: RuntimeCommand = {
             continue;
           }
         }
+
+        await assertDestinationParentDirectory(
+          ctx.fs,
+          targetDisplayPath,
+          ctx.cwd,
+        );
+
         // A no-clobber skip performs no destructive operation and therefore
         // does not require proving the identity of the existing target.
         if (noClobber) {
@@ -186,11 +202,19 @@ export const mvCommand: RuntimeCommand = {
         ) {
           throw error;
         }
-        const message = getErrorMessage(error);
-        if (message.includes("ENOENT") || message.includes("no such file")) {
-          stderr += `mv: cannot stat '${src}': No such file or directory\n`;
+        if (error instanceof DestinationParentError) {
+          const description =
+            error.code === "ENOENT"
+              ? "No such file or directory"
+              : "Not a directory";
+          stderr += `mv: cannot move '${src}' to '${targetDisplayPath}': ${description}\n`;
         } else {
-          stderr += `mv: cannot move '${src}': ${message}\n`;
+          const message = getErrorMessage(error);
+          if (message.includes("ENOENT") || message.includes("no such file")) {
+            stderr += `mv: cannot stat '${src}': No such file or directory\n`;
+          } else {
+            stderr += `mv: cannot move '${src}': ${message}\n`;
+          }
         }
         exitCode = 1;
       }

--- a/packages/just-bash/src/comparison-tests/file-operations.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/file-operations.comparison.test.ts
@@ -170,6 +170,50 @@ describe("cp command - Real Bash Comparison", () => {
     expect(result.stdout).toContain("a.txt");
     expect(result.stdout).toContain("b.txt");
   });
+
+  it("should not create missing destination parents", async () => {
+    const env = await setupFiles(testDir, {
+      "source.txt": "content\n",
+    });
+
+    const envResult = await env.exec("cp source.txt missing/copied.txt");
+    const realResult = await runRealBash(
+      "cp source.txt missing/copied.txt",
+      testDir,
+    );
+
+    expect(envResult.exitCode).toBe(realResult.exitCode);
+    expect(envResult.exitCode).toBe(1);
+    expect(envResult.stderr).toContain("No such file or directory");
+    expect(realResult.stderr).toContain("No such file or directory");
+    expect(await env.readFile(path.join(testDir, "source.txt"))).toBe(
+      "content\n",
+    );
+
+    const envMissingParent = await env.exec("test -e missing");
+    const realMissingParent = await runRealBash("test -e missing", testDir);
+    expect(envMissingParent.exitCode).toBe(1);
+    expect(realMissingParent.exitCode).toBe(1);
+  });
+
+  it("should resolve dot-dot only after traversing the preceding destination component", async () => {
+    const env = await setupFiles(testDir, {
+      "source.txt": "content\n",
+    });
+
+    const envResult = await env.exec("cp source.txt missing/../copied.txt");
+    const realResult = await runRealBash(
+      "cp source.txt missing/../copied.txt",
+      testDir,
+    );
+
+    expect(envResult.exitCode).toBe(realResult.exitCode);
+    expect(envResult.exitCode).toBe(1);
+    expect(envResult.stderr).toContain("No such file or directory");
+    expect(realResult.stderr).toContain("No such file or directory");
+    expect((await env.exec("test -e copied.txt")).exitCode).toBe(1);
+    expect((await runRealBash("test -e copied.txt", testDir)).exitCode).toBe(1);
+  });
 });
 
 describe("mv command - Real Bash Comparison", () => {
@@ -236,6 +280,50 @@ describe("mv command - Real Bash Comparison", () => {
     expect(rootLs.stdout).not.toContain("b.txt");
     expect(dirLs.stdout).toContain("a.txt");
     expect(dirLs.stdout).toContain("b.txt");
+  });
+
+  it("should not create missing destination parents", async () => {
+    const env = await setupFiles(testDir, {
+      "source.txt": "content\n",
+    });
+
+    const envResult = await env.exec("mv source.txt missing/moved.txt");
+    const realResult = await runRealBash(
+      "mv source.txt missing/moved.txt",
+      testDir,
+    );
+
+    expect(envResult.exitCode).toBe(realResult.exitCode);
+    expect(envResult.exitCode).toBe(1);
+    expect(envResult.stderr).toContain("No such file or directory");
+    expect(realResult.stderr).toContain("No such file or directory");
+    expect(await env.readFile(path.join(testDir, "source.txt"))).toBe(
+      "content\n",
+    );
+
+    const envMissingParent = await env.exec("test -e missing");
+    const realMissingParent = await runRealBash("test -e missing", testDir);
+    expect(envMissingParent.exitCode).toBe(1);
+    expect(realMissingParent.exitCode).toBe(1);
+  });
+
+  it("should resolve dot-dot only after traversing the preceding destination component", async () => {
+    const env = await setupFiles(testDir, {
+      "source.txt": "content\n",
+    });
+
+    const envResult = await env.exec("mv source.txt missing/../moved.txt");
+    const realResult = await runRealBash(
+      "mv source.txt missing/../moved.txt",
+      testDir,
+    );
+
+    expect(envResult.exitCode).toBe(realResult.exitCode);
+    expect(envResult.exitCode).toBe(1);
+    expect(envResult.stderr).toContain("No such file or directory");
+    expect(realResult.stderr).toContain("No such file or directory");
+    expect((await env.exec("test -e moved.txt")).exitCode).toBe(1);
+    expect((await runRealBash("test -e moved.txt", testDir)).exitCode).toBe(1);
   });
 });
 

--- a/packages/just-bash/src/fs/cp-mv-destination-parent.test.ts
+++ b/packages/just-bash/src/fs/cp-mv-destination-parent.test.ts
@@ -1,0 +1,312 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { DestinationParentError } from "./destination-parent.js";
+import { InMemoryFs } from "./in-memory-fs/in-memory-fs.js";
+import type { IFileSystem } from "./interface.js";
+import { MountableFs } from "./mountable-fs/mountable-fs.js";
+import { OverlayFs } from "./overlay-fs/overlay-fs.js";
+import { normalizePath } from "./path-utils.js";
+import { ReadWriteFs } from "./read-write-fs/read-write-fs.js";
+
+interface FilesystemHarness {
+  filesystem: IFileSystem;
+  destinationParentPath: string;
+  cleanup: () => void;
+}
+
+interface FilesystemCase {
+  name: string;
+  createHarness: () => FilesystemHarness;
+}
+
+function createInitialFiles(rootPath: string): void {
+  fs.writeFileSync(path.join(rootPath, "source.txt"), "file content");
+  fs.writeFileSync(path.join(rootPath, "not-a-directory"), "blocking file");
+  fs.mkdirSync(path.join(rootPath, "source-directory"));
+  fs.writeFileSync(
+    path.join(rootPath, "source-directory", "nested.txt"),
+    "nested content",
+  );
+}
+
+function createHostFilesystemHarness(
+  filesystemVariant: "overlay" | "read-write",
+): FilesystemHarness {
+  const rootPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), `destination-parent-${filesystemVariant}-`),
+  );
+  createInitialFiles(rootPath);
+  const filesystem =
+    filesystemVariant === "overlay"
+      ? new OverlayFs({ root: rootPath, mountPoint: "/" })
+      : new ReadWriteFs({ root: rootPath });
+  return {
+    filesystem,
+    destinationParentPath: "/missing",
+    cleanup: () => fs.rmSync(rootPath, { recursive: true, force: true }),
+  };
+}
+
+const filesystemCases: FilesystemCase[] = [
+  {
+    name: "InMemoryFs",
+    createHarness: () => ({
+      filesystem: new InMemoryFs({
+        "/not-a-directory": "blocking file",
+        "/source.txt": "file content",
+        "/source-directory/nested.txt": "nested content",
+      }),
+      destinationParentPath: "/missing",
+      cleanup: () => undefined,
+    }),
+  },
+  {
+    name: "OverlayFs",
+    createHarness: () => createHostFilesystemHarness("overlay"),
+  },
+  {
+    name: "ReadWriteFs",
+    createHarness: () => createHostFilesystemHarness("read-write"),
+  },
+  {
+    name: "MountableFs same filesystem",
+    createHarness: () => ({
+      filesystem: new MountableFs({
+        base: new InMemoryFs({
+          "/not-a-directory": "blocking file",
+          "/source.txt": "file content",
+          "/source-directory/nested.txt": "nested content",
+        }),
+      }),
+      destinationParentPath: "/missing",
+      cleanup: () => undefined,
+    }),
+  },
+  {
+    name: "MountableFs cross filesystem",
+    createHarness: () => ({
+      filesystem: new MountableFs({
+        base: new InMemoryFs({
+          "/source.txt": "file content",
+          "/source-directory/nested.txt": "nested content",
+        }),
+        mounts: [
+          {
+            mountPoint: "/mnt",
+            filesystem: new InMemoryFs({
+              "/not-a-directory": "blocking file",
+            }),
+          },
+        ],
+      }),
+      destinationParentPath: "/mnt/missing",
+      cleanup: () => undefined,
+    }),
+  },
+];
+
+describe.each(
+  filesystemCases,
+)("$name destination parents", (filesystemCase) => {
+  let filesystemHarness: FilesystemHarness;
+
+  beforeEach(() => {
+    filesystemHarness = filesystemCase.createHarness();
+  });
+
+  afterEach(() => {
+    filesystemHarness.cleanup();
+  });
+
+  it("rejects copying a file without creating its destination parent", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/copied.txt`;
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(DestinationParentError);
+    expect(copyError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(
+        filesystemHarness.destinationParentPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects recursively copying a directory without creating its destination parent", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/copied-directory`;
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source-directory", destinationPath, { recursive: true })
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(DestinationParentError);
+    expect(copyError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(
+      await filesystemHarness.filesystem.exists("/source-directory/nested.txt"),
+    ).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(
+        filesystemHarness.destinationParentPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects moving a file without removing its source", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/moved.txt`;
+
+    const moveError = await filesystemHarness.filesystem
+      .mv("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(moveError).toBeInstanceOf(DestinationParentError);
+    expect(moveError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(
+        filesystemHarness.destinationParentPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects moving a directory without removing its source", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/moved-directory`;
+
+    const moveError = await filesystemHarness.filesystem
+      .mv("/source-directory", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(moveError).toBeInstanceOf(DestinationParentError);
+    expect(moveError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(
+      await filesystemHarness.filesystem.exists("/source-directory/nested.txt"),
+    ).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(
+        filesystemHarness.destinationParentPath,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects copying through a missing component followed by dot-dot", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/../copied.txt`;
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(DestinationParentError);
+    expect(copyError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(normalizePath(destinationPath)),
+    ).toBe(false);
+  });
+
+  it("rejects moving through a missing component followed by dot-dot", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/../moved.txt`;
+
+    const moveError = await filesystemHarness.filesystem
+      .mv("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(moveError).toBeInstanceOf(DestinationParentError);
+    expect(moveError).toMatchObject({ code: "ENOENT", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists(normalizePath(destinationPath)),
+    ).toBe(false);
+  });
+
+  it("rejects copying when the destination parent is not a directory", async () => {
+    const nonDirectoryParentPath =
+      filesystemHarness.destinationParentPath.replace(
+        "/missing",
+        "/not-a-directory",
+      );
+    const destinationPath = `${nonDirectoryParentPath}/nested/copied.txt`;
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(DestinationParentError);
+    expect(copyError).toMatchObject({ code: "ENOTDIR", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+  });
+
+  it("rejects moving when the destination parent is not a directory", async () => {
+    const nonDirectoryParentPath =
+      filesystemHarness.destinationParentPath.replace(
+        "/missing",
+        "/not-a-directory",
+      );
+    const destinationPath = `${nonDirectoryParentPath}/nested/moved.txt`;
+
+    const moveError = await filesystemHarness.filesystem
+      .mv("/source.txt", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(moveError).toBeInstanceOf(DestinationParentError);
+    expect(moveError).toMatchObject({ code: "ENOTDIR", destinationPath });
+    expect(await filesystemHarness.filesystem.exists("/source.txt")).toBe(true);
+  });
+
+  it("rejects a non-recursive directory copy before checking its destination parent", async () => {
+    const destinationPath = `${filesystemHarness.destinationParentPath}/copied-directory`;
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source-directory", destinationPath)
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(Error);
+    expect((copyError as Error).message).toContain("EISDIR");
+    expect(
+      await filesystemHarness.filesystem.exists("/source-directory/nested.txt"),
+    ).toBe(true);
+  });
+
+  it("rejects a recursive self-copy before checking its destination parent", async () => {
+    const destinationPath = "/source-directory/missing/copied-directory";
+
+    const copyError = await filesystemHarness.filesystem
+      .cp("/source-directory", destinationPath, { recursive: true })
+      .catch((error: unknown) => error);
+
+    expect(copyError).toBeInstanceOf(Error);
+    expect((copyError as Error).message).toContain("EINVAL");
+    expect(
+      await filesystemHarness.filesystem.exists("/source-directory/nested.txt"),
+    ).toBe(true);
+    expect(
+      await filesystemHarness.filesystem.exists("/source-directory/missing"),
+    ).toBe(false);
+  });
+
+  it("allows recursive copies to create the final destination directory", async () => {
+    const existingParentPath = filesystemHarness.destinationParentPath.replace(
+      "/missing",
+      "/existing",
+    );
+    await filesystemHarness.filesystem.mkdir(existingParentPath, {
+      recursive: true,
+    });
+    const destinationPath = `${existingParentPath}/copied-directory`;
+
+    await filesystemHarness.filesystem.cp(
+      "/source-directory",
+      destinationPath,
+      { recursive: true },
+    );
+
+    expect(
+      await filesystemHarness.filesystem.readFile(
+        `${destinationPath}/nested.txt`,
+      ),
+    ).toBe("nested content");
+  });
+});

--- a/packages/just-bash/src/fs/destination-parent.ts
+++ b/packages/just-bash/src/fs/destination-parent.ts
@@ -1,0 +1,132 @@
+import type { FsStat, IFileSystem } from "./interface.js";
+import { dirname, joinPath, normalizePath } from "./path-utils.js";
+
+type FileSystemErrorCode = "EACCES" | "ENOENT" | "ENOTDIR";
+
+export class DestinationParentError extends Error {
+  readonly code: "ENOENT" | "ENOTDIR";
+  readonly destinationPath: string;
+  readonly parentPath: string;
+
+  constructor(
+    code: "ENOENT" | "ENOTDIR",
+    destinationPath: string,
+    parentPath: string,
+  ) {
+    const description =
+      code === "ENOENT" ? "no such file or directory" : "not a directory";
+    super(`${code}: ${description}, destination parent '${parentPath}'`);
+    this.name = "DestinationParentError";
+    this.code = code;
+    this.destinationPath = destinationPath;
+    this.parentPath = parentPath;
+  }
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+  ) {
+    return error.code;
+  }
+  return undefined;
+}
+
+function errorHasCode(error: unknown, code: FileSystemErrorCode): boolean {
+  if (getErrorCode(error) === code) return true;
+  if (!(error instanceof Error)) return false;
+  const virtualErrorMessage = error.message;
+  return virtualErrorMessage.startsWith(`${code}:`);
+}
+
+async function classifyParentLookupFailure(
+  filesystem: Pick<IFileSystem, "stat">,
+  parentPath: string,
+  missingParentKnown: boolean,
+): Promise<"ENOENT" | "ENOTDIR" | undefined> {
+  let ancestorPath = dirname(parentPath);
+
+  while (true) {
+    try {
+      const ancestorStat = await filesystem.stat(ancestorPath);
+      if (!ancestorStat.isDirectory) return "ENOTDIR";
+      return missingParentKnown ? "ENOENT" : undefined;
+    } catch (error) {
+      if (errorHasCode(error, "ENOTDIR")) return "ENOTDIR";
+      if (!errorHasCode(error, "ENOENT") && !errorHasCode(error, "EACCES")) {
+        throw error;
+      }
+    }
+
+    if (ancestorPath === "/") {
+      return missingParentKnown ? "ENOENT" : undefined;
+    }
+    ancestorPath = dirname(ancestorPath);
+  }
+}
+
+export async function assertDestinationParentDirectory(
+  filesystem: Pick<IFileSystem, "stat">,
+  destinationPath: string,
+  basePath = "/",
+): Promise<void> {
+  const normalizedBasePath = normalizePath(basePath);
+  const pathComponents = destinationPath.split("/").filter(Boolean);
+  const parentComponents = pathComponents.slice(0, -1);
+  const resolvedComponents = destinationPath.startsWith("/")
+    ? []
+    : normalizedBasePath.split("/").filter(Boolean);
+
+  for (const component of parentComponents) {
+    if (component === ".") continue;
+    if (component === "..") {
+      resolvedComponents.pop();
+      continue;
+    }
+    resolvedComponents.push(component);
+    const traversedParentPath = `/${resolvedComponents.join("/")}`;
+    await assertDirectoryPath(filesystem, destinationPath, traversedParentPath);
+  }
+
+  const absoluteDestinationPath = destinationPath.startsWith("/")
+    ? destinationPath
+    : joinPath(normalizedBasePath, destinationPath);
+  await assertDirectoryPath(
+    filesystem,
+    destinationPath,
+    dirname(absoluteDestinationPath),
+  );
+}
+
+async function assertDirectoryPath(
+  filesystem: Pick<IFileSystem, "stat">,
+  destinationPath: string,
+  parentPath: string,
+): Promise<void> {
+  let parentStat: FsStat;
+  try {
+    parentStat = await filesystem.stat(parentPath);
+  } catch (error) {
+    const missingParentKnown = errorHasCode(error, "ENOENT");
+    if (missingParentKnown || errorHasCode(error, "EACCES")) {
+      const code = await classifyParentLookupFailure(
+        filesystem,
+        parentPath,
+        missingParentKnown,
+      );
+      if (!code) throw error;
+      throw new DestinationParentError(code, destinationPath, parentPath);
+    }
+    if (errorHasCode(error, "ENOTDIR")) {
+      throw new DestinationParentError("ENOTDIR", destinationPath, parentPath);
+    }
+    throw error;
+  }
+
+  if (!parentStat.isDirectory) {
+    throw new DestinationParentError("ENOTDIR", destinationPath, parentPath);
+  }
+}

--- a/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
+++ b/packages/just-bash/src/fs/in-memory-fs/in-memory-fs.ts
@@ -4,6 +4,7 @@ import {
   utf8ByteLength,
 } from "../../encoding.js";
 import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
+import { assertDestinationParentDirectory } from "../destination-parent.js";
 import { fromBuffer, getEncoding, toBuffer } from "../encoding.js";
 import type {
   BufferEncoding,
@@ -756,8 +757,18 @@ export class InMemoryFs implements IFileSystem {
       throw new Error(`ENOENT: no such file or directory, cp '${src}'`);
     }
 
+    if (srcEntry.type === "directory") {
+      if (!options?.recursive) {
+        throw new Error(`EISDIR: is a directory, cp '${src}'`);
+      }
+      if (isSameOrDescendantPath(srcNorm, destNorm)) {
+        throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
+      }
+    }
+
+    await assertDestinationParentDirectory(this, dest);
+
     if (srcEntry.type === "file") {
-      this.ensureParentDirs(destNorm);
       // Deep copy: create a new Uint8Array to avoid sharing the buffer reference
       if ("content" in srcEntry) {
         const sourceBytes =
@@ -776,15 +787,8 @@ export class InMemoryFs implements IFileSystem {
       }
     } else if (srcEntry.type === "symlink") {
       // Copy the symlink itself (not its target)
-      this.ensureParentDirs(destNorm);
       this.data.set(destNorm, { ...srcEntry });
     } else if (srcEntry.type === "directory") {
-      if (!options?.recursive) {
-        throw new Error(`EISDIR: is a directory, cp '${src}'`);
-      }
-      if (isSameOrDescendantPath(srcNorm, destNorm)) {
-        throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
-      }
       await this.mkdir(destNorm, { recursive: true });
       const children = await this.readdir(srcNorm);
       for (const child of children) {
@@ -813,6 +817,8 @@ export class InMemoryFs implements IFileSystem {
       throw new Error(`EINVAL: cannot move '${src}' into itself, '${dest}'`);
     }
 
+    await assertDestinationParentDirectory(this, dest);
+
     if (source.type === "directory") {
       await this.mkdir(destNorm, { recursive: true });
       const children = await this.readdir(srcNorm);
@@ -823,7 +829,6 @@ export class InMemoryFs implements IFileSystem {
       return;
     }
 
-    this.ensureParentDirs(destNorm);
     // Reuse the same body while the old path still retains it. The accounting
     // helper therefore sees an existing reference and a rename never needs
     // temporary capacity equal to the file size.

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -216,12 +216,13 @@ export interface IFileSystem {
 
   /**
    * Copy a file or directory
-   * @throws Error if source doesn't exist or trying to copy directory without recursive
+   * @throws Error if the source or destination parent doesn't exist, the destination parent isn't a directory, or trying to copy directory without recursive
    */
   cp(src: string, dest: string, options?: CpOptions): Promise<void>;
 
   /**
    * Move/rename a file or directory
+   * @throws Error if the source or destination parent doesn't exist or the destination parent isn't a directory
    */
   mv(src: string, dest: string): Promise<void>;
 

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -344,6 +344,19 @@ describe("MountableFs", () => {
       const content = await mounted.readFile("/dest.txt");
       expect(content).toBe("content");
     });
+
+    it("should copy into a synthetic mount parent on the base filesystem", async () => {
+      const baseFilesystem = new InMemoryFs({ "/src.txt": "content" });
+      const mountableFilesystem = new MountableFs({ base: baseFilesystem });
+      mountableFilesystem.mount("/mnt/data", new InMemoryFs());
+
+      await mountableFilesystem.cp("/src.txt", "/mnt/copied.txt");
+
+      expect(await baseFilesystem.readFile("/mnt/copied.txt")).toBe("content");
+      expect((await mountableFilesystem.stat("/mnt/data")).isDirectory).toBe(
+        true,
+      );
+    });
   });
 
   describe("cross-mount move", () => {
@@ -379,6 +392,20 @@ describe("MountableFs", () => {
 
       expect(await mounted.readFile("/dest.txt")).toBe("content");
       expect(await mounted.exists("/src.txt")).toBe(false);
+    });
+
+    it("should move into a synthetic mount parent on the base filesystem", async () => {
+      const baseFilesystem = new InMemoryFs({ "/src.txt": "content" });
+      const mountableFilesystem = new MountableFs({ base: baseFilesystem });
+      mountableFilesystem.mount("/mnt/data", new InMemoryFs());
+
+      await mountableFilesystem.mv("/src.txt", "/mnt/moved.txt");
+
+      expect(await baseFilesystem.readFile("/mnt/moved.txt")).toBe("content");
+      expect(await baseFilesystem.exists("/src.txt")).toBe(false);
+      expect((await mountableFilesystem.stat("/mnt/data")).isDirectory).toBe(
+        true,
+      );
     });
   });
 

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -1,4 +1,5 @@
 import { type ByteString, readBytesFrom } from "../../encoding.js";
+import { assertDestinationParentDirectory } from "../destination-parent.js";
 import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
 import type {
   BufferEncoding,
@@ -13,6 +14,7 @@ import type {
 } from "../interface.js";
 import {
   DEFAULT_DIR_MODE,
+  dirname,
   isSameOrDescendantPath,
   joinPath,
   normalizePath,
@@ -241,6 +243,18 @@ export class MountableFs implements IFileSystem {
     }
 
     return children;
+  }
+
+  private async materializeSyntheticDestinationParent(
+    destinationPath: string,
+    destinationRoute: { fs: IFileSystem; relativePath: string },
+  ): Promise<void> {
+    const destinationParentPath = dirname(destinationPath);
+    if (this.getChildMountPoints(destinationParentPath).length === 0) return;
+
+    await destinationRoute.fs.mkdir(dirname(destinationRoute.relativePath), {
+      recursive: true,
+    });
   }
 
   // ==================== IFileSystem Implementation ====================
@@ -473,11 +487,18 @@ export class MountableFs implements IFileSystem {
 
   async cp(src: string, dest: string, options?: CpOptions): Promise<void> {
     const srcStat = await this.stat(src);
-    if (srcStat.isDirectory && isSameOrDescendantPath(src, dest)) {
-      throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
+    if (srcStat.isDirectory) {
+      if (!options?.recursive) {
+        throw new Error(`EISDIR: is a directory, cp '${src}'`);
+      }
+      if (isSameOrDescendantPath(src, dest)) {
+        throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
+      }
     }
+    await assertDestinationParentDirectory(this, dest);
     const srcRoute = this.routePath(src);
     const destRoute = this.routePath(dest);
+    await this.materializeSyntheticDestinationParent(dest, destRoute);
 
     // If same filesystem, delegate directly
     if (srcRoute.fs === destRoute.fs) {
@@ -504,8 +525,10 @@ export class MountableFs implements IFileSystem {
       throw new Error(`EBUSY: mount point, cannot move '${src}'`);
     }
 
+    await assertDestinationParentDirectory(this, dest);
     const srcRoute = this.routePath(src);
     const destRoute = this.routePath(dest);
+    await this.materializeSyntheticDestinationParent(dest, destRoute);
 
     // If same filesystem, delegate directly
     if (srcRoute.fs === destRoute.fs) {
@@ -645,7 +668,7 @@ export class MountableFs implements IFileSystem {
       await this.chmod(dest, srcStat.mode);
     } else if (srcStat.isDirectory) {
       if (!options?.recursive) {
-        throw new Error(`cp: ${src} is a directory (not copied)`);
+        throw new Error(`EISDIR: is a directory, cp '${src}'`);
       }
       await this.mkdir(dest, { recursive: true });
       const children = await this.readdir(src);

--- a/packages/just-bash/src/fs/overlay-fs/overlay-fs.ts
+++ b/packages/just-bash/src/fs/overlay-fs/overlay-fs.ts
@@ -14,6 +14,7 @@
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import { type ByteString, unsafeBytesFromLatin1 } from "../../encoding.js";
+import { assertDestinationParentDirectory } from "../destination-parent.js";
 import {
   type FileContent,
   fromBuffer,
@@ -1135,6 +1136,7 @@ export class OverlayFs implements IFileSystem {
 
     if (srcStat.isFile) {
       const content = await this.readFileBuffer(srcNorm);
+      await assertDestinationParentDirectory(this, dest);
       await this.writeFile(destNorm, content);
     } else if (srcStat.isDirectory) {
       if (!options?.recursive) {
@@ -1143,6 +1145,7 @@ export class OverlayFs implements IFileSystem {
       if (isSameOrDescendantPath(srcNorm, destNorm)) {
         throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
       }
+      await assertDestinationParentDirectory(this, dest);
       await this.mkdir(destNorm, { recursive: true });
       const children = await this.readdir(srcNorm);
       for (const child of children) {

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.copy-hardening.test.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.copy-hardening.test.ts
@@ -41,6 +41,7 @@ describe("ReadWriteFs recursive copy and append hardening", () => {
     fs.writeFileSync(path.join(sandboxDir, "target.txt"), "content");
     const rwfs = new ReadWriteFs({ root: sandboxDir, allowSymlinks: true });
     await rwfs.symlink("/target.txt", "/source/link.txt");
+    fs.mkdirSync(path.join(sandboxDir, "deep/nested"), { recursive: true });
 
     await rwfs.cp("/source/link.txt", "/deep/nested/link.txt");
 
@@ -66,6 +67,7 @@ describe("ReadWriteFs recursive copy and append hardening", () => {
       path.join(rootAlias, "target.txt"),
       path.join(realRoot, "source/link.txt"),
     );
+    fs.mkdirSync(path.join(realRoot, "copied"));
     const rwfs = new ReadWriteFs({ root: rootAlias, allowSymlinks: true });
 
     await rwfs.cp("/source/link.txt", "/copied/link.txt");
@@ -77,20 +79,21 @@ describe("ReadWriteFs recursive copy and append hardening", () => {
     expect(fs.readFileSync(copied, "utf8")).toBe("content");
   });
 
-  it("preserves a relative symlink target when copying to a missing parent", async () => {
+  it("preserves a relative symlink target when copying to an existing parent", async () => {
     fs.mkdirSync(path.join(sandboxDir, "source"));
+    fs.mkdirSync(path.join(sandboxDir, "destination"));
     fs.writeFileSync(path.join(sandboxDir, "source/target.txt"), "content");
     fs.symlinkSync("target.txt", path.join(sandboxDir, "source/link.txt"));
     const rwfs = new ReadWriteFs({ root: sandboxDir, allowSymlinks: true });
 
-    await rwfs.cp("/source/link.txt", "/missing/parent/link.txt");
+    await rwfs.cp("/source/link.txt", "/destination/link.txt");
 
-    expect(
-      fs.readlinkSync(path.join(sandboxDir, "missing/parent/link.txt")),
-    ).toBe("target.txt");
+    expect(fs.readlinkSync(path.join(sandboxDir, "destination/link.txt"))).toBe(
+      "target.txt",
+    );
     expect(
       fs
-        .lstatSync(path.join(sandboxDir, "missing/parent/link.txt"))
+        .lstatSync(path.join(sandboxDir, "destination/link.txt"))
         .isSymbolicLink(),
     ).toBe(true);
   });

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.security.test.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.security.test.ts
@@ -187,10 +187,13 @@ describe("ReadWriteFs Security - Path Traversal Prevention", () => {
 
       // This should NOT write to the real outside path
       const targetPath = path.join(outsideDir, "stolen.txt");
-      await rwfs.cp("/source.txt", targetPath);
+      await expect(rwfs.cp("/source.txt", targetPath)).rejects.toThrow(
+        "ENOENT",
+      );
 
       // Real outside directory should not have the file
       expect(fs.existsSync(targetPath)).toBe(false);
+      expect(await rwfs.exists("/source.txt")).toBe(true);
     });
 
     it("should not move from outside root", async () => {
@@ -205,12 +208,15 @@ describe("ReadWriteFs Security - Path Traversal Prevention", () => {
       expect(await rwfs.exists("/to-move.txt")).toBe(true);
 
       const targetPath = path.join(outsideDir, "moved.txt");
-      // Note: mv to outside path maps to a deep nested path inside root
-      // which may fail with ENOENT if parent dirs don't exist
-      await rwfs.mv("/to-move.txt", targetPath);
+      // The absolute-looking destination is a virtual path inside the root,
+      // and its missing parent must not be created implicitly.
+      await expect(rwfs.mv("/to-move.txt", targetPath)).rejects.toThrow(
+        "ENOENT",
+      );
 
       // Real outside directory should not have the file
       expect(fs.existsSync(targetPath)).toBe(false);
+      expect(await rwfs.exists("/to-move.txt")).toBe(true);
     });
   });
 

--- a/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
+++ b/packages/just-bash/src/fs/read-write-fs/read-write-fs.ts
@@ -15,6 +15,7 @@ import { randomBytes } from "node:crypto";
 import * as fs from "node:fs";
 import * as nodePath from "node:path";
 import { type ByteString, unsafeBytesFromLatin1 } from "../../encoding.js";
+import { assertDestinationParentDirectory } from "../destination-parent.js";
 import {
   type FileContent,
   fromBuffer,
@@ -31,7 +32,10 @@ import type {
   RmOptions,
   WriteFileOptions,
 } from "../interface.js";
-import { resolvePath as resolveVPath } from "../path-utils.js";
+import {
+  isSameOrDescendantPath,
+  resolvePath as resolveVPath,
+} from "../path-utils.js";
 import {
   isPathWithinRoot,
   normalizePath,
@@ -765,7 +769,6 @@ export class ReadWriteFs implements IFileSystem {
     // cp operates on the source directory entry itself, including when it is
     // a symlink. Validate its parent without resolving the final component.
     const srcCanonical = this.validateParent(srcReal, src);
-    const destCanonical = this.resolveAndValidate(destReal, dest);
     let srcStat: fs.Stats;
     try {
       srcStat = await fs.promises.lstat(srcCanonical);
@@ -776,6 +779,19 @@ export class ReadWriteFs implements IFileSystem {
       }
       this.sanitizeError(e, src, "cp");
     }
+
+    if (srcStat.isDirectory()) {
+      if (!options?.recursive) {
+        throw new Error(`EISDIR: is a directory, cp '${src}'`);
+      }
+      if (isSameOrDescendantPath(src, dest)) {
+        throw new Error(`EINVAL: cannot copy '${src}' into itself, '${dest}'`);
+      }
+    }
+
+    await assertDestinationParentDirectory(this, dest);
+    const destCanonical = this.resolveAndValidate(destReal, dest);
+
     if (
       srcStat.isDirectory() &&
       isPathWithinRoot(destCanonical, srcCanonical)
@@ -815,20 +831,6 @@ export class ReadWriteFs implements IFileSystem {
       await this.preflightCopyTree(srcCanonical, src);
     } catch (e) {
       this.sanitizeError(e, src, "cp");
-    }
-
-    // Match fs.cp's behavior for a missing destination hierarchy. Validate
-    // again after creating it so the path used for replacement reflects the
-    // directory entries that now exist.
-    if (srcStat.isFile() || srcStat.isSymbolicLink()) {
-      try {
-        await fs.promises.mkdir(nodePath.dirname(destCanonical), {
-          recursive: true,
-        });
-        this.resolveAndValidate(destReal, dest);
-      } catch (e) {
-        this.sanitizeError(e, dest, "cp");
-      }
     }
 
     try {
@@ -913,7 +915,14 @@ export class ReadWriteFs implements IFileSystem {
         destinationReal,
         virtualDestination,
       );
-      await fs.promises.mkdir(destination, { recursive: true });
+      try {
+        await fs.promises.mkdir(destination);
+      } catch (e) {
+        const err = e as NodeJS.ErrnoException;
+        if (err.code !== "EEXIST") throw e;
+        const destinationStat = await fs.promises.stat(destination);
+        if (!destinationStat.isDirectory()) throw e;
+      }
       // A pre-existing child symlink, or a parent swap during mkdir, must not
       // redirect subsequent recursive entries outside the sandbox.
       destination = this.resolveAndValidate(
@@ -1108,7 +1117,6 @@ export class ReadWriteFs implements IFileSystem {
     // directory entries — it does NOT follow the final symlink component.
     // resolveAndValidate would resolve through symlinks, breaking symlink moves.
     const srcCanonical = this.validateParent(srcReal, src);
-    const destCanonical = this.validateParent(destReal, dest);
     let sourceStat: fs.Stats;
     try {
       sourceStat = await fs.promises.lstat(srcCanonical);
@@ -1119,6 +1127,13 @@ export class ReadWriteFs implements IFileSystem {
       }
       this.sanitizeError(e, src, "mv");
     }
+    if (sourceStat.isDirectory() && isSameOrDescendantPath(src, dest)) {
+      throw new Error(`EINVAL: cannot move '${src}' into itself, '${dest}'`);
+    }
+
+    await assertDestinationParentDirectory(this, dest);
+    const destCanonical = this.validateParent(destReal, dest);
+
     if (
       sourceStat.isDirectory() &&
       this.isSameOrDescendantIdentity(srcCanonical, destCanonical)
@@ -1157,14 +1172,6 @@ export class ReadWriteFs implements IFileSystem {
         throw e;
       }
       // For other errors, let the rename below handle it
-    }
-
-    // Ensure destination parent directory exists
-    const destDir = nodePath.dirname(destCanonical);
-    try {
-      await fs.promises.mkdir(destDir, { recursive: true });
-    } catch (e) {
-      this.sanitizeError(e, dest, "mv");
     }
 
     try {


### PR DESCRIPTION
## Summary

  - Stop `cp` and `mv` from implicitly creating missing destination parent directories.
  - Enforce the destination-parent invariant across `InMemoryFs`, `OverlayFs`, `ReadWriteFs`, and same- and cross-filesystem `MountableFs` operations.
  - Validate destination components before resolving `..`, matching standard filesystem traversal behavior.
  - Preflight destination parents in the command layer so custom `IFileSystem` implementations receive correct `ENOENT` and `ENOTDIR` diagnostics.
  - Preserve synthetic `MountableFs` parent directories when delegating operations to an underlying filesystem.
  - Preserve recursive `cp` behavior that creates the final destination directory when its parent already exists.
  - Add filesystem contract tests, command regressions, mount-namespace tests, and real-Bash comparison coverage.

  ## Context

  Standard `cp` and `mv` utilities fail when an intermediate destination directory does not exist. Previously, just-bash created that hierarchy automatically, which could make invalid
  shell commands succeed and, for `mv`, remove the source.

  Path normalization also allowed commands such as `cp source missing/../copied` to bypass the missing component. Destination errors from custom filesystems could consequently be
  attributed to the source, while synthetic `MountableFs` parents could be rejected by the underlying filesystem despite existing in the wrapper’s virtual namespace.

  This change validates the unnormalized destination traversal, standardizes command diagnostics through a filesystem preflight, and preserves valid synthetic mount parents during
  delegation.

  ## Testing

  - Focused destination-parent and mount regressions: 127 passed.
  - Filesystem, `cp`, and `mv` suites: 1,264 passed, 1 skipped.
  - Real-Bash file-operation comparisons: 23 passed.
  - Build, typecheck, `knip`, changeset validation, and worker synchronization passed.