### PR TITLE
perf(regex): cache compiled RE2 patterns across UserRegex constructions

### DIFF
--- a/.changeset/regex-compile-cache.md
+++ b/.changeset/regex-compile-cache.md
@@ -15,7 +15,8 @@ dominated these workloads.
 
 Compiled patterns are now memoized in a 256-entry cache keyed on the pattern and
 the RE2 flags, mirroring the existing glob regex cache in `src/utils/glob.ts`.
-Only the compiled pattern is shared — `lastIndex`, the reusable matcher, result
+Patterns longer than 1024 characters are compiled but not retained, bounding the
+cache's retained pattern source at 256 KiB. Only the compiled pattern is shared — `lastIndex`, the reusable matcher, result
 limits and the abort signal stay per-instance, so matching semantics are
 unchanged. Over 100k rows: jq `test()` 8.96s → 4.26s, awk `~` 4.15s → 2.55s,
 awk `gsub` 7.16s → 6.10s, sed `s///g` 10.46s → 8.29s. Commands that already

--- a/.changeset/regex-compile-cache.md
+++ b/.changeset/regex-compile-cache.md
@@ -1,0 +1,22 @@
+---
+"just-bash": patch
+---
+
+regex: cache compiled RE2 patterns across `UserRegex` constructions
+
+Every `createUserRegex()` call recompiled its pattern from source
+(`translateRegExp` → parse → simplify → compile). Commands that build a
+`UserRegex` inside a per-row loop therefore recompiled the same pattern once per
+row: jq's `test`/`match`/`capture`/`scan`/`splits`/`sub`/`gsub`, awk's `~`/`!~`
+and `sub`/`gsub`/`match`/`split`, and sed's `s///` (which compiled the same
+pattern twice per line for the `g` and Nth-occurrence paths). Compiling costs
+~23µs against ~1.5µs to match with an already-compiled pattern, so compilation
+dominated these workloads.
+
+Compiled patterns are now memoized in a 256-entry cache keyed on the pattern and
+the RE2 flags, mirroring the existing glob regex cache in `src/utils/glob.ts`.
+Only the compiled pattern is shared — `lastIndex`, the reusable matcher, result
+limits and the abort signal stay per-instance, so matching semantics are
+unchanged. Over 100k rows: jq `test()` 8.96s → 4.26s, awk `~` 4.15s → 2.55s,
+awk `gsub` 7.16s → 6.10s, sed `s///g` 10.46s → 8.29s. Commands that already
+hoisted compilation out of their loop (grep, rg) are unaffected.

--- a/packages/just-bash/src/regex/compile-cache.test.ts
+++ b/packages/just-bash/src/regex/compile-cache.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from "vitest";
+import { createUserRegex, type UserRegex } from "./user-regex.js";
+
+/**
+ * The compiled RE2JS is shared between UserRegex instances built from the same
+ * (pattern, flags). Reading it lets these tests assert that sharing happens (or
+ * deliberately does not) rather than only asserting it stays correct.
+ */
+function compiledOf(regex: UserRegex): unknown {
+  return (regex as unknown as { _re2: unknown })._re2;
+}
+
+describe("compiled pattern cache", () => {
+  it("shares one compiled pattern between identical constructions", () => {
+    const first = createUserRegex("(escalat|urgent)", "i");
+    const second = createUserRegex("(escalat|urgent)", "i");
+    expect(compiledOf(second)).toBe(compiledOf(first));
+    expect(first.test("URGENT delivery")).toBe(true);
+    expect(second.test("URGENT delivery")).toBe(true);
+  });
+
+  it("does not share across flags that change matching", () => {
+    const insensitive = createUserRegex("abc", "i");
+    const sensitive = createUserRegex("abc", "");
+    expect(compiledOf(sensitive)).not.toBe(compiledOf(insensitive));
+    expect(insensitive.test("ABC")).toBe(true);
+    expect(sensitive.test("ABC")).toBe(false);
+  });
+
+  it("keeps m and s distinct from each other and from no flags", () => {
+    const plain = createUserRegex("a.b$", "");
+    const dotAll = createUserRegex("a.b$", "s");
+    const multiline = createUserRegex("a.b$", "m");
+    expect(compiledOf(dotAll)).not.toBe(compiledOf(plain));
+    expect(compiledOf(multiline)).not.toBe(compiledOf(plain));
+    expect(compiledOf(multiline)).not.toBe(compiledOf(dotAll));
+    expect(plain.test("a\nb")).toBe(false);
+    expect(dotAll.test("a\nb")).toBe(true);
+  });
+
+  it("shares across flags that only the wrapper interprets", () => {
+    // g and d never reach RE2; UserRegex implements them. They must not split
+    // the cache, and must still behave independently per instance.
+    const global = createUserRegex("a", "g");
+    const plain = createUserRegex("a", "");
+    expect(compiledOf(global)).toBe(compiledOf(plain));
+    expect(global.global).toBe(true);
+    expect(plain.global).toBe(false);
+    expect(global.match("aaa")).toEqual(["a", "a", "a"]);
+    const plainMatch = plain.match("aaa");
+    expect(plainMatch?.length).toBe(1);
+    expect(plainMatch?.[0]).toBe("a");
+  });
+
+  it("keeps lastIndex independent between instances sharing a pattern", () => {
+    const first = createUserRegex("a", "g");
+    const second = createUserRegex("a", "g");
+    expect(compiledOf(second)).toBe(compiledOf(first));
+    expect(first.exec("aaa")?.index).toBe(0);
+    expect(first.exec("aaa")?.index).toBe(1);
+    expect(first.lastIndex).toBe(2);
+    expect(second.lastIndex).toBe(0);
+    expect(second.exec("aaa")?.index).toBe(0);
+  });
+
+  it("keeps result limits per instance, not per compiled pattern", () => {
+    const unlimited = createUserRegex("a", "g");
+    const limited = createUserRegex("a", "g", { maxResults: 2 });
+    expect(compiledOf(limited)).toBe(compiledOf(unlimited));
+    expect(unlimited.match("aaaa")).toEqual(["a", "a", "a", "a"]);
+    expect(() => limited.match("aaaa")).toThrow(/result limit exceeded \(2\)/);
+    // The shared compiled pattern is unaffected by the other instance throwing.
+    expect(unlimited.match("aaaa")).toEqual(["a", "a", "a", "a"]);
+  });
+
+  it("keeps interleaved matchAll iterators independent", () => {
+    const first = createUserRegex("\\d", "g");
+    const second = createUserRegex("\\d", "g");
+    expect(compiledOf(second)).toBe(compiledOf(first));
+    const a = first.matchAll("1 2 3");
+    const b = second.matchAll("7 8 9");
+    expect(a.next().value?.[0]).toBe("1");
+    expect(b.next().value?.[0]).toBe("7");
+    expect(a.next().value?.[0]).toBe("2");
+    expect(b.next().value?.[0]).toBe("8");
+    expect(a.next().value?.[0]).toBe("3");
+    expect(b.next().value?.[0]).toBe("9");
+    expect(a.next().done).toBe(true);
+    expect(b.next().done).toBe(true);
+  });
+
+  it("stays correct after the cache evicts an entry", () => {
+    const pattern = "evicted-(alpha|beta)";
+    const original = createUserRegex(pattern, "i");
+    expect(original.test("EVICTED-ALPHA")).toBe(true);
+
+    // The cache holds 256 entries; 300 distinct patterns guarantee eviction.
+    for (let i = 0; i < 300; i++) {
+      expect(
+        createUserRegex(`filler-${i}-(x|y)`, "i").test(`filler-${i}-x`),
+      ).toBe(true);
+    }
+
+    const rebuilt = createUserRegex(pattern, "i");
+    expect(compiledOf(rebuilt)).not.toBe(compiledOf(original));
+    expect(rebuilt.test("EVICTED-ALPHA")).toBe(true);
+    expect(rebuilt.test("evicted-beta")).toBe(true);
+    expect(rebuilt.test("nope")).toBe(false);
+    // The pre-eviction instance still holds its own compiled pattern.
+    expect(original.test("EVICTED-BETA")).toBe(true);
+  });
+
+  it("throws on every construction of an invalid pattern", () => {
+    for (let i = 0; i < 3; i++) {
+      expect(() => createUserRegex("[")).toThrow(/Invalid regular expression/);
+    }
+  });
+
+  it("reports lookahead as unsupported on repeat constructions", () => {
+    for (let i = 0; i < 3; i++) {
+      expect(() => createUserRegex("(?=x)")).toThrow(/Lookahead/);
+    }
+  });
+
+  it("keeps source and flags reported per instance", () => {
+    const global = createUserRegex("shared", "g");
+    const plain = createUserRegex("shared", "");
+    expect(global.source).toBe("shared");
+    expect(plain.source).toBe("shared");
+    expect(global.flags).toBe("g");
+    expect(plain.flags).toBe("");
+  });
+});

--- a/packages/just-bash/src/regex/compile-cache.test.ts
+++ b/packages/just-bash/src/regex/compile-cache.test.ts
@@ -110,6 +110,25 @@ describe("compiled pattern cache", () => {
     expect(original.test("EVICTED-BETA")).toBe(true);
   });
 
+  it("does not retain patterns longer than 1024 characters", () => {
+    const oversized = `${"a".repeat(1025)}|needle`;
+    const first = createUserRegex(oversized);
+    const second = createUserRegex(oversized);
+    expect(compiledOf(second)).not.toBe(compiledOf(first));
+    expect(first.test("needle")).toBe(true);
+    expect(second.test("needle")).toBe(true);
+    expect(second.test("haystack")).toBe(false);
+  });
+
+  it("still retains a pattern of exactly 1024 characters", () => {
+    const boundary = `${"a".repeat(1017)}|needle`;
+    expect(boundary.length).toBe(1024);
+    const first = createUserRegex(boundary);
+    const second = createUserRegex(boundary);
+    expect(compiledOf(second)).toBe(compiledOf(first));
+    expect(second.test("needle")).toBe(true);
+  });
+
   it("throws on every construction of an invalid pattern", () => {
     for (let i = 0; i < 3; i++) {
       expect(() => createUserRegex("[")).toThrow(/Invalid regular expression/);

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -77,6 +77,43 @@ function translatePattern(pattern: string): string {
   return RE2JS.translateRegExp(pattern);
 }
 
+// Compiling a pattern (translate -> parse -> simplify -> compile) costs ~23us,
+// while matching with an already-compiled pattern costs ~1.5us. Callers build a
+// UserRegex per operation -- jq's test/gsub and awk's `~` run once per row -- so
+// without this the same source pattern is recompiled once per row.
+//
+// Only the compiled RE2JS is shared. It derives purely from (pattern, flags) and
+// UserRegex only reads from it (groupCount/namedGroups/matcher); all per-call
+// state (lastIndex, the reusable Matcher, result limits, AbortSignal) stays on
+// the UserRegex instance, which is still constructed per call.
+//
+// 256 entries with insertion-order eviction, mirroring the glob regex cache in
+// src/utils/glob.ts. The cap sits far below that cache's 2048 because a cached
+// RE2JS also retains a lazy-DFA state cache that grows as it matches (re2js
+// bounds it at 10k states), whereas a glob pattern compiles to a tiny program.
+const COMPILED_CACHE_MAX = 256;
+const compiledCache = new Map<string, RE2JS>();
+
+function compilePattern(pattern: string, flags: string): RE2JS {
+  const re2Flags = convertFlags(flags);
+  // Keyed on the numeric RE2 flags rather than the flag string: `g` and `d` are
+  // handled by UserRegex, so test("a") and match("a") share one compiled pattern.
+  const key = `${re2Flags} ${pattern}`;
+  const cached = compiledCache.get(key);
+  if (cached !== undefined) {
+    return cached;
+  }
+  const compiled = RE2JS.compile(translatePattern(pattern), re2Flags);
+  if (compiledCache.size >= COMPILED_CACHE_MAX) {
+    const oldest = compiledCache.keys().next().value;
+    if (oldest !== undefined) {
+      compiledCache.delete(oldest);
+    }
+  }
+  compiledCache.set(key, compiled);
+  return compiled;
+}
+
 /**
  * A wrapper around RE2JS that provides a RegExp-compatible interface.
  * Uses RE2 for linear-time matching, providing ReDoS protection.
@@ -204,9 +241,7 @@ export class UserRegex implements RegexLike {
     }
 
     try {
-      const translatedPattern = translatePattern(pattern);
-      const re2Flags = convertFlags(flags);
-      this._re2 = RE2JS.compile(translatedPattern, re2Flags);
+      this._re2 = compilePattern(pattern, flags);
     } catch (e) {
       if (e instanceof RE2JSSyntaxException) {
         // Provide helpful error messages for unsupported RE2 features

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -77,27 +77,20 @@ function translatePattern(pattern: string): string {
   return RE2JS.translateRegExp(pattern);
 }
 
-// Compiling a pattern (translate -> parse -> simplify -> compile) costs ~23us,
-// while matching with an already-compiled pattern costs ~1.5us. Callers build a
-// UserRegex per operation -- jq's test/gsub and awk's `~` run once per row -- so
-// without this the same source pattern is recompiled once per row.
-//
-// Only the compiled RE2JS is shared. It derives purely from (pattern, flags) and
-// UserRegex only reads from it (groupCount/namedGroups/matcher); all per-call
-// state (lastIndex, the reusable Matcher, result limits, AbortSignal) stays on
-// the UserRegex instance, which is still constructed per call.
-//
-// 256 entries with insertion-order eviction, mirroring the glob regex cache in
-// src/utils/glob.ts. The cap sits far below that cache's 2048 because a cached
-// RE2JS also retains a lazy-DFA state cache that grows as it matches (re2js
-// bounds it at 10k states), whereas a glob pattern compiles to a tiny program.
+// Only the immutable compiled RE2JS is shared; per-call state (lastIndex, the
+// reusable Matcher, result limits, AbortSignal) stays on each UserRegex.
+// Keyed on the numeric RE2 flags because `g` and `d` are handled by UserRegex.
+// Patterns are user-controlled and unbounded in length, so oversized ones are
+// compiled but not retained — the cache holds at most 256 KiB of pattern source.
 const COMPILED_CACHE_MAX = 256;
+const COMPILED_CACHE_MAX_PATTERN_LENGTH = 1024;
 const compiledCache = new Map<string, RE2JS>();
 
 function compilePattern(pattern: string, flags: string): RE2JS {
   const re2Flags = convertFlags(flags);
-  // Keyed on the numeric RE2 flags rather than the flag string: `g` and `d` are
-  // handled by UserRegex, so test("a") and match("a") share one compiled pattern.
+  if (pattern.length > COMPILED_CACHE_MAX_PATTERN_LENGTH) {
+    return RE2JS.compile(translatePattern(pattern), re2Flags);
+  }
   const key = `${re2Flags} ${pattern}`;
   const cached = compiledCache.get(key);
   if (cached !== undefined) {


### PR DESCRIPTION

## The defect

`UserRegex`'s constructor compiles its pattern from source on every construction
— [`packages/just-bash/src/regex/user-regex.ts:206-209`](packages/just-bash/src/regex/user-regex.ts#L206-L209) on `main`:

```ts
const translatedPattern = translatePattern(pattern);
const re2Flags = convertFlags(flags);
this._re2 = RE2JS.compile(translatedPattern, re2Flags);
```

That runs the full `translateRegExp → parse → simplify → compileRegexp →
prefix()` pipeline. There is no memoization anywhere between `createUserRegex()`
and `RE2JS.compile`.

This is fine for callers that build one `UserRegex` and reuse it. It is not fine
for callers that build one **per row**, and several do:

| Caller | Site | Frequency |
| --- | --- | --- |
| jq `test` | `commands/query-engine/builtins/string-builtins.ts:181` | once per input value |
| jq `match` | `string-builtins.ts:194` | once per input value |
| jq `capture` | `string-builtins.ts:228` | once per input value |
| jq `sub` | `string-builtins.ts:246` | once per input value |
| jq `gsub` | `string-builtins.ts:263` | once per input value |
| jq `scan` | `string-builtins.ts:151` | once per input value |
| jq `splits` | `string-builtins.ts:124` | once per input value |
| awk `~` / `!~` | `commands/awk/interpreter/expressions.ts:229,252` | once per record |
| awk `sub`/`gsub`/`match`/`split` | `commands/awk/builtins.ts:227,273,303,366,402,417` | once per call |
| awk dynamic regex coercion | `commands/awk/interpreter/type-coercion.ts:69` | once per comparison |
| sed `s///` | `commands/sed/executor.ts:539`, plus `:559` / `:576` | **twice** per line |
| `find -regex` | `commands/find/matcher.ts:99,452` | once per file |
| `tar` include/exclude | `commands/tar/tar.ts:129,130,138,165,166` | up to 5× per entry |

The `sed` case is worth calling out: `executor.ts:539` compiles the pattern to
run `test()`, then `:559` or `:576` compiles **the same pattern string again**
with a `g` flag to do the replacement — two compiles per line.

### Why it costs so much

just-bash uses `re2js`, a pure-JS RE2 port, for linear-time (ReDoS-immune)
matching. That immunity is bought with an expensive compiler, and unlike V8's
`RegExp` there is no engine-level compilation cache to fall back on.

Measured on this machine (Node 24, `re2js@1.3.3`), median of 5 interleaved
rounds, pattern `urgent|asap|priority|escalat|critical|blocker|p0|sev1` with
flag `i`:

| | anchored `^(alt)` | unanchored `(alt)` |
| --- | --- | --- |
| `createUserRegex()` + `.test()` (per call, `main`) | 25.8 µs | 43.8 µs |
| `.test()` on a reused instance | 1.5 µs | 21.1 µs |
| `RE2JS.compile()` alone | 23.4 µs | 22.2 µs |
| native `RegExp.test()` on a reused instance | 0.013 µs | 0.048 µs |

Compilation is **91% of the cost** for the anchored pattern and **51%** for the
unanchored one. The share depends on how expensive matching is, but the absolute
compile cost (~23 µs) is the same either way and is paid once per row.

### Production shape

This was found in a production Node service that embeds just-bash as the tool
surface for an LLM agent. The agent authored a jq script that called `test()`
once per row over a ~170k-row dataset. That produced ~174k compilations of one
identical pattern (plus ~116k more from a `gsub` in the same script) and ran for
19.6 s, blocking the host event loop for the duration. CPU profiling of that
window attributed 44% of all just-bash time to the `RE2JS` constructor and its
compile chain; `simpleFold → toUpperCase` appeared prominently because it runs
per literal character *during compilation*, not during matching.

LLM-authored scripts make this shape common rather than exotic: the model has no
reason to hoist a pattern out of a row loop, and jq offers no way to express a
precompiled regex.

## The fix

Memoize the compiled `RE2JS` inside the constructor's compile step. One new
function, one changed line at the call site:

```ts
const COMPILED_CACHE_MAX = 256;
const compiledCache = new Map<string, RE2JS>();

function compilePattern(pattern: string, flags: string): RE2JS {
  const re2Flags = convertFlags(flags);
  const key = `${re2Flags} ${pattern}`;
  const cached = compiledCache.get(key);
  if (cached !== undefined) {
    return cached;
  }
  const compiled = RE2JS.compile(translatePattern(pattern), re2Flags);
  if (compiledCache.size >= COMPILED_CACHE_MAX) {
    const oldest = compiledCache.keys().next().value;
    if (oldest !== undefined) {
      compiledCache.delete(oldest);
    }
  }
  compiledCache.set(key, compiled);
  return compiled;
}
```

Every one of the call sites in the table above is fixed without touching any of
them.

### Design decisions

**Cache the compiled pattern, not the `UserRegex`.** `UserRegex` is *not* safe
to share: it carries `_lastIndex`, a reusable `_matcher` whose `charSequence` is
mutated in place, and per-construction `maxResults` / `maxOutputBytes` /
`AbortSignal`. `RE2JS` is the immutable compiled artifact — `UserRegex` only
calls `groupCount()`, `namedGroups()` and `matcher()` on it, all read-only. So
the expensive part is shared and every piece of mutable state stays per-instance,
with `UserRegex` still constructed per call.

**Key on the numeric RE2 flags, not the flag string.** `convertFlags` maps only
`i`/`m`/`s` into RE2; `g` and `d` are implemented by `UserRegex` itself. Keying
on the numeric flags therefore both prevents the correctness bug (`i` must split
the cache — it does) and lets `test("a")`, `test("a";"g")` and `match("a")`
(which appends `d`) share one compiled pattern instead of making three entries.

**Module scope.** Precedent: `src/utils/glob.ts:12` already keeps a module-level,
2048-entry, insertion-order-evicting cache of compiled `UserRegex` objects, and
`src/commands/registry.ts:538` caches runtime commands the same way. This cache
is strictly more conservative than the glob one — it shares only the immutable
compiled artifact, where the glob cache shares whole stateful `UserRegex`
instances across `Bash` instances.

Nothing execution-scoped is retained: the cached value derives purely from
(pattern, flags), holds no input text, no filesystem handle and no signal. The
one piece of state a cached `RE2JS` accumulates is `re2js`'s internal lazy-DFA
state cache, whose entries are keyed by NFA program counters — automaton
structure, not input content — and which `re2js` bounds at 10k states per
pattern. Measured retention with 256 warm cached patterns: **0.20 MB** (see
below).

**Cap of 256 with insertion-order eviction.** A realistic script uses a handful
of distinct patterns; 256 absorbs pathological LLM-generated scripts while
bounding worst-case DFA retention. It is deliberately below the glob cache's 2048
because a glob pattern compiles to a tiny program with a trivial DFA, whereas an
arbitrary user pattern does not. Eviction mirrors `glob.ts` exactly
(`keys().next().value`) — insertion-order FIFO, not true LRU, for consistency
with the existing house pattern and to keep the hot path allocation-free.

**Reentrancy checked, not assumed.** Sharing one `RE2` across concurrently-live
`Matcher`s is safe: `RE2.doExecuteNFA` acquires a machine from the pool, matches,
and returns it within one synchronous call, never holding it across a `yield`,
and allocates a fresh one when the pool is empty. `DFA.match`'s only instance
write memoizes `startState`, derived from the program. This is exercised by the
interleaved-`matchAll` test below. (`UserRegex` already created multiple
`Matcher`s per `RE2` before this change, so the sharing pattern itself is not
new — only its scope is.)

## Benchmarks

Same machine, same harness, `before` = this branch's merge base. Wall clock,
median of 7 interleaved runs, 100k rows.

### Realistic: same pattern, once per row

| Workload | before | after | speedup |
| --- | --- | --- | --- |
| `jq 'select(.subject \| test("<8-alt>"; "i"))'` | 8957 ms | 4256 ms | **2.10×** |
| `awk '$0 ~ /<3-alt>/ {n++}'` | 4152 ms | 2554 ms | **1.63×** |
| `awk '{n+=gsub(/<2-alt>/,"X")}'` | 7158 ms | 6095 ms | **1.17×** |
| `sed -E 's/<2-alt>/X/g'` | 10459 ms | 8289 ms | **1.26×** |
| `jq '.subject \| capture("(?<w>...)")'` (50k) | 1723 ms | 1163 ms | **1.48×** |

Micro, per-call construction + match (median of 5 × 3000 ops):

| | before | after | cache ceiling (reused instance) |
| --- | --- | --- | --- |
| anchored `^(alt)`, flag `i` | 25.8 µs | **2.03 µs** | 1.46 µs |
| unanchored `(alt)`, flag `i` | 43.8 µs | **21.0 µs** | 21.1 µs |

Both land at the reuse ceiling — the remaining cost is matching, which this
change does not address. Constructing a `UserRegex` on a cache hit is 0.18 µs.

### Regression guard: cache thrash (100% miss)

A distinct pattern per row, so every lookup misses and evicts:
`jq '. as $r | select($r.subject | test("(escalat|urgent|sev1)|zzz\($r.id)"; "i"))'`

| | before | after | delta |
| --- | --- | --- | --- |
| 100k distinct patterns | 5685 ms | 5896 ms | **+3.7%** |

Isolated bookkeeping cost on a pure miss (key build, failed `get`, evict,
`set`, against a full 256-entry `Map`): **0.33 µs/op**, against ~20 µs to
compile — so ~1.6% is arithmetic overhead and the remainder is GC pressure from
keeping 256 compiled patterns live. That is the honest trade: ~4% worse on a
workload where no pattern ever repeats, 2.1× better when any pattern repeats.

`grep -Ec` over the same 100k lines: 1537 ms → 1555 ms (unchanged). grep already
hoists compilation out of its line loop, which is a useful control — it shows the
cache costs nothing measurable where there is nothing to win.

### Memory

| | result |
| --- | --- |
| Retained heap, 256 warm cached patterns (each matched against 12 inputs) | **0.20 MB** |
| Retained heap after 20k distinct patterns (cache saturated + evicting) | no measurable growth |

Bounded by construction: 256 entries max, and each entry's DFA is capped by
`re2js` at 10k states.

## Tests

New file `packages/just-bash/src/regex/compile-cache.test.ts` (11 tests). The
existing `user-regex.test.ts` is already 528 lines, past the 300-line guidance in
`CLAUDE.md`, so these went in their own file.

- one compiled pattern is shared between identical constructions
- `i` splits the cache and still matches case-sensitively vs not
- `m` and `s` are distinct from each other and from no flags
- `g` / `d` share a compiled pattern but keep per-instance `global` semantics
- `lastIndex` stays independent between two instances sharing a pattern
- `maxResults` stays per-instance; one instance throwing does not disturb the other
- interleaved `matchAll` iterators on two instances sharing a pattern stay independent
- correctness holds after eviction (300 filler patterns force it), and the
  pre-eviction instance keeps working
- invalid patterns and lookahead throw on *every* construction, not just the first

**5 of the 11 fail on the merge base and pass with this change**; the other 6 are
correctness guards that hold either way.

No timing-based test was added — the suite has no precedent for one and it would
be flaky.

## Validation

```
pnpm lint             ✓  (biome + workflow security + banned patterns)
pnpm knip             ✓  (only the 2 pre-existing knip.json config hints)
tsc --noEmit          ✓
pnpm build            ✓
pnpm test:unit        1 failed | 14705 passed | 98 skipped
pnpm test:comparison  872 passed (54 files)
```

The single `test:unit` failure is `src/package-contents.test.ts`, which shells out
to `npm pack` and fails locally with *"This project is configured to use pnpm
because … has a `packageManager` field"* — an environment issue, unrelated to
this change (it adds no exports and no entry to `files`).

Before building `dist/`, `pnpm test:run` reports 97 failures — all
`*.bundle.test.ts`, CLI and WASM-worker (python3/sqlite3/js-exec) cases that need
a built `dist/`. Those are **identical on the merge base** (`diff` of the two FAIL
lists is empty; 97 failed | 15369 passed there vs 97 failed | 15380 passed here,
the 11-test delta being this PR's new file), and they all clear after `pnpm
build`, which is what CI does.

The comparison and spec suites for jq, awk, sed, grep, rg, find, xan and tar pass
unchanged — those exercise the shared-compilation path heavily.

## Deliberately not changed

- **Failed compiles are not cached.** An invalid pattern still costs ~9 µs per
  construction (it fails during parse, before the expensive compile stage), and
  jq's `test` swallows the error and returns `false` — so a per-row invalid
  pattern still recompiles per row. Caching thrown errors raises questions about
  error and stack identity that felt out of scope here; the measurement is
  included so you can judge. `[` → 9.18 µs, `(?=x)` → 8.64 µs.
- **No call sites were hoisted.** Fixing this in the constructor covers all of
  them; hoisting compilation out of jq's builtin dispatch or awk's expression
  evaluator would be a larger, riskier diff for the same win.
- **`sed`'s duplicate compile per line was left in place.** It is now a cache hit
  rather than a second compile. Deduplicating it properly is a `sed` refactor,
  not a regex change.
- **True LRU was not implemented.** Insertion-order FIFO matches `glob.ts` and
  keeps the hit path free of bookkeeping writes. Worth revisiting only if a
  workload is found that cycles through slightly more than 256 patterns.
- **No cache-clearing hook was exposed.** Nothing in the codebase needs one, and
  `RE2JS` already offers `reset()` for releasing its internal caches if that ever
  changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
