### PR TITLE
fix: keep native compression codecs opt-in

### DIFF
--- a/.changeset/quiet-codecs-opt-in.md
+++ b/.changeset/quiet-codecs-opt-in.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Keep the native zstd and xz codecs opt-in so installing just-bash does not require approving their build scripts. Applications that use those tar compression formats can install `@mongodb-js/zstd` or `node-liblzma` explicitly.

--- a/package.json
+++ b/package.json
@@ -34,5 +34,9 @@
       "postcss@<8.5.10": "^8.5.10"
     }
   },
-  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8"
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
+  "optionalDependencies": {
+    "@mongodb-js/zstd": "^7.0.0",
+    "node-liblzma": "^2.2.0"
+  }
 }

--- a/packages/just-bash/AGENTS.npm.md
+++ b/packages/just-bash/AGENTS.npm.md
@@ -346,8 +346,8 @@ to inline these, and some of them cannot be inlined. Mark all six as external:
 
 | Package | What it is |
 | --- | --- |
-| `@mongodb-js/zstd` | native binding (`optionalDependencies`) |
-| `node-liblzma` | native binding (`optionalDependencies`) |
+| `@mongodb-js/zstd` | native binding (optional peer) |
+| `node-liblzma` | native binding (optional peer) |
 | `sql.js` | ships a `.wasm` asset |
 | `quickjs-emscripten` | ships a `.wasm` asset |
 | `seek-bzip` | CommonJS-only bzip2 decoder |
@@ -381,9 +381,9 @@ add them to `externals` (or use `webpack-node-externals`). esbuild/rollup:
 
 **Node version**: just-bash requires Node `>=20.19` (`guarded-fetch`'s floor).
 
-**Optional dependencies**: `@mongodb-js/zstd` and `node-liblzma` are declared
-in `optionalDependencies`, so an install that cannot build them still succeeds.
-Only the compression they provide is lost: `tar -J` then exits non-zero with
-`xz compression requires node-liblzma which failed to load`, rather than
-crashing the interpreter. The other four are regular dependencies and are
-required.
+**Optional codecs**: `@mongodb-js/zstd` and `node-liblzma` are optional peer
+dependencies, so they are not installed unless the application opts into their
+native bindings. Without them, only the compression they provide is unavailable:
+`tar -J` exits non-zero with an actionable `node-liblzma` installation error
+rather than crashing the interpreter. The other four are regular dependencies
+and are required.

--- a/packages/just-bash/package.json
+++ b/packages/just-bash/package.json
@@ -128,8 +128,16 @@
     "undici": "^7.29.0",
     "yaml": "^2.9.0"
   },
-  "optionalDependencies": {
+  "peerDependencies": {
     "@mongodb-js/zstd": "^7.0.0",
     "node-liblzma": "^2.2.0"
+  },
+  "peerDependenciesMeta": {
+    "@mongodb-js/zstd": {
+      "optional": true
+    },
+    "node-liblzma": {
+      "optional": true
+    }
   }
 }

--- a/packages/just-bash/src/commands/tar/archive.ts
+++ b/packages/just-bash/src/commands/tar/archive.ts
@@ -25,7 +25,7 @@ import { DefenseInDepthBox } from "../../security/defense-in-depth-box.js";
 import { CodecBudget } from "../compression/codec-budget.js";
 import { bzip2Compress } from "./bzip2-compress.js";
 
-// Lazy load node-liblzma since it requires native compilation
+// Lazy load the optional node-liblzma peer since it requires native compilation
 // that may fail on some systems (e.g., missing liblzma-dev)
 let lzma: typeof import("node-liblzma") | null = null;
 let lzmaLoadError: Error | null = null;
@@ -41,14 +41,14 @@ async function getLzma(): Promise<typeof import("node-liblzma")> {
     return lzma;
   } catch {
     lzmaLoadError = new Error(
-      "xz compression requires node-liblzma which failed to load. " +
-        "Install liblzma-dev (apt) or xz (brew) and reinstall dependencies.",
+      "xz compression requires node-liblzma which is not installed or failed to load. " +
+        "Install it with: npm install node-liblzma (requires liblzma-dev on apt or xz on brew).",
     );
     throw lzmaLoadError;
   }
 }
 
-// Lazy load @mongodb-js/zstd since it's an optional dependency
+// Lazy load the optional @mongodb-js/zstd peer
 let zstd: typeof import("@mongodb-js/zstd") | null = null;
 let zstdLoadError: Error | null = null;
 

--- a/packages/just-bash/src/package-contents.test.ts
+++ b/packages/just-bash/src/package-contents.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from "node:child_process";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { promisify } from "node:util";
@@ -12,7 +12,29 @@ interface PackResult {
   files: Array<{ path: string }>;
 }
 
+interface PackageManifest {
+  optionalDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+}
+
 describe("published package declarations", () => {
+  it("keeps native codecs opt-in", async () => {
+    const manifest = JSON.parse(
+      await readFile(resolve(packageRoot, "package.json"), "utf8"),
+    ) as PackageManifest;
+
+    expect(manifest.optionalDependencies).toBeUndefined();
+    expect(manifest.peerDependencies).toMatchObject({
+      "@mongodb-js/zstd": "^7.0.0",
+      "node-liblzma": "^2.2.0",
+    });
+    expect(manifest.peerDependenciesMeta).toMatchObject({
+      "@mongodb-js/zstd": { optional: true },
+      "node-liblzma": { optional: true },
+    });
+  });
+
   it("includes declaration trees referenced by public declarations", async () => {
     const npmCache = await mkdtemp(resolve(tmpdir(), "just-bash-npm-cache-"));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,13 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@26.2.0)
+    optionalDependencies:
+      '@mongodb-js/zstd':
+        specifier: ^7.0.0
+        version: 7.0.0
+      node-liblzma:
+        specifier: ^2.2.0
+        version: 2.2.0
 
   examples/bash-agent:
     dependencies:
@@ -159,6 +166,9 @@ importers:
 
   packages/just-bash:
     dependencies:
+      '@mongodb-js/zstd':
+        specifier: ^7.0.0
+        version: 7.0.0
       diff:
         specifier: ^8.0.4
         version: 8.0.4
@@ -177,6 +187,9 @@ importers:
       modern-tar:
         specifier: ^0.7.7
         version: 0.7.7
+      node-liblzma:
+        specifier: ^2.2.0
+        version: 2.2.0
       papaparse:
         specifier: ^5.6.0
         version: 5.6.0
@@ -247,13 +260,6 @@ importers:
       vitest:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
-    optionalDependencies:
-      '@mongodb-js/zstd':
-        specifier: ^7.0.0
-        version: 7.0.0
-      node-liblzma:
-        specifier: ^2.2.0
-        version: 2.2.0
 
   packages/just-bash-executor:
     dependencies:
@@ -3727,8 +3733,8 @@ packages:
       sass:
         optional: true
 
-  node-abi@3.94.0:
-    resolution: {integrity: sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==}
+  node-abi@3.96.0:
+    resolution: {integrity: sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==}
     engines: {node: '>=10'}
 
   node-addon-api@8.9.2:
@@ -5443,7 +5449,7 @@ snapshots:
       '@standard-schema/spec': 1.1.0
       effect: 4.0.0-beta.59
     optionalDependencies:
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@fal-ai/client@1.10.1':
     dependencies:
@@ -5733,7 +5739,6 @@ snapshots:
     dependencies:
       node-addon-api: 8.9.2
       prebuild-install: 7.1.3
-    optional: true
 
   '@mozilla/readability@0.6.0': {}
 
@@ -6276,7 +6281,7 @@ snapshots:
       obug: 2.1.4
       std-env: 4.2.0
       tinyrainbow: 3.1.1
-      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@25.9.5)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@25.9.5)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      vitest: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@vitest/expect@4.1.10':
     dependencies:
@@ -6302,6 +6307,14 @@ snapshots:
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.10(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+
+  '@vitest/mocker@4.1.10(vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -6510,8 +6523,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.11.14: {}
 
@@ -6537,7 +6549,6 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   body-parser@2.3.0:
     dependencies:
@@ -6580,7 +6591,6 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
 
   bytes@3.1.2: {}
 
@@ -6637,8 +6647,7 @@ snapshots:
       undici: 7.29.0
       whatwg-mimetype: 4.0.0
 
-  chownr@1.1.4:
-    optional: true
+  chownr@1.1.4: {}
 
   client-only@0.0.1: {}
 
@@ -6747,10 +6756,8 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
-  deep-extend@0.6.0:
-    optional: true
+  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -6859,7 +6866,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.24.5:
     dependencies:
@@ -7064,7 +7070,7 @@ snapshots:
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -7097,7 +7103,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -7112,7 +7118,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7279,8 +7285,7 @@ snapshots:
     dependencies:
       eventsource-parser: 3.1.1
 
-  expand-template@2.0.3:
-    optional: true
+  expand-template@2.0.3: {}
 
   expect-type@1.4.0: {}
 
@@ -7451,8 +7456,7 @@ snapshots:
 
   fresh@2.0.0: {}
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
 
   fs-extra@7.0.1:
     dependencies:
@@ -7521,8 +7525,7 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  github-from-package@0.0.0:
-    optional: true
+  github-from-package@0.0.0: {}
 
   glob-parent@5.1.2:
     dependencies:
@@ -7683,8 +7686,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8:
-    optional: true
+  ini@1.3.8: {}
 
   ini@6.0.0: {}
 
@@ -8153,8 +8155,7 @@ snapshots:
 
   mime@4.1.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.6:
     dependencies:
@@ -8168,8 +8169,7 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mkdirp-classic@0.5.3:
-    optional: true
+  mkdirp-classic@0.5.3: {}
 
   modern-tar@0.7.7: {}
 
@@ -8197,8 +8197,7 @@ snapshots:
 
   nanoid@3.3.18: {}
 
-  napi-build-utils@2.0.0:
-    optional: true
+  napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -8231,13 +8230,11 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  node-abi@3.94.0:
+  node-abi@3.96.0:
     dependencies:
       semver: 7.8.5
-    optional: true
 
-  node-addon-api@8.9.2:
-    optional: true
+  node-addon-api@8.9.2: {}
 
   node-exports-info@1.6.2:
     dependencies:
@@ -8255,14 +8252,12 @@ snapshots:
       detect-libc: 2.1.2
     optional: true
 
-  node-gyp-build@4.8.4:
-    optional: true
+  node-gyp-build@4.8.4: {}
 
   node-liblzma@2.2.0:
     dependencies:
       node-addon-api: 8.9.2
       node-gyp-build: 4.8.4
-    optional: true
 
   node-releases@2.0.53: {}
 
@@ -8468,13 +8463,12 @@ snapshots:
       minimist: 1.2.8
       mkdirp-classic: 0.5.3
       napi-build-utils: 2.0.0
-      node-abi: 3.94.0
+      node-abi: 3.96.0
       pump: 3.0.4
       rc: 1.2.8
       simple-get: 4.0.1
       tar-fs: 2.1.5
       tunnel-agent: 0.6.0
-    optional: true
 
   prelude-ls@1.2.1: {}
 
@@ -8495,7 +8489,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode@2.3.1: {}
 
@@ -8539,7 +8532,6 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
-    optional: true
 
   re2js@1.3.3: {}
 
@@ -8564,7 +8556,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   redis-errors@1.2.0: {}
 
@@ -8656,8 +8647,7 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
-  safe-buffer@5.2.1:
-    optional: true
+  safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
     dependencies:
@@ -8815,15 +8805,13 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1:
-    optional: true
+  simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
     dependencies:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
-    optional: true
 
   slash@3.0.0: {}
 
@@ -8911,7 +8899,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -8919,8 +8906,7 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-json-comments@2.0.1:
-    optional: true
+  strip-json-comments@2.0.1: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -8959,7 +8945,6 @@ snapshots:
       mkdirp-classic: 0.5.3
       pump: 3.0.4
       tar-stream: 2.2.0
-    optional: true
 
   tar-stream@2.2.0:
     dependencies:
@@ -8968,7 +8953,6 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
 
   term-size@2.2.1: {}
 
@@ -9035,7 +9019,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   turndown@7.2.4:
     dependencies:
@@ -9165,8 +9148,7 @@ snapshots:
 
   urlpattern-polyfill@10.1.0: {}
 
-  util-deprecate@1.0.2:
-    optional: true
+  util-deprecate@1.0.2: {}
 
   uuid@13.0.2: {}
 
@@ -9196,6 +9178,21 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 25.9.5
+      esbuild: 0.28.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      tsx: 4.23.12
+      yaml: 2.9.0
+
+  vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.0.0-rc.17
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 26.2.0
       esbuild: 0.28.2
       fsevents: 2.3.3
       jiti: 2.7.0
@@ -9257,6 +9254,36 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 25.9.5
+      '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      jsdom: 27.3.0
+    transitivePeerDependencies:
+      - msw
+
+  vitest@4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.2.0)(@vitest/coverage-v8@4.1.10)(jsdom@27.3.0)(vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.0.10(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(tsx@4.23.12)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 26.2.0
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
       jsdom: 27.3.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Native zstd and xz support is optional at runtime, but declaring the codecs in `optionalDependencies` makes package managers install them by default. Under strict pnpm build policies, installing `just-bash` can therefore fail until users approve two native build scripts—even when they never use those codecs.

This moves the codecs to optional peers so applications opt into their native bindings explicitly. The monorepo root retains them as optional development dependencies for codec coverage, missing-codec errors remain actionable, and package metadata coverage prevents native codecs from becoming default install dependencies again.

## Validation

Built the package and confirmed a packed tarball installs in a clean pnpm 11 consumer with `strictDepBuilds: true`, without installing either native codec. The focused package metadata test, lint, typecheck, and knip checks pass.
