### PR TITLE
fix(interpreter): give a bare assignment exit status 0, not the previous command's

### DIFF
--- a/.changeset/assignment-exit-status.md
+++ b/.changeset/assignment-exit-status.md
@@ -1,0 +1,17 @@
+---
+"just-bash": patch
+---
+
+interpreter: give a bare assignment exit status 0 instead of the previous command's
+
+A command with no command word — `x=1`, `arr=(a b)`, `> file`, a `$empty` that expands to nothing — reported whatever `$?` already held rather than success. Bash gives such a command status 0 unless a command substitution in an assigned value set the status.
+
+The leak is invisible until something reads `$?`, and an `else` branch is where it bites: the branch runs with `$?` set to 1 by the condition that just failed, so an `else` branch ending in an assignment made the whole `if` report failure. Under `set -e` that ended the script with no output and no diagnostic:
+
+```bash
+set -e
+if false; then :; else x=1; fi
+echo done                          # never ran
+```
+
+A command substitution still sets the status where bash says it does: `x=$(exit 7)` is 7, the last substitution wins across several assignments, and one nested in `${y:=$(...)}` counts. A substitution in a redirection target does not, and neither does a process substitution.

--- a/.changeset/assignment-exit-status.md
+++ b/.changeset/assignment-exit-status.md
@@ -4,7 +4,7 @@
 
 interpreter: give a bare assignment exit status 0 instead of the previous command's
 
-A command with no command word — `x=1`, `arr=(a b)`, `> file`, a `$empty` that expands to nothing — reported whatever `$?` already held rather than success. Bash gives such a command status 0 unless a command substitution in an assigned value set the status.
+A command with no command word — `x=1`, `arr=(a b)`, `> file`, a `$empty` that expands to nothing — reported whatever `$?` already held rather than success. Bash gives such a command status 0 unless a command substitution ran while expanding it.
 
 The leak is invisible until something reads `$?`, and an `else` branch is where it bites: the branch runs with `$?` set to 1 by the condition that just failed, so an `else` branch ending in an assignment made the whole `if` report failure. Under `set -e` that ended the script with no output and no diagnostic:
 
@@ -14,4 +14,4 @@ if false; then :; else x=1; fi
 echo done                          # never ran
 ```
 
-A command substitution still sets the status where bash says it does: `x=$(exit 7)` is 7, the last substitution wins across several assignments, and one nested in `${y:=$(...)}` counts. A substitution in a redirection target does not, and neither does a process substitution.
+A command substitution still sets the status where bash says it does. It counts from an assigned value or a redirection word, assignments expanded first and the last substitution winning: `x=$(exit 7)` is 7, `> /dev/null$(exit 5)` is 5, and `x=$(exit 7) > /dev/null$(exit 5)` is 5. A redirection onto fd 0 discards it and reports 0, matching bash 5.x, which forks a child to perform such a command's redirections. Process substitution never contributes, and neither does a command substitution in `PS4` under `set -x`.

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -405,6 +405,7 @@ export class Bash {
       sourceDepth: 0,
       commandCount: 0,
       lastExitCode: 0,
+      lastSubstitutionExitCode: null,
       lastArg: "", // $_ is initially empty (or could be shell name)
       startTime: Date.now(),
       lastBackgroundPid: 0,

--- a/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
+++ b/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
@@ -424,4 +424,79 @@ describe("exit status of commands with no command word", () => {
       expect(result.exitCode).toBe(0);
     });
   });
+
+  describe("shapes reported from the field", () => {
+    // Contributed on PR #400 by the SLICC integration that hit this in
+    // production, where it cost an 18-step bisection. Kept as written, because
+    // each one isolates a different reason the bug was hard to see.
+    it("should reset $? with no control flow involved at all", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=1; y=2; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? for an assignment ending a subshell", async () => {
+      const env = new Bash();
+      const result = await env.exec(`( false; x=1 ); echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should survive a defaults helper whose else ends in an assignment", async () => {
+      // The production shape: the assignment is the natural last statement, so
+      // its status becomes the function's, and under set -e the script's fate.
+      const env = new Bash();
+      const result = await env.exec(
+        `set -e\ncfg() { if [ -n "$1" ]; then val="$1"; else val="fallback"; fi; }\ncfg ""\necho "val=$val"`,
+      );
+      expect(result.stdout).toBe("val=fallback\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should agree with the assignment builtins that were never affected", async () => {
+      // `local`, `export` and `declare` are real command words, so they always
+      // took the normal path and reported their own status. Re-declaring with
+      // `local` was the field workaround; this pins that the two paths now
+      // agree rather than that one of them is right by accident.
+      const env = new Bash();
+      const script = (assign: string) =>
+        `set -e\nf() { if false; then :; else ${assign}; fi; }\nf\necho ok`;
+      for (const assign of ["local v=1", "export E=1", "declare d=1", "v=1"]) {
+        const result = await env.exec(script(assign));
+        expect(result.stdout, assign).toBe("ok\n");
+        expect(result.exitCode, assign).toBe(0);
+      }
+    });
+
+    it("should behave the same whether or not a statement follows", async () => {
+      // Adding any statement after the assignment masked the bug completely,
+      // so a script failed or not depending on where the assignment fell.
+      const env = new Bash();
+      const trailing = await env.exec(
+        `set -e\nif false; then :; else x=1; echo "x=$x"; fi\necho done`,
+      );
+      expect(trailing.stdout).toBe("x=1\ndone\n");
+      expect(trailing.exitCode).toBe(0);
+
+      const bare = await env.exec(
+        `set -e\nif false; then :; else x=1; fi\necho done`,
+      );
+      expect(bare.stdout).toBe("done\n");
+      expect(bare.exitCode).toBe(0);
+    });
+
+    it("should leave a loop followed by an assignment alone", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `set -e; while false; do :; done; y=2; echo done`,
+      );
+      expect(result.stdout).toBe("done\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
 });

--- a/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
+++ b/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
@@ -5,9 +5,11 @@ import { Bash } from "../Bash.js";
  * `$?` after a command that has no command word.
  *
  * Bash gives a bare assignment status 0 — it does not re-report whatever ran
- * before it. The only thing that can change that is a command substitution in
- * one of the assigned values (`x=$(exit 7)` is 7); a substitution in a
- * redirection target is not one of those.
+ * before it. The only thing that can change that is a command substitution
+ * performed while expanding the command: an assigned value (`x=$(exit 7)` is
+ * 7) or a redirection word (`> /dev/null$(exit 5)` is 5), last one wins. A
+ * redirection onto fd 0 overrides all of it with 0, because bash performs
+ * such a command's redirections in a forked child.
  *
  * Leaking the previous status here is invisible until something reads it. An
  * `else` branch is the sharp edge: it runs with `$?` set to 1 by the failed
@@ -132,7 +134,7 @@ describe("exit status of commands with no command word", () => {
       expect(result.exitCode).toBe(0);
     });
 
-    it("should report the substitution even with a redirection attached", async () => {
+    it("should report a value substitution when the target has none", async () => {
       const env = new Bash();
       const result = await env.exec(
         `false; x=$(exit 7) > /tmp/out; echo "status=$?"`,
@@ -257,6 +259,168 @@ describe("exit status of commands with no command word", () => {
       const result = await env.exec(`false; x=1; exit`);
       expect(result.stdout).toBe("");
       expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("substitutions in redirection words count too", () => {
+    it("should report a substitution in a bare redirection's target", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `true; > /dev/null$(exit 5); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should let a target substitution outrank an earlier value one", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=$(exit 7) > /dev/null$(exit 5); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report the last target when several redirections carry one", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `x=$(exit 7) > /dev/null$(exit 5) > /dev/null$(exit 3); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=3\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should expand assignments before redirections, whatever the order written", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `> /dev/null$(exit 5) x=$(exit 7); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report a target substitution on an empty command word", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; e=; $e > /dev/null$(exit 5); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=5\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should leave a command that has a command word alone", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `true; echo hi > /dev/null$(exit 5); echo "status=$?"`,
+      );
+      // "hi" went to /dev/null; the command's own status wins over the target's.
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("a redirection onto fd 0 reports success", () => {
+    // bash performs a null command's redirections in a forked child when one
+    // of them reads stdin, so the substitution status is discarded. bash 3.2
+    // predates that fork and keeps the status; these follow bash 5.x, which
+    // the comparison fixtures are recorded against.
+    it("should discard the value substitution for an input redirection", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `x=$(exit 7) < /dev/null; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should discard it for a here-string", async () => {
+      const env = new Bash();
+      const result = await env.exec(`x=$(exit 7) <<< x; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should discard it for a read-write open on fd 0", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `e=; $e <> /dev/null$(exit 5); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should discard it when fd 0 is closed", async () => {
+      const env = new Bash();
+      const result = await env.exec(`x=$(exit 7) 0<&-; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep the status for an input redirection on another fd", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `x=$(exit 7) 3< /dev/null; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep the status when fd 0 is only the source of a dup", async () => {
+      const env = new Bash();
+      const result = await env.exec(`x=$(exit 7) 3<&0; echo "status=$?"`);
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep the status for an output redirection", async () => {
+      const env = new Bash();
+      const result = await env.exec(`x=$(exit 7) 1>&2; echo "status=$?"`);
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("PS4 expansion under set -x", () => {
+    // The trace prefix is expanded for output only; a substitution in it is
+    // not one of the command's own expansions.
+    it("should not let a PS4 substitution become a bare assignment's status", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `PS4='$(exit 4)+'\nset -x\nfalse\nx=1\ns=$?\nset +x\necho "status=$s"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not let a PS4 substitution outrank the assigned value's", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `PS4='$(exit 4)+'\nset -x\nfalse\nx=$(exit 7)\ns=$?\nset +x\necho "status=$s"`,
+      );
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not let a PS4 substitution become a bare redirection's status", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `PS4='$(exit 4)+'\nset -x\nfalse\n> /dev/null\ns=$?\nset +x\necho "status=$s"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
       expect(result.exitCode).toBe(0);
     });
   });

--- a/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
+++ b/packages/just-bash/src/interpreter/assignment-exit-status.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * `$?` after a command that has no command word.
+ *
+ * Bash gives a bare assignment status 0 — it does not re-report whatever ran
+ * before it. The only thing that can change that is a command substitution in
+ * one of the assigned values (`x=$(exit 7)` is 7); a substitution in a
+ * redirection target is not one of those.
+ *
+ * Leaking the previous status here is invisible until something reads it. An
+ * `else` branch is the sharp edge: it runs with `$?` set to 1 by the failed
+ * condition, so an `else` branch ending in an assignment made the whole `if`
+ * report failure, and under `set -e` that killed the script with no output.
+ *
+ * Every expectation here was verified against real bash before being written.
+ */
+describe("exit status of commands with no command word", () => {
+  describe("bare assignments report success", () => {
+    it("should reset $? after a plain assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=1; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? after multiple assignments in one command", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=1 y=2; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? after an array assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; arr=(a b); echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? after a subscript assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; arr[0]=a; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? after an append assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x+=tail; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should let the assignment read $? before resetting it", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=$?; echo "x=$x status=$?"`);
+      expect(result.stdout).toBe("x=1 status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? for every assignment in a row", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=1; echo "first=$?"; false; y=2; echo "second=$?"`,
+      );
+      expect(result.stdout).toBe("first=0\nsecond=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? for a bare redirection", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; > /tmp/out; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? for a command word that expands to nothing", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; empty=; $empty; echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("command substitutions still set the status", () => {
+    it("should report the status of a substitution in the value", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=$(exit 7); echo "status=$?"`);
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report the last substitution when several run", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=$(exit 3) y=$(exit 4); echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=4\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should keep the substitution status across a later plain value", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=$(exit 3) y=plain; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=3\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report a substitution nested in a parameter expansion", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=\${y:=$(exit 9)}; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=9\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report the substitution even with a redirection attached", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; x=$(exit 7) > /tmp/out; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report a substitution used as the command word", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; $(exit 42); echo "status=$?"`);
+      expect(result.stdout).toBe("status=42\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not take the status from a process substitution", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=<(echo hi); echo "status=$?"`);
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("an else branch ending in an assignment", () => {
+    it("should run the whole branch and report success", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `if false; then echo then; else x=1; echo "else x=$x"; fi`,
+      );
+      expect(result.stdout).toBe("else x=1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report success when the branch is a single assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `if false; then :; else x=1; fi; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report success when the branch is only assignments", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `if false; then :; else x=1; y=2; fi; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should report success for an assignment inside a group", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `if false; then :; else { x=1; }; fi; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not abort the script under set -e", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `set -e\nif false; then :; else x=1; echo reached; fi\necho done`,
+      );
+      expect(result.stdout).toBe("reached\ndone\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should not abort the script when the branch ends in the assignment", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `set -e\nif false; then :; else x=1; fi\necho done`,
+      );
+      expect(result.stdout).toBe("done\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("other constructs that inherit a failed status", () => {
+    it("should reset $? for an assignment in a case branch", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; case q in q) x=1;; esac; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should reset $? for an assignment in a loop body", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `false; for i in 1; do x=1; done; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should make a bare return report the assignment's success", async () => {
+      const env = new Bash();
+      const result = await env.exec(
+        `f() { false; x=1; return; }; f; echo "status=$?"`,
+      );
+      expect(result.stdout).toBe("status=0\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("should make a bare exit report the assignment's success", async () => {
+      const env = new Bash();
+      const result = await env.exec(`false; x=1; exit`);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/interpreter/builtins/complete.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/complete.test.ts
@@ -16,6 +16,7 @@ function createMockCtx(): InterpreterContext {
     sourceDepth: 0,
     commandCount: 0,
     lastExitCode: 0,
+    lastSubstitutionExitCode: null,
     lastArg: "",
     startTime: Date.now(),
     lastBackgroundPid: 0,

--- a/packages/just-bash/src/interpreter/builtins/compopt.test.ts
+++ b/packages/just-bash/src/interpreter/builtins/compopt.test.ts
@@ -17,6 +17,7 @@ function createMockCtx(): InterpreterContext {
     sourceDepth: 0,
     commandCount: 0,
     lastExitCode: 0,
+    lastSubstitutionExitCode: null,
     lastArg: "",
     startTime: Date.now(),
     lastBackgroundPid: 0,

--- a/packages/just-bash/src/interpreter/expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion.ts
@@ -91,6 +91,7 @@ import {
   splitByIfsForExpansion,
 } from "./helpers/ifs.js";
 import { isNameref, resolveNameref } from "./helpers/nameref.js";
+import { recordSubstitutionExit } from "./helpers/substitution-status.js";
 import { getLiteralValue, isQuotedPart } from "./helpers/word-parts.js";
 import { openProcessSubstitution } from "./process-substitution.js";
 import type { InterpreterContext } from "./types.js";
@@ -765,8 +766,7 @@ async function expandPart(
             : `${ctx.state.cwd}/${filePath}`;
           // Read the file
           const content = await ctx.fs.readFile(resolvedPath);
-          ctx.state.lastExitCode = 0;
-          ctx.state.env.set("?", "0");
+          recordSubstitutionExit(ctx.state, 0);
           // Strip trailing newlines (like command substitution does)
           const result = content.replace(/\n+$/, "");
           // Check string length limit
@@ -782,8 +782,7 @@ async function expandPart(
             throw error;
           }
           // File not found or read error - return empty string, set exit code
-          ctx.state.lastExitCode = 1;
-          ctx.state.env.set("?", "1");
+          recordSubstitutionExit(ctx.state, 1);
           return "";
         }
       }
@@ -825,8 +824,7 @@ async function expandPart(
         ctx.state.cwd = savedCwd;
         ctx.state.suppressVerbose = savedSuppressVerbose;
         // Store the exit code for $?
-        ctx.state.lastExitCode = exitCode;
-        ctx.state.env.set("?", String(exitCode));
+        recordSubstitutionExit(ctx.state, exitCode);
         // Command substitution stderr should go to the shell's stderr at expansion time,
         // NOT be affected by later redirections on the outer command
         if (result.stderr) {
@@ -857,8 +855,7 @@ async function expandPart(
         }
         if (error instanceof ExitError) {
           // Catch exit in command substitution - return output so far
-          ctx.state.lastExitCode = error.exitCode;
-          ctx.state.env.set("?", String(error.exitCode));
+          recordSubstitutionExit(ctx.state, error.exitCode);
           // Also forward stderr from the exit
           if (error.stderr) {
             ctx.state.expansionStderr =

--- a/packages/just-bash/src/interpreter/expansion/pattern-expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion/pattern-expansion.ts
@@ -9,6 +9,7 @@ import type { ScriptNode } from "../../ast/types.js";
 import { Parser } from "../../parser/parser.js";
 import { ExecutionLimitError, ExitError } from "../errors.js";
 import { cloneArrays } from "../helpers/array.js";
+import { recordSubstitutionExit } from "../helpers/substitution-status.js";
 import type { InterpreterContext } from "../types.js";
 import { escapeGlobChars } from "./glob-escape.js";
 
@@ -132,8 +133,7 @@ async function executeCommandSubstitutionFromString(
     ctx.state.arrays = savedArrays;
     ctx.state.cwd = savedCwd;
     ctx.state.suppressVerbose = savedSuppressVerbose;
-    ctx.state.lastExitCode = exitCode;
-    ctx.state.env.set("?", String(exitCode));
+    recordSubstitutionExit(ctx.state, exitCode);
     if (result.stderr) {
       ctx.state.expansionStderr =
         (ctx.state.expansionStderr || "") + result.stderr;
@@ -150,8 +150,7 @@ async function executeCommandSubstitutionFromString(
       throw error;
     }
     if (error instanceof ExitError) {
-      ctx.state.lastExitCode = error.exitCode;
-      ctx.state.env.set("?", String(error.exitCode));
+      recordSubstitutionExit(ctx.state, error.exitCode);
       return error.stdout?.replace(/\n+$/, "") ?? "";
     }
     return "";

--- a/packages/just-bash/src/interpreter/helpers/substitution-status.ts
+++ b/packages/just-bash/src/interpreter/helpers/substitution-status.ts
@@ -2,6 +2,7 @@
  * Exit-status bookkeeping for command substitutions.
  */
 
+import type { RedirectionNode } from "../../ast/types.js";
 import type { InterpreterState } from "../types.js";
 
 /**
@@ -20,4 +21,48 @@ export function recordSubstitutionExit(
   state.lastExitCode = exitCode;
   state.env.set("?", String(exitCode));
   state.lastSubstitutionExitCode = exitCode;
+}
+
+/** Does this redirection put something on fd 0? */
+function redirectsStdin(redirection: RedirectionNode): boolean {
+  switch (redirection.operator) {
+    case "<":
+    case "<&":
+    case "<<":
+    case "<<-":
+    case "<<<":
+    case "<>":
+      // Input operators default to fd 0 when no fd is written.
+      return redirection.fd === null || redirection.fd === 0;
+    default:
+      return false;
+  }
+}
+
+/**
+ * The status bash gives a command that has no command word.
+ *
+ * It is the status of the last command substitution performed while expanding
+ * the command — assigned values and redirection words alike, in that order —
+ * and 0 when no substitution ran. A bare `x=1` is therefore 0 rather than
+ * whatever the previous command left in `$?`.
+ *
+ * A redirection onto fd 0 overrides all of that with 0. bash performs the
+ * redirections of a null command in a forked child when one of them reads
+ * stdin (`execute_null_command`'s `forcefork`), so the shell reports the
+ * child's status and any substitution in the words is discarded:
+ * `x=$(exit 7) < /dev/null` is 0, while `x=$(exit 7) 3< /dev/null` is 7.
+ *
+ * Verified against GNU bash 5.3. bash 3.2 predates the fork and reports 7 for
+ * both; this follows 5.x, which is what the comparison fixtures are recorded
+ * against.
+ */
+export function nullCommandExitStatus(
+  state: InterpreterState,
+  redirections: readonly RedirectionNode[],
+): number {
+  if (redirections.some(redirectsStdin)) {
+    return 0;
+  }
+  return state.lastSubstitutionExitCode ?? 0;
 }

--- a/packages/just-bash/src/interpreter/helpers/substitution-status.ts
+++ b/packages/just-bash/src/interpreter/helpers/substitution-status.ts
@@ -1,0 +1,23 @@
+/**
+ * Exit-status bookkeeping for command substitutions.
+ */
+
+import type { InterpreterState } from "../types.js";
+
+/**
+ * Record the exit status of a command substitution.
+ *
+ * `$?` and the "a substitution ran here" marker have to move together: a
+ * command with no command word (`x=1`, `> file`, an expansion that came out
+ * empty) reports the status of the last substitution that ran inside it, and
+ * 0 when none did. Setting `lastExitCode` without the marker leaves such a
+ * command reporting the *previous* command's status instead.
+ */
+export function recordSubstitutionExit(
+  state: InterpreterState,
+  exitCode: number,
+): void {
+  state.lastExitCode = exitCode;
+  state.env.set("?", String(exitCode));
+  state.lastSubstitutionExitCode = exitCode;
+}

--- a/packages/just-bash/src/interpreter/helpers/xtrace.ts
+++ b/packages/just-bash/src/interpreter/helpers/xtrace.ts
@@ -37,6 +37,13 @@ async function getXtracePrefix(ctx: InterpreterContext): Promise<string> {
 
   const xtraceWasEnabled = ctx.state.options.xtrace;
   ctx.state.options.xtrace = false;
+  // PS4 is expanded for the trace line only. A command substitution in it must
+  // not become the traced command's status, so `$?` and the substitution
+  // marker are put back exactly as they were: under `set -x` with a PS4 that
+  // substitutes, `x=1` is still 0 and `x=$(exit 7)` is still 7.
+  const savedExitCode = ctx.state.lastExitCode;
+  const savedExitCodeVar = ctx.state.env.get("?");
+  const savedSubstitutionExitCode = ctx.state.lastSubstitutionExitCode;
   try {
     // Parse PS4 as a word to handle variable expansion
     const parser = new Parser();
@@ -66,6 +73,13 @@ async function getXtracePrefix(ctx: InterpreterContext): Promise<string> {
     return ps4 || DEFAULT_PS4;
   } finally {
     ctx.state.options.xtrace = xtraceWasEnabled;
+    ctx.state.lastExitCode = savedExitCode;
+    ctx.state.lastSubstitutionExitCode = savedSubstitutionExitCode;
+    if (savedExitCodeVar === undefined) {
+      ctx.state.env.delete("?");
+    } else {
+      ctx.state.env.set("?", savedExitCodeVar);
+    }
   }
 }
 

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -666,6 +666,11 @@ export class Interpreter {
     // Clear expansion stderr at the start
     this.ctx.state.expansionStderr = "";
 
+    // A command with no command word reports the status of the last command
+    // substitution that ran inside it, so start every simple command with a
+    // clean marker rather than inheriting the previous command's.
+    this.ctx.state.lastSubstitutionExitCode = null;
+
     // Process all assignments (array, subscript, and scalar)
     const assignmentResult = await processAssignments(this.ctx, node);
     if (assignmentResult.error) {
@@ -673,6 +678,10 @@ export class Interpreter {
     }
     const tempAssignments = assignmentResult.tempAssignments;
     const xtraceAssignmentOutput = assignmentResult.xtraceOutput;
+    // Captured before the redirection targets are expanded: a substitution in
+    // a target (`> $(pick-file)`) does not set `$?` in bash, only one in an
+    // assignment value does.
+    const assignmentExitCode = this.ctx.state.lastSubstitutionExitCode ?? 0;
     const restoreTempAssignments = (): void => {
       for (const [name, value] of tempAssignments) {
         if (value === undefined) this.ctx.state.env.delete(name);
@@ -705,7 +714,11 @@ export class Interpreter {
             transaction.finish();
           }
         }
-        const baseResult = result("", xtraceAssignmentOutput, 0);
+        const baseResult = result(
+          "",
+          xtraceAssignmentOutput,
+          assignmentExitCode,
+        );
         const redirected = await applyRedirections(
           this.ctx,
           baseResult,
@@ -718,15 +731,16 @@ export class Interpreter {
         return redirected;
       }
 
-      // Assignment-only command: preserve the exit code from command substitution
-      // e.g., x=$(false) should set $? to 1, not 0
+      // Assignment-only command: the status is the one from a command
+      // substitution in the values (`x=$(false)` is 1), and 0 when there was
+      // none — a bare `x=1` never re-reports the previous command's status.
       // Also clear $_ - bash clears it for bare assignments
       this.ctx.state.lastArg = "";
       // Include any stderr from command substitutions (e.g., FOO=$(echo foo 1>&2))
       const stderrOutput =
         (this.ctx.state.expansionStderr || "") + xtraceAssignmentOutput;
       this.ctx.state.expansionStderr = "";
-      return result("", stderrOutput, this.ctx.state.lastExitCode);
+      return result("", stderrOutput, assignmentExitCode);
     }
 
     // Mark prefix assignment variables as temporarily exported for this command
@@ -841,6 +855,10 @@ export class Interpreter {
       quotedArgs.shift();
     }
 
+    // Word expansion is done; anything a redirection target expands to below
+    // must not change the status this command reports.
+    const expansionExitCode = this.ctx.state.lastSubstitutionExitCode ?? 0;
+
     const transaction = createRedirectionTransaction(
       this.ctx,
       node.redirections,
@@ -874,10 +892,10 @@ export class Interpreter {
     // However, a literal empty string (like '') is "command not found".
     if (!commandName) {
       if (commandIsOnlyExpansions) {
-        // No args - treat as no-op (status 0)
-        // Preserve lastExitCode for command subs like $(exit 42)
+        // No args - treat as a no-op that reports the status of a command
+        // substitution in the word (`$(exit 42)` is 42) and 0 otherwise.
         transaction.finish();
-        return result("", "", this.ctx.state.lastExitCode);
+        return result("", "", expansionExitCode);
       }
       // Literal empty command name - command not found
       transaction.finish();

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -84,6 +84,7 @@ import { advanceFd } from "./fd-table.js";
 import { executeFunctionDef } from "./functions.js";
 import { failure, OK, result, testResult } from "./helpers/result.js";
 import { isPosixSpecialBuiltin } from "./helpers/shell-constants.js";
+import { nullCommandExitStatus } from "./helpers/substitution-status.js";
 import { isWordLiteralMatch } from "./helpers/word-matching.js";
 import { traceSimpleCommand } from "./helpers/xtrace.js";
 import { executePipeline as executePipelineHelper } from "./pipeline-execution.js";
@@ -678,10 +679,6 @@ export class Interpreter {
     }
     const tempAssignments = assignmentResult.tempAssignments;
     const xtraceAssignmentOutput = assignmentResult.xtraceOutput;
-    // Captured before the redirection targets are expanded: a substitution in
-    // a target (`> $(pick-file)`) does not set `$?` in bash, only one in an
-    // assignment value does.
-    const assignmentExitCode = this.ctx.state.lastSubstitutionExitCode ?? 0;
     const restoreTempAssignments = (): void => {
       for (const [name, value] of tempAssignments) {
         if (value === undefined) this.ctx.state.env.delete(name);
@@ -714,10 +711,11 @@ export class Interpreter {
             transaction.finish();
           }
         }
+        // After `prepare`, so a substitution in a redirection target counts.
         const baseResult = result(
           "",
           xtraceAssignmentOutput,
-          assignmentExitCode,
+          nullCommandExitStatus(this.ctx.state, node.redirections),
         );
         const redirected = await applyRedirections(
           this.ctx,
@@ -740,7 +738,11 @@ export class Interpreter {
       const stderrOutput =
         (this.ctx.state.expansionStderr || "") + xtraceAssignmentOutput;
       this.ctx.state.expansionStderr = "";
-      return result("", stderrOutput, assignmentExitCode);
+      return result(
+        "",
+        stderrOutput,
+        nullCommandExitStatus(this.ctx.state, []),
+      );
     }
 
     // Mark prefix assignment variables as temporarily exported for this command
@@ -855,10 +857,6 @@ export class Interpreter {
       quotedArgs.shift();
     }
 
-    // Word expansion is done; anything a redirection target expands to below
-    // must not change the status this command reports.
-    const expansionExitCode = this.ctx.state.lastSubstitutionExitCode ?? 0;
-
     const transaction = createRedirectionTransaction(
       this.ctx,
       node.redirections,
@@ -895,7 +893,11 @@ export class Interpreter {
         // No args - treat as a no-op that reports the status of a command
         // substitution in the word (`$(exit 42)` is 42) and 0 otherwise.
         transaction.finish();
-        return result("", "", expansionExitCode);
+        return result(
+          "",
+          "",
+          nullCommandExitStatus(this.ctx.state, node.redirections),
+        );
       }
       // Literal empty command name - command not found
       transaction.finish();

--- a/packages/just-bash/src/interpreter/process-substitution.ts
+++ b/packages/just-bash/src/interpreter/process-substitution.ts
@@ -274,6 +274,7 @@ async function runBody(
   const savedGroupStdin = ctx.state.groupStdin;
   const savedExitCode = ctx.state.lastExitCode;
   const savedExitCodeVar = ctx.state.env.get("?");
+  const savedSubstitutionExitCode = ctx.state.lastSubstitutionExitCode;
 
   ctx.substitutionDepth = currentDepth + 1;
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
@@ -304,8 +305,11 @@ async function runBody(
     ctx.state.bashPid = savedBashPid;
     ctx.state.suppressVerbose = savedSuppressVerbose;
     ctx.state.groupStdin = savedGroupStdin;
-    // The body's status is never the shell's `$?` (bash forks it away).
+    // The body's status is never the shell's `$?` (bash forks it away), and
+    // a substitution inside it must not become the enclosing command's status
+    // either — `x=<(echo $(false))` is still 0.
     ctx.state.lastExitCode = savedExitCode;
+    ctx.state.lastSubstitutionExitCode = savedSubstitutionExitCode;
     if (savedExitCodeVar !== undefined) {
       ctx.state.env.set("?", savedExitCodeVar);
     } else {

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -414,6 +414,13 @@ export interface InterpreterState
   // ---- Execution Tracking ----
   /** Exit code of last executed command */
   lastExitCode: number;
+  /**
+   * Exit status of the most recent command substitution, or `null` when none
+   * has run since the current simple command began expanding. A command with
+   * no command word takes its status from this, not from `lastExitCode`:
+   * `x=$(exit 7)` is 7, while a plain `x=1` is 0 no matter what ran before it.
+   */
+  lastSubstitutionExitCode: number | null;
   /** Last argument of previous command, for $_ expansion */
   lastArg: string;
   /** Current line number being executed (for $LINENO) */

--- a/packages/just-bash/src/security/attacks/fuzz-discovered-attacks.test.ts
+++ b/packages/just-bash/src/security/attacks/fuzz-discovered-attacks.test.ts
@@ -385,6 +385,10 @@ describe("Fuzz-discovered attack vectors", () => {
       assertExecResultSafe(result);
     });
 
+    // The loop condition is a pipeline of two assignments, which bash gives
+    // status 0, so this loop does not terminate on its own — the execution
+    // limits are what stop it. Running to the iteration limit takes longer
+    // than the 5s default on the slower CI runners.
     it("while loop with brace expansion and prototype assignment", async () => {
       const env = new Bash();
       const script = `
@@ -396,7 +400,7 @@ describe("Fuzz-discovered attack vectors", () => {
       `;
       const result = await env.exec(`${script} 2>&1 || true`);
       assertExecResultSafe(result);
-    });
+    }, 30_000);
 
     it("yq pipe with for loop using prototype variables", async () => {
       const env = new Bash();


### PR DESCRIPTION
fix(interpreter): give a bare assignment exit status 0, not the previous command's

## Problem

```bash
set -e
if false; then :; else x=1; fi
echo done
```

Nothing is printed and the shell exits 1. There is no diagnostic, and no command in the script failed.

Found by an agent driving just-bash inside SLICC, where it cost an 18-step bisection. The failure has no surface a script can inspect: no stderr, no non-zero from any command that ran, no partial output. Invoked as a subprocess it reads as a subcommand that "silently did nothing," which looks like argument parsing, an auth failure or a hung network call long before it looks like an exit-status bug in the shell.

Three things made it expensive to find, all of them now test cases:

- **Any statement after the assignment masks it.** `else x=1; echo "x=$x"; fi` is fine; `else x=1; fi` is not. A real script fails or not depending on where the assignment happens to fall, so one subcommand breaks and its neighbour doesn't.
- **`local`, `export` and `declare` are immune.** They are real command words and report their own status, so only a bare assignment is affected. Re-declaring with `local` was the workaround SLICC shipped, correct but for reasons nobody had at the time.
- **The `if`/`else` framing is a red herring.** The bisection landed on "assignment followed by another statement inside `if`/`else`, but not `case`", which is right about the symptom and wrong about the cause.

The production shape was a defaults helper, where the assignment is the natural last statement:

```bash
set -e
cfg() { if [ -n "$1" ]; then val="$1"; else val="fallback"; fi; }
cfg ""
echo "val=$val"      # never runs — and val was set correctly
```

## Cause

A simple command with no command word returned `ctx.state.lastExitCode`:

```ts
// Assignment-only command: preserve the exit code from command substitution
// e.g., x=$(false) should set $? to 1, not 0
return result("", stderrOutput, this.ctx.state.lastExitCode);
```

The comment describes the case it was written for. `x=$(false)` works because the substitution writes `lastExitCode` on its way through, and reading it back afterwards recovers 1. But when no substitution runs there is nothing to read back, and `lastExitCode` still holds whatever the *previous* command left there. Bash gives a bare assignment status 0.

No control flow is needed to see it:

```bash
false; x=1; echo $?        # 1, bash says 0
false; x=1; y=2; echo $?   # 1 — the last assignment does not clear it either
( false; x=1 ); echo $?    # 1 — same inside a subshell
```

An `else` branch is where it turns fatal, because it is entered with `$?` set to 1 by the condition that just failed. The assignment reports 1, the branch's last statement decides the `if`'s status, the `if` reports failure, and `set -e` turns that into an exit. `then` branches hid it because a true condition leaves `$?` at 0, and so did `case`, which is entered carrying whatever status preceded it.

The same read appears in a neighbouring path with the same consequence: a command word that expands to nothing (`$empty`) inherited the previous failure.

## Fix

Separate "the status a substitution set" from "the status of the last command". Command substitutions record through one helper:

```ts
export function recordSubstitutionExit(state: InterpreterState, exitCode: number): void {
  state.lastExitCode = exitCode;
  state.env.set("?", String(exitCode));
  state.lastSubstitutionExitCode = exitCode;
}
```

Every simple command clears the marker before expanding, and a command with no command word reports the last substitution performed while expanding it — assigned values first, then redirection words in written order — or 0 when none ran.

```bash
x=$(exit 7)                                  # 7
x=$(exit 3) y=$(exit 4)                      # 4, last wins
x=$(exit 3) y=plain                          # 3, a plain value does not clear it
x=${y:=$(exit 9)}                            # 9, nested in a parameter expansion
> /dev/null$(exit 5)                         # 5, redirection words count
x=$(exit 7) > /dev/null$(exit 5)             # 5
> /dev/null$(exit 5) x=$(exit 7)             # 5, assignments expand first regardless of order
x=1                                          # 0
```

Three details follow bash rather than convenience:

- **A redirection onto fd 0 reports 0 regardless.** bash performs a null command's redirections in a forked child when one of them reads stdin, so the substitution status is discarded: `x=$(exit 7) < /dev/null` is 0, `x=$(exit 7) <<< x` is 0, `x=$(exit 7) 0<&-` is 0, while `x=$(exit 7) 3< /dev/null` and `x=$(exit 7) 3<&0` are 7. This follows bash 5.x; bash 3.2 predates the fork and reports 7 for all of them, and the comparison fixtures are recorded against 5.x.
- **Process substitution** restores the marker alongside `$?`, which it already saved. `false; x=<(echo hi)` is 0 in bash, and the marker must not survive the body any more than `$?` does.
- **`PS4`** is expanded for the trace line only, so a substitution in it is not one of the command's own expansions. `$?` and the marker are restored after prompt expansion, next to the `xtrace` flag that was already saved there.

Six call sites in `expansion.ts` and `expansion/pattern-expansion.ts` already wrote the `lastExitCode` / `env["?"]` pair by hand; they now call the helper.

## Scope

Unchanged: every command that has a command word, including prefix assignments on a real command (`FOO=$(exit 5) true` is 0, `true`'s status) and redirection targets on one (`echo hi > /dev/null$(exit 5)` is 0). `local`, `export` and `declare` were never affected and are now pinned as agreeing with the bare-assignment path rather than being right by accident.

Not addressed, deliberately:

- `x=$"hi"` (locale translation quoting) keeps its trailing quote. Unrelated, found while fuzzing this area.
- A diagnostic when `set -e` aborts on a construct containing no failing command. That silence is precisely what bash does, and matching bash is this project's rule, so a warning would be a deliberate divergence and belongs in its own issue. `set -x` does show it — the trace ends at the assignment — though that is thin help when the symptom surfaces three layers up in a subprocess.

## Review round

Two findings, both real, both fixed in `f06ad146`.

**The redirection rule was backwards, and my justification for it was a bad probe.** I had snapshotted the marker *before* redirection expansion, on the grounds that `> $(sh -c "exit 5"; echo f)` is 0 in bash. That probe proves nothing: the substitution's own status is 0 because `echo` is its last command, so `exit 5` never reaches the status. It said "this substitution succeeded", not "targets are ignored". With a substitution that actually exits nonzero bash counts it, and the snapshot had regressed `$empty > /dev/null$(exit 5)` from 5 to 0 — the same swallowed-failure class this PR is about, pointing the other way. The snapshot is gone and the fd-0 rule above replaces it.

**`PS4` leaked into the status.** Under `set -x` with a substituting `PS4`, `x=1` reported the prompt's status (4) instead of 0, and `x=$(exit 7)` reported 4 instead of 7.

## CI

`unit-tests (20)` and `(22)` failed on the first push, with `(24)` passing. Caused by this change, and the new behaviour is correct: the fuzz-discovered `while prototype={4..14} | H08OO9hF[constructor]=PI8` condition is a pipeline of two assignments, which bash gives status 0, so that loop is non-terminating in bash too. It previously exited on the leaked status; now the execution limits stop it (exit 126, ~1s locally), which is what that test exists to demonstrate. It needed more than the 5s default on the slower runners, so it has an explicit 30s timeout with the reason in a comment. All three jobs are green.

## Tests

`src/interpreter/assignment-exit-status.test.ts`, 48 cases in six groups:

1. bare assignments of every shape reset `$?` (plain, multiple, array, subscript, append, `x=$?`, bare redirection, empty command word);
2. substitutions in assigned values still set it, including nested and last-wins ordering;
3. substitutions in redirection words set it too, with the documented ordering;
4. a redirection onto fd 0 reports 0 while other fds and dup sources do not;
5. `PS4` never contributes;
6. the shapes reported from the field — no-control-flow repros, the `local`/`export`/`declare` asymmetry, the `cfg()` defaults helper, and the masking case.

Plus the `else`-branch cases under and without `set -e`, and the constructs that read a stale status (`case`, loop bodies, bare `return`, bare `exit`).

**34 of the 48 fail against `main`** — verified by reverting only the source files and re-running.

Every expectation was checked against GNU bash 5.3.15, and the version-independent ones against bash 3.2.57 as well; the two agree except on the fd-0 rule, noted above and in the code. The bug was found by differential fuzzing against `/bin/bash` over assignment shapes crossed with following statements and if/else/case/top-level wrappers; that sweep is clean apart from environment differences (`$HOME`, cwd contents) and the `$"..."` case.

Suite: 596 files, 15,508 passed, 98 skipped. Lint, typecheck and knip clean. Six python3/CPython-WASM tests fail on my machine both with and without the change — `vendor/cpython-emscripten/python.wasm` is a git-LFS pointer locally; verified by stashing the change and re-running, and they are green in CI.

---

Authored with Claude Opus 5
