### PR TITLE
chore: add prha as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default: changes anywhere need a review from a maintainer.
-* @cramforce
+* @cramforce @prha
 
 # Release plumbing — the workflow is bound to npm Trusted Publisher by
 # filename, so a rename or behavioural change is a security-relevant edit.


### PR DESCRIPTION
## Summary

Add `@prha` to the default CODEOWNERS rule so they are automatically requested on changes across the repository. The release workflow, changeset configuration, and CODEOWNERS file remain explicitly owned only by `@cramforce`.

## Validation

Not applicable; this only updates repository review ownership.
