### PR TITLE
fix(rg): preserve empty piped stdin

### DIFF
--- a/.changeset/rg-empty-stdin.md
+++ b/.changeset/rg-empty-stdin.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Treat direct empty pipeline and input-redirection streams as `rg` input instead of recursively searching the current directory.

--- a/packages/just-bash/src/commands/rg/rg-search.ts
+++ b/packages/just-bash/src/commands/rg/rg-search.ts
@@ -263,16 +263,16 @@ export async function executeSearch(
     for (const lease of patternSourceLeases) lease.release();
   }
 
-  // If no paths given and stdin has content, search stdin (like real rg).
-  // In a pipeline, the previous command's stdout becomes this command's
-  // stdin — search that text instead of defaulting to the current directory.
+  // If no paths are given and stdin was provided, search stdin (like real rg).
+  // Pipeline stages and explicit redirections can provide an empty stdin, which
+  // must still suppress rg's fallback recursive search of the current directory.
   // Skip when `-f -` already consumed stdin for patterns to avoid
   // double-consuming it as both pattern source and search input.
   const stdinConsumedByPatternFile = options.patternFiles.includes("-");
   const stdinText = decodeBytesToUtf8(ctx.stdin);
   if (
     inputPaths.length === 0 &&
-    stdinText.length > 0 &&
+    (ctx.stdinProvided || stdinText.length > 0) &&
     !stdinConsumedByPatternFile
   ) {
     const content = stdinText;

--- a/packages/just-bash/src/commands/rg/rg.stdin.test.ts
+++ b/packages/just-bash/src/commands/rg/rg.stdin.test.ts
@@ -17,6 +17,104 @@ describe("rg searches stdin when no paths are given", () => {
     expect(result.stdout).not.toContain("decoy");
   });
 
+  it("searches empty piped stdin instead of cwd", async () => {
+    const env = new Bash({ files: { "/decoy.txt": "target line\n" } });
+    const result = await env.exec('printf "" | rg "target"');
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    });
+  });
+
+  it("lets an empty input redirection override enclosing stdin", async () => {
+    const env = new Bash({
+      files: {
+        "/empty.txt": "",
+        "/outer.txt": "outer target\n",
+      },
+    });
+    const result = await env.exec("{ rg target < /empty.txt; } < /outer.txt");
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    });
+  });
+
+  it("treats an empty fd-0 here-doc as direct stdin", async () => {
+    const env = new Bash({ files: { "/decoy.txt": "target line\n" } });
+    const result = await env.exec("rg target <<EOF\nEOF");
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "",
+      exitCode: 1,
+    });
+  });
+
+  it("ignores an empty here-doc on a non-stdin descriptor", async () => {
+    const env = new Bash({ files: { "/outer.txt": "outer target\n" } });
+    const result = await env.exec("{ rg target 2<<EOF\nEOF\n} < /outer.txt");
+
+    expect(result).toMatchObject({
+      stdout: "1:outer target\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("ignores an empty input redirection on a non-stdin descriptor", async () => {
+    const env = new Bash({
+      files: {
+        "/empty.txt": "",
+        "/outer.txt": "outer target\n",
+      },
+    });
+    const result = await env.exec("{ rg target 2< /empty.txt; } < /outer.txt");
+
+    expect(result).toMatchObject({
+      stdout: "1:outer target\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("preserves inherited stdin through an fd-0 self-duplication", async () => {
+    const env = new Bash({ files: { "/outer.txt": "outer target\n" } });
+    const result = await env.exec("{ rg target <&0; } < /outer.txt");
+
+    expect(result).toMatchObject({
+      stdout: "1:outer target\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("still searches an explicit path when piped stdin is empty", async () => {
+    const env = new Bash({ files: { "/data.txt": "target line\n" } });
+    const result = await env.exec('printf "" | rg "target" /data.txt');
+
+    expect(result).toMatchObject({
+      stdout: "target line\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("does not treat wrapper-created empty stdin as direct input", async () => {
+    const env = new Bash({ files: { "/decoy.txt": "target line\n" } });
+    const result = await env.exec("bash -c 'rg target'");
+
+    expect(result).toMatchObject({
+      stdout: "decoy.txt:1:target line\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
   it("returns exit code 1 when stdin has no match", async () => {
     const env = new Bash({ files: {} });
     const result = await env.exec('echo "hello" | rg "xyz"');

--- a/packages/just-bash/src/interpreter/builtin-dispatch.ts
+++ b/packages/just-bash/src/interpreter/builtin-dispatch.ts
@@ -759,6 +759,7 @@ export async function executeExternalCommand(
   args: string[],
   stdin: string,
   useDefaultPath: boolean,
+  stdinProvided = false,
 ): Promise<ExecResult> {
   const { ctx, buildExportedEnv, executeUserScript } = dispatchCtx;
 
@@ -809,16 +810,12 @@ export async function executeExternalCommand(
     ctx.state.hashTable.set(commandName, cmdPath);
   }
 
-  // Use groupStdin as fallback if no stdin from redirections/pipeline —
-  // needed for commands inside groups/functions that receive stdin via
-  // heredoc. The pipeline glue (pipeline-execution.ts) and the
-  // stdin-source sites (heredoc, here-string, `< file`, options.stdin)
-  // are responsible for handing us a latin1-shaped byte buffer; we just
-  // brand it. Commands that decode their input internally (sed, jq,
-  // ...) return text via `textOutput()`, and the pipe / redirect layer
-  // converts to bytes on their behalf.
+  // Direct pipeline or redirection input wins even when empty. Inherited group
+  // stdin keeps the established content-based fallback until descriptor-aware
+  // ownership can be preserved across every nested execution path.
+  const commandStdinProvided = stdinProvided || stdin.length > 0;
   const effectiveStdin = unsafeBytesFromLatin1(
-    stdin || ctx.state.groupStdin || "",
+    commandStdinProvided ? stdin : ctx.state.groupStdin || "",
   );
   let stdinAccessed = false;
 
@@ -887,6 +884,7 @@ export async function executeExternalCommand(
       stdinAccessed = true;
       return effectiveStdin;
     },
+    stdinProvided: commandStdinProvided,
     limits: ctx.limits,
     executionScope: cmd.internalIsExtension
       ? createCommandExecutionBudget(ctx.executionScope)

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -525,8 +525,8 @@ export class Interpreter {
   }
 
   private async executePipeline(node: PipelineNode): Promise<ExecResult> {
-    return executePipelineHelper(this.ctx, node, (cmd, stdin) =>
-      this.executeCommand(cmd, stdin),
+    return executePipelineHelper(this.ctx, node, (cmd, stdin, stdinProvided) =>
+      this.executeCommand(cmd, stdin, stdinProvided),
     );
   }
 
@@ -575,7 +575,7 @@ export class Interpreter {
     this.ctx.coverage?.hit(`bash:cmd:${node.type}`);
     switch (node.type) {
       case "SimpleCommand":
-        return this.executeSimpleCommand(node, stdin);
+        return this.executeSimpleCommand(node, stdin, stdinOwned);
       case "If":
         return executeIf(this.ctx, node);
       case "For":
@@ -606,12 +606,18 @@ export class Interpreter {
   private async executeSimpleCommand(
     node: SimpleCommandNode,
     stdin: string,
+    stdinProvided: boolean,
   ): Promise<ExecResult> {
     let transaction: RedirectionTransaction | undefined;
     try {
-      return await this.executeSimpleCommandInner(node, stdin, (created) => {
-        transaction = created;
-      });
+      return await this.executeSimpleCommandInner(
+        node,
+        stdin,
+        stdinProvided,
+        (created) => {
+          transaction = created;
+        },
+      );
     } catch (error) {
       transaction?.finish();
       if (error instanceof GlobError) {
@@ -627,6 +633,7 @@ export class Interpreter {
   private async executeSimpleCommandInner(
     node: SimpleCommandNode,
     stdin: string,
+    stdinProvided: boolean,
     onTransaction: (transaction: RedirectionTransaction) => void,
   ): Promise<ExecResult> {
     // Update currentLine for $LINENO
@@ -859,7 +866,7 @@ export class Interpreter {
       return preparedRedirectionError(preparedRedirections);
     }
     const stdinSourceFd = preparedRedirections.stdinSourceFd;
-    const stdinRedirected = preparedRedirections.stdin !== undefined;
+    const stdinRedirected = preparedRedirections.stdinReplaced;
     if (preparedRedirections.stdin !== undefined) {
       stdin = preparedRedirections.stdin;
     }
@@ -935,6 +942,7 @@ export class Interpreter {
         false,
         stdinSourceFd,
         stdinRedirected,
+        stdinProvided,
       );
     } catch (error) {
       // For break/continue, we still need to apply redirections before propagating
@@ -1062,6 +1070,7 @@ export class Interpreter {
     useDefaultPath = false,
     stdinSourceFd = -1,
     stdinRedirected = false,
+    stdinProvided = false,
   ): Promise<ExecResult> {
     const dispatchCtx: BuiltinDispatchContext = {
       ctx: this.ctx,
@@ -1096,6 +1105,7 @@ export class Interpreter {
       args,
       stdin,
       useDefaultPath,
+      stdinRedirected || stdinProvided,
     );
     return { ...externalResult, internalProducerCommand: commandName };
   }

--- a/packages/just-bash/src/interpreter/pipeline-execution.ts
+++ b/packages/just-bash/src/interpreter/pipeline-execution.ts
@@ -24,6 +24,7 @@ import type { InterpreterContext } from "./types.js";
 export type ExecuteCommandFn = (
   node: CommandNode,
   stdin: string,
+  stdinOwned?: boolean,
 ) => Promise<ExecResult>;
 
 /**
@@ -94,7 +95,7 @@ export async function executePipeline(
     const outputCheckpoint = ctx.executionScope.outputBytesUsed;
     try {
       ctx.state.commandCount = ctx.executionScope.chargeCommand();
-      result = await executeCommand(command, stdin);
+      result = await executeCommand(command, stdin, !isFirst);
     } catch (error) {
       // BadSubstitutionError should fail the command but not abort the script
       if (error instanceof BadSubstitutionError) {

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -124,6 +124,7 @@ export type PreparedRedirections = {
   standardRoutes: Map<number, FdEntry>;
   stdin: string | undefined;
   stdinSourceFd: number;
+  stdinReplaced: boolean;
   error: ExecResult | null;
   errorCause?: ExitError | ExecutionLimitError;
 };
@@ -331,6 +332,7 @@ async function prepareRedirectionsWithState(
   const snapshot = transaction.numericSnapshot;
   let stdin: string | undefined;
   let stdinSourceFd = -1;
+  let stdinReplaced = false;
   const initialStdin = standardRoutes.get(0);
   if (initialStdin?.kind === "input") {
     stdin = initialStdin.content;
@@ -345,6 +347,7 @@ async function prepareRedirectionsWithState(
     standardRoutes,
     stdin,
     stdinSourceFd,
+    stdinReplaced,
     error: null,
   });
   const fail = async (
@@ -460,6 +463,7 @@ async function prepareRedirectionsWithState(
         stdin = latin1FromBytes(encodeUtf8ToBytes(content));
         stdinSourceFd = -1;
         persistStandard(effectiveFd, { kind: "input", content: stdin });
+        stdinReplaced = true;
       } else {
         const entry: FdEntry = { kind: "input", content };
         if (transaction.policy === "persistent") {
@@ -779,6 +783,7 @@ async function prepareRedirectionsWithState(
         if (effectiveFd === 0) {
           stdin = "";
           stdinSourceFd = -1;
+          stdinReplaced = true;
         }
         if (effectiveFd !== null && effectiveFd < FIRST_USER_FD) {
           standardRoutes.set(effectiveFd, { kind: "closed" });
@@ -889,6 +894,13 @@ async function prepareRedirectionsWithState(
           stdinSourceFd = -1;
         }
       }
+      if (
+        redir.operator === "<&" &&
+        effectiveFd === 0 &&
+        parsed.sourceFd !== 0
+      ) {
+        stdinReplaced = true;
+      }
       if (parsed.move) {
         if (parsed.sourceFd >= FIRST_USER_FD) {
           closeFd(ctx, parsed.sourceFd);
@@ -933,12 +945,14 @@ async function prepareRedirectionsWithState(
       stdin = latin1FromBytes(encodeUtf8ToBytes(`${target}\n`));
       stdinSourceFd = -1;
       persistStandard(effectiveFd, { kind: "input", content: stdin });
+      if (effectiveFd === 0) stdinReplaced = true;
     } else if (redir.operator === "<") {
       const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
       try {
         stdin = (await readBytesFrom(ctx.fs, filePath)) as unknown as string;
         stdinSourceFd = -1;
         persistStandard(effectiveFd, { kind: "input", content: stdin });
+        if (effectiveFd === 0) stdinReplaced = true;
       } catch {
         return fail(
           makeResult("", `bash: ${target}: No such file or directory\n`, 1),
@@ -953,6 +967,7 @@ async function prepareRedirectionsWithState(
       if (effectiveFd === 0 && entry.kind === "readwrite") {
         stdin = entry.content;
         stdinSourceFd = -1;
+        stdinReplaced = true;
       }
     }
   }

--- a/packages/just-bash/src/types.ts
+++ b/packages/just-bash/src/types.ts
@@ -182,6 +182,12 @@ export interface RuntimeCommandContext {
    */
   stdin: ByteString;
   /**
+   * Whether this command's direct dispatch received pipeline or redirection
+   * input, even when empty. Inherited group stdin is intentionally excluded.
+   * @internal
+   */
+  stdinProvided?: boolean;
+  /**
    * Execution limits configuration.
    * Fully resolved by Bash before a command is invoked.
    */


### PR DESCRIPTION
## Summary

- make a directly dispatched `rg` command distinguish empty pipeline or fd-0 input-redirection stdin from absent stdin
- select direct stdin by source presence before content, so explicit EOF overrides an enclosing nonempty group stream
- preserve explicit path searches and ordinary cwd searches, including nested wrappers that merely materialize an empty buffer
- record whether redirection preparation actually replaced fd 0, excluding non-stdin input redirects and fd-0 self-duplication

## Reproduction

```bash
printf '' | rg target
```

Released versions see an empty stdin buffer and treat it as absent, so `rg` recursively scans the current directory. Real ripgrep treats the empty pipe as its input and exits with no matches.

## Scope

This patch intentionally carries source presence only to the directly dispatched runtime command. Generalizing empty-stdin ownership through command expansion, compound commands, `eval`, functions, executable scripts, wrappers, or descriptor cursors requires preserving descriptor identity, exact consumption, and nested input accounting rather than forwarding a boolean.

<details>
<summary>How the final fix works</summary>

### Why content length is insufficient

`rg` previously selected stdin only when `stdinText.length > 0`. That makes absent stdin and a provided-but-empty stream indistinguishable because both contain `""`. With no explicit path, the empty-stream case therefore fell through to `rg`'s normal recursive cwd search.

The fix keeps the bytes and source-presence decision separate.

### Direct pipeline input

`pipeline-execution.ts` marks every stage after the first as receiving pipeline stdin, even when the previous stage produced zero bytes. `interpreter.ts` carries that bit through simple-command dispatch without propagating it through nested execution paths.

### Direct input redirections

`redirections.ts` adds `PreparedRedirections.stdinReplaced`. It is set only when preparation actually replaces fd 0, including an fd-0 file, here-string, here-doc, duplication from another fd, or close.

It remains false when the redirection does not replace stdin, including:

- an input redirect on another descriptor such as `2< file`
- a here-doc on a nonzero descriptor
- fd-0 self-duplication with `<&0`

This prevents unrelated or no-op redirections from overriding inherited fd 0.

### Command dispatch

`builtin-dispatch.ts` now chooses direct stdin by source presence before content:

```ts
const commandStdinProvided = stdinProvided || stdin.length > 0;
const effectiveStdin = commandStdinProvided
  ? stdin
  : ctx.state.groupStdin || "";
```

A direct empty pipe or fd-0 redirection therefore wins over inherited group input, while commands with no direct stdin keep the existing fallback behavior.

### `rg` selection

`rg-search.ts` now searches stdin when either condition is true:

```ts
ctx.stdinProvided || stdinText.length > 0
```

Explicit path arguments still win, and `-f -` still consumes stdin only as a pattern source rather than also searching it as content.

</details>

## Validation

- focused `rg`, redirection, numeric-fd, pipeline, group-wrapper, and `bash` coverage (190 tests)
- `pnpm lint`
- `pnpm typecheck`
- `pnpm knip`
- `pnpm test:run` reached 15,470 passing tests; the same four local XZ codec failures remain in untouched tar tests and reproduce on `origin/main` in this environment
- final independent review: no P0, P1, or P2 findings within the stated scope
