### PR TITLE
feat(fs): add optional writable file descriptions

### DIFF
--- a/.changeset/open-writable-files.md
+++ b/.changeset/open-writable-files.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add an optional `IFileSystem.openWritable()` interface for output redirections and numeric descriptors. Custom local, remote, and versioned filesystems can now preserve writable open-file-description identity and lifecycle, while existing implementations continue using the `writeFile()` and `appendFile()` fallback.

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -327,39 +327,6 @@ const fs = new MountableFs({
 });
 ```
 
-### Custom writable files
-
-Custom `IFileSystem` implementations may provide the optional `openWritable()`
-method when they can model one writable open file description. just-bash uses
-it for output redirections and numeric output descriptors, including persistent
-and duplicated descriptors. Existing implementations remain compatible and
-fall back to `writeFile()` and `appendFile()` when the method is absent.
-
-```typescript
-import type { IFileSystem } from "just-bash";
-
-async function appendLog(fs: IFileSystem) {
-  const file = await fs.openWritable?.("/logs/run.txt", { mode: "append" });
-  if (!file) return;
-  try {
-    await file.write("started\n", "utf8");
-  } finally {
-    await file.close();
-  }
-}
-```
-
-`mode: "truncate"` must create the file if needed and make its empty content
-observable before `openWritable()` resolves. `mode: "append"` preserves existing
-content and appends each write at the then-current end. Duplicated shell file
-descriptors share the returned object and its write position. Successful opens
-and writes are never rolled back by `close()`.
-
-This interface lets local filesystems retain a real OS handle and lets remote or
-versioned filesystems maintain an execution-visible staging view before making
-their final durable commit. Implementations that cannot preserve these semantics
-should omit the method and use the compatible fallback.
-
 ## Optional Capabilities
 
 ### Network Access

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -327,6 +327,39 @@ const fs = new MountableFs({
 });
 ```
 
+### Custom writable files
+
+Custom `IFileSystem` implementations may provide the optional `openWritable()`
+method when they can model one writable open file description. just-bash uses
+it for output redirections and numeric output descriptors, including persistent
+and duplicated descriptors. Existing implementations remain compatible and
+fall back to `writeFile()` and `appendFile()` when the method is absent.
+
+```typescript
+import type { IFileSystem } from "just-bash";
+
+async function appendLog(fs: IFileSystem) {
+  const file = await fs.openWritable?.("/logs/run.txt", { mode: "append" });
+  if (!file) return;
+  try {
+    await file.write("started\n", "utf8");
+  } finally {
+    await file.close();
+  }
+}
+```
+
+`mode: "truncate"` must create the file if needed and make its empty content
+observable before `openWritable()` resolves. `mode: "append"` preserves existing
+content and appends each write at the then-current end. Duplicated shell file
+descriptors share the returned object and its write position. Successful opens
+and writes are never rolled back by `close()`.
+
+This interface lets local filesystems retain a real OS handle and lets remote or
+versioned filesystems maintain an execution-visible staging view before making
+their final durable commit. Implementations that cannot preserve these semantics
+should omit the method and use the compatible fallback.
+
 ## Optional Capabilities
 
 ### Network Access

--- a/packages/just-bash/src/browser.ts
+++ b/packages/just-bash/src/browser.ts
@@ -42,8 +42,10 @@ export type {
   LazyFileEntry,
   LazyFileProvider,
   MkdirOptions,
+  OpenWritableOptions,
   RmOptions,
   SymlinkEntry,
+  WritableFile,
 } from "./fs/interface.js";
 export {
   MountableFs,

--- a/packages/just-bash/src/comparison-tests/fixtures/redirection-transactions.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/redirection-transactions.comparison.fixtures.json
@@ -13,10 +13,24 @@
     "stderr": "",
     "exitCode": 0
   },
+  "3a42f4c8ffb59f64": {
+    "command": "exec 3>out.txt; exec 4>&3; exec 3>&-; printf data >&4; exec 4>&-; cat out.txt",
+    "files": {},
+    "stdout": "data",
+    "stderr": "",
+    "exitCode": 0
+  },
   "62b3ba73f0e8520d": {
     "command": "fn() { printf before; printf problem >&2; return 4; } >out.txt 2>err.txt; fn; printf 'rc=%s out=%s err=%s' \"$?\" \"$(cat out.txt)\" \"$(cat err.txt)\"",
     "files": {},
     "stdout": "rc=4 out=before err=problem",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "784d8a723759f3c3": {
+    "command": "printf data >first.txt >second.txt; wc -c <first.txt; cat second.txt",
+    "files": {},
+    "stdout": "0\ndata",
     "stderr": "",
     "exitCode": 0
   },
@@ -32,6 +46,13 @@
     "command": "shopt -s expand_aliases; alias routed=': >alias.txt'; eval routed; echo after; test -f alias.txt && echo exists; test ! -s alias.txt && echo empty",
     "files": {},
     "stdout": "after\nexists\nempty\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "cc41fc0fb314e0e8": {
+    "command": "printf previous >out.txt; false >out.txt; wc -c <out.txt",
+    "files": {},
+    "stdout": "0\n",
     "stderr": "",
     "exitCode": 0
   },

--- a/packages/just-bash/src/comparison-tests/redirection-transactions.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/redirection-transactions.comparison.test.ts
@@ -62,6 +62,33 @@ describe("redirection transactions - Real Bash Comparison", () => {
     );
   });
 
+  it("keeps truncation when the redirected command fails", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      "printf previous >out.txt; false >out.txt; wc -c <out.txt",
+    );
+  });
+
+  it("opens multiple output targets in source order", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      "printf data >first.txt >second.txt; wc -c <first.txt; cat second.txt",
+    );
+  });
+
+  it("keeps a duplicated output description alive until its last descriptor closes", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      "exec 3>out.txt; exec 4>&3; exec 3>&-; printf data >&4; exec 4>&-; cat out.txt",
+    );
+  });
+
   it("rejects output written through an fd1 heredoc", async () => {
     const env = await setupFiles(testDirectory, {});
     await compareOutputs(env, testDirectory, "echo hi 1<<EOF\nvalue\nEOF");

--- a/packages/just-bash/src/fs/interface.ts
+++ b/packages/just-bash/src/fs/interface.ts
@@ -31,6 +31,34 @@ export interface WriteFileOptions {
   encoding?: BufferEncoding;
 }
 
+/** How opening a writable file affects existing content. */
+export interface OpenWritableOptions {
+  /**
+   * `truncate` creates the file if needed, empties it immediately, and starts
+   * writing at offset zero. `append` creates the file if needed, preserves its
+   * content, and writes at the then-current end of the file.
+   */
+  mode: "truncate" | "append";
+}
+
+/**
+ * One writable open file description. Duplicated shell descriptors share this
+ * object and therefore its write position.
+ */
+export interface WritableFile {
+  /**
+   * Writes all content at this description's current position and advances it
+   * by the encoded byte length. Unwritten trailing bytes remain. In append
+   * mode, each write instead begins at the file's then-current end.
+   */
+  write(
+    content: FileContent,
+    options?: WriteFileOptions | BufferEncoding,
+  ): Promise<void>;
+  /** Releases this description without rolling back successful mutations. */
+  close(): Promise<void>;
+}
+
 /**
  * File system entry types
  */
@@ -175,6 +203,20 @@ export interface IFileSystem {
     content: FileContent,
     options?: WriteFileOptions | BufferEncoding,
   ): Promise<void>;
+
+  /**
+   * Optionally opens one writable file description for offset-aware output.
+   *
+   * Each call returns a distinct description, even for the same path. Opening
+   * must apply create/truncate semantics before this promise resolves, and
+   * subsequent reads through this filesystem must observe successful writes
+   * before the description is closed. Callers fall back to
+   * `writeFile`/`appendFile` when this method is absent.
+   */
+  openWritable?(
+    path: string,
+    options: OpenWritableOptions,
+  ): Promise<WritableFile>;
 
   /**
    * Check if a path exists

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -66,8 +66,10 @@ export type {
   LazyFileEntry,
   LazyFileProvider,
   MkdirOptions,
+  OpenWritableOptions,
   RmOptions,
   SymlinkEntry,
+  WritableFile,
 } from "./fs/interface.js";
 export {
   MountableFs,

--- a/packages/just-bash/src/interpreter/fd-table.ts
+++ b/packages/just-bash/src/interpreter/fd-table.ts
@@ -198,27 +198,33 @@ export function closeUnusedWritables(
     ...opened,
   ]);
   ctx.state.writableCloseCandidates?.clear();
-  const active = new Set(ctx.state.outputWriters?.values() ?? []);
+  const active = new Set([
+    ...(ctx.state.outputWriters?.values() ?? []),
+    ...(ctx.state.inheritedOutputWriters ?? []),
+  ]);
   const closable = [...candidates]
     .reverse()
     .filter((writable) => !active.has(writable));
   if (closable.length === 0) return undefined;
-  return closeWritables(closable);
+  return closeWritables(ctx, closable);
 }
 
 async function closeWritables(
+  ctx: InterpreterContext,
   writables: readonly WritableFile[],
 ): Promise<void> {
-  const errors: unknown[] = [];
   for (const writable of writables) {
     try {
       await writable.close();
     } catch (error) {
-      errors.push(error);
+      // Preserve the result-oriented Bash.exec contract and any in-flight
+      // shell control flow. ExecutionScope reports cleanup failures as 126.
+      try {
+        ctx.executionScope.registerCleanup(() => Promise.reject(error));
+      } catch {
+        // An existing abort or limit failure remains authoritative.
+      }
     }
-  }
-  if (errors.length > 0) {
-    throw new AggregateError(errors, "failed to close writable files");
   }
 }
 

--- a/packages/just-bash/src/interpreter/fd-table.ts
+++ b/packages/just-bash/src/interpreter/fd-table.ts
@@ -189,19 +189,28 @@ function attachWritable(
  * Newly opened command-scoped descriptions may be supplied because standard
  * descriptors do not always need an encoded table entry.
  */
-export async function closeUnusedWritables(
+export function closeUnusedWritables(
   ctx: InterpreterContext,
   opened: readonly WritableFile[] = [],
-): Promise<void> {
+): Promise<void> | undefined {
   const candidates = new Set([
     ...(ctx.state.writableCloseCandidates ?? []),
     ...opened,
   ]);
   ctx.state.writableCloseCandidates?.clear();
   const active = new Set(ctx.state.outputWriters?.values() ?? []);
+  const closable = [...candidates]
+    .reverse()
+    .filter((writable) => !active.has(writable));
+  if (closable.length === 0) return undefined;
+  return closeWritables(closable);
+}
+
+async function closeWritables(
+  writables: readonly WritableFile[],
+): Promise<void> {
   const errors: unknown[] = [];
-  for (const writable of [...candidates].reverse()) {
-    if (active.has(writable)) continue;
+  for (const writable of writables) {
     try {
       await writable.close();
     } catch (error) {

--- a/packages/just-bash/src/interpreter/fd-table.ts
+++ b/packages/just-bash/src/interpreter/fd-table.ts
@@ -23,6 +23,7 @@
  * older code paths.
  */
 
+import type { WritableFile } from "../fs/interface.js";
 import { checkFdLimit } from "./helpers/result.js";
 import type { InterpreterContext } from "./types.js";
 
@@ -37,7 +38,12 @@ export const FIRST_USER_FD = 3;
 
 export type FdEntry =
   | { kind: "input"; content: string }
-  | { kind: "output"; path: string; append: boolean }
+  | {
+      kind: "output";
+      path: string;
+      append: boolean;
+      writable?: WritableFile;
+    }
   | { kind: "readwrite"; path: string; position: number; content: string }
   | { kind: "dup-out"; sourceFd: number }
   | { kind: "dup-in"; sourceFd: number }
@@ -50,6 +56,7 @@ export type FdEntry =
 interface FdSnapshotEntry {
   raw: string | undefined;
   isInput: boolean;
+  writable: WritableFile | undefined;
   aliases: number[];
 }
 
@@ -152,6 +159,60 @@ function markContent(ctx: InterpreterContext, fd: number, isInput: boolean) {
   }
 }
 
+function writableForFd(
+  ctx: InterpreterContext,
+  fd: number,
+): WritableFile | undefined {
+  return ctx.state.outputWriters?.get(fd);
+}
+
+function detachWritable(ctx: InterpreterContext, fd: number): void {
+  const writable = writableForFd(ctx, fd);
+  if (!writable) return;
+  ctx.state.outputWriters?.delete(fd);
+  ctx.state.writableCloseCandidates ??= new Set();
+  ctx.state.writableCloseCandidates.add(writable);
+}
+
+function attachWritable(
+  ctx: InterpreterContext,
+  fd: number,
+  writable: WritableFile | undefined,
+): void {
+  if (!writable) return;
+  ctx.state.outputWriters ??= new Map();
+  ctx.state.outputWriters.set(fd, writable);
+}
+
+/**
+ * Closes candidate descriptions that no live shell descriptor still owns.
+ * Newly opened command-scoped descriptions may be supplied because standard
+ * descriptors do not always need an encoded table entry.
+ */
+export async function closeUnusedWritables(
+  ctx: InterpreterContext,
+  opened: readonly WritableFile[] = [],
+): Promise<void> {
+  const candidates = new Set([
+    ...(ctx.state.writableCloseCandidates ?? []),
+    ...opened,
+  ]);
+  ctx.state.writableCloseCandidates?.clear();
+  const active = new Set(ctx.state.outputWriters?.values() ?? []);
+  const errors: unknown[] = [];
+  for (const writable of [...candidates].reverse()) {
+    if (active.has(writable)) continue;
+    try {
+      await writable.close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "failed to close writable files");
+  }
+}
+
 // ---- Shared open file descriptions -----------------------------------------
 // `N<&M` gives N and M the same open file description, so they share ONE read
 // offset: after `exec 4<&3`, reading fd 3 moves fd 4 forward too. The table
@@ -217,7 +278,10 @@ export function getFdEntry(
   // A descriptor known to hold content is never re-parsed: a file whose
   // first line reads `__file__:/tmp/x` is data, not a marker.
   if (ctx.state.inputFds?.has(fd)) return { kind: "input", content: raw };
-  return decodeFdEntry(raw);
+  const entry = decodeFdEntry(raw);
+  if (entry.kind !== "output") return entry;
+  const writable = writableForFd(ctx, fd);
+  return writable ? { ...entry, writable } : entry;
 }
 
 export function isFdOpen(ctx: InterpreterContext, fd: number): boolean {
@@ -250,6 +314,7 @@ export function setRawFd(
   isInput = false,
 ): void {
   leaveAliasGroup(ctx, fd);
+  detachWritable(ctx, fd);
   writeRawFd(ctx, fd, raw, isInput);
 }
 
@@ -259,11 +324,13 @@ export function setFdEntry(
   entry: FdEntry,
 ): void {
   setRawFd(ctx, fd, encodeFdEntry(entry), entry.kind === "input");
+  attachWritable(ctx, fd, entry.kind === "output" ? entry.writable : undefined);
 }
 
 export function closeFd(ctx: InterpreterContext, fd: number): void {
   ctx.state.fileDescriptors?.delete(fd);
   ctx.state.inputFds?.delete(fd);
+  detachWritable(ctx, fd);
   leaveAliasGroup(ctx, fd);
 }
 
@@ -280,7 +347,9 @@ export function dupFd(
 ): boolean {
   const raw = getRawFd(ctx, sourceFd);
   if (raw === undefined) return false;
+  const writable = writableForFd(ctx, sourceFd);
   setRawFd(ctx, fd, raw, ctx.state.inputFds?.has(sourceFd) === true);
+  attachWritable(ctx, fd, writable);
   joinAliasGroup(ctx, fd, sourceFd);
   return true;
 }
@@ -294,11 +363,13 @@ export function moveFd(
   if (raw === undefined) return false;
   if (fd === sourceFd) return true;
   const isInput = ctx.state.inputFds?.has(sourceFd) === true;
+  const writable = writableForFd(ctx, sourceFd);
   const aliases = [...(aliasGroup(ctx, sourceFd) ?? [])].filter(
     (member) => member !== sourceFd,
   );
   closeFd(ctx, sourceFd);
   setRawFd(ctx, fd, raw, isInput);
+  attachWritable(ctx, fd, writable);
   const survivor = aliases.find((member) => isFdOpen(ctx, member));
   if (survivor !== undefined) joinAliasGroup(ctx, fd, survivor);
   return true;
@@ -370,7 +441,11 @@ export async function writeFdEntry(
   encoding: "binary" | "utf8",
 ): Promise<boolean> {
   if (entry.kind === "output") {
-    await ctx.fs.appendFile(entry.path, content, encoding);
+    if (entry.writable) {
+      await entry.writable.write(content, encoding);
+    } else {
+      await ctx.fs.appendFile(entry.path, content, encoding);
+    }
     return true;
   }
   const liveEntry = descriptors
@@ -414,6 +489,7 @@ export function rememberFd(
   snapshot.set(fd, {
     raw: getRawFd(ctx, fd),
     isInput: ctx.state.inputFds?.has(fd) === true,
+    writable: writableForFd(ctx, fd),
     aliases: group ? [...group].filter((member) => member !== fd) : [],
   });
 }
@@ -444,13 +520,14 @@ export function restoreFds(
 ): void {
   const fds = ctx.state.fileDescriptors;
   if (!fds) return;
-  for (const [fd, { raw, isInput, aliases }] of snapshot) {
+  for (const [fd, { raw, isInput, writable, aliases }] of snapshot) {
     if (raw === undefined) {
       closeFd(ctx, fd);
       continue;
     }
     // Re-opening the saved value detaches fd from whatever it aliases now.
     setRawFd(ctx, fd, raw, isInput);
+    attachWritable(ctx, fd, writable);
     // Then re-attach it to whichever of its original co-members is still
     // open — they all share one description, so any survivor will do.
     const survivor = aliases.find((member) => fds.has(member));

--- a/packages/just-bash/src/interpreter/functions.ts
+++ b/packages/just-bash/src/interpreter/functions.ts
@@ -208,6 +208,7 @@ export async function callFunction(
       execResult,
       func.redirections,
       prepared.targets,
+      prepared.outputEntries,
       prepared.dupSources,
       prepared.standardRoutes,
     );
@@ -220,7 +221,10 @@ export async function callFunction(
     }
     throw error;
   } finally {
-    redirectionTransaction.finish();
-    cleanup();
+    try {
+      await redirectionTransaction.finish();
+    } finally {
+      cleanup();
+    }
   }
 }

--- a/packages/just-bash/src/interpreter/functions.ts
+++ b/packages/just-bash/src/interpreter/functions.ts
@@ -222,7 +222,8 @@ export async function callFunction(
     throw error;
   } finally {
     try {
-      await redirectionTransaction.finish();
+      const closing = redirectionTransaction.finish();
+      if (closing) await closing;
     } finally {
       cleanup();
     }

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -613,7 +613,8 @@ export class Interpreter {
         transaction = created;
       });
     } catch (error) {
-      await transaction?.finish();
+      const closing = transaction?.finish();
+      if (closing) await closing;
       if (error instanceof GlobError) {
         // GlobError from failglob should return exit code 1 with error message
         return failure(error.stderr);
@@ -696,13 +697,15 @@ export class Interpreter {
         if (preparedRedirections.error) {
           restoreTempAssignments();
           if (!preparedRedirections.errorCause) {
-            await transaction.finish();
+            const closing = transaction.finish();
+            if (closing) await closing;
             return preparedRedirections.error;
           }
           try {
             return preparedRedirectionError(preparedRedirections);
           } finally {
-            await transaction.finish();
+            const closing = transaction.finish();
+            if (closing) await closing;
           }
         }
         const baseResult = result("", xtraceAssignmentOutput, 0);
@@ -715,7 +718,8 @@ export class Interpreter {
           preparedRedirections.dupSources,
           preparedRedirections.standardRoutes,
         );
-        await transaction.finish();
+        const closing = transaction.finish();
+        if (closing) await closing;
         return redirected;
       }
 
@@ -854,7 +858,8 @@ export class Interpreter {
     if (preparedRedirections.error) {
       restoreTempAssignments();
       if (!preparedRedirections.errorCause) {
-        await transaction.finish();
+        const closing = transaction.finish();
+        if (closing) await closing;
         return preparedRedirections.error;
       }
       return preparedRedirectionError(preparedRedirections);
@@ -877,11 +882,13 @@ export class Interpreter {
       if (commandIsOnlyExpansions) {
         // No args - treat as no-op (status 0)
         // Preserve lastExitCode for command subs like $(exit 42)
-        await transaction.finish();
+        const closing = transaction.finish();
+        if (closing) await closing;
         return result("", "", this.ctx.state.lastExitCode);
       }
       // Literal empty command name - command not found
-      await transaction.finish();
+      const closing = transaction.finish();
+      if (closing) await closing;
       return failure("bash: : command not found\n", 127);
     }
 
@@ -901,7 +908,8 @@ export class Interpreter {
           this.ctx.state.tempExportedVars.delete(name);
         }
       }
-      await transaction.finish();
+      const closing = transaction.finish();
+      if (closing) await closing;
       return OK;
     }
 
@@ -976,7 +984,8 @@ export class Interpreter {
       cmdResult.internalProducerCommand ?? commandName,
       cmdResult.internalProducerOmitsShellPrefix,
     );
-    await transaction.finish();
+    const closing = transaction.finish();
+    if (closing) await closing;
 
     // If we caught a break/continue error, re-throw it after applying redirections
     if (controlFlowError) {

--- a/packages/just-bash/src/interpreter/interpreter.ts
+++ b/packages/just-bash/src/interpreter/interpreter.ts
@@ -613,7 +613,7 @@ export class Interpreter {
         transaction = created;
       });
     } catch (error) {
-      transaction?.finish();
+      await transaction?.finish();
       if (error instanceof GlobError) {
         // GlobError from failglob should return exit code 1 with error message
         return failure(error.stderr);
@@ -696,13 +696,13 @@ export class Interpreter {
         if (preparedRedirections.error) {
           restoreTempAssignments();
           if (!preparedRedirections.errorCause) {
-            transaction.finish();
+            await transaction.finish();
             return preparedRedirections.error;
           }
           try {
             return preparedRedirectionError(preparedRedirections);
           } finally {
-            transaction.finish();
+            await transaction.finish();
           }
         }
         const baseResult = result("", xtraceAssignmentOutput, 0);
@@ -711,10 +711,11 @@ export class Interpreter {
           baseResult,
           node.redirections,
           preparedRedirections.targets,
+          preparedRedirections.outputEntries,
           preparedRedirections.dupSources,
           preparedRedirections.standardRoutes,
         );
-        transaction.finish();
+        await transaction.finish();
         return redirected;
       }
 
@@ -853,7 +854,7 @@ export class Interpreter {
     if (preparedRedirections.error) {
       restoreTempAssignments();
       if (!preparedRedirections.errorCause) {
-        transaction.finish();
+        await transaction.finish();
         return preparedRedirections.error;
       }
       return preparedRedirectionError(preparedRedirections);
@@ -876,11 +877,11 @@ export class Interpreter {
       if (commandIsOnlyExpansions) {
         // No args - treat as no-op (status 0)
         // Preserve lastExitCode for command subs like $(exit 42)
-        transaction.finish();
+        await transaction.finish();
         return result("", "", this.ctx.state.lastExitCode);
       }
       // Literal empty command name - command not found
-      transaction.finish();
+      await transaction.finish();
       return failure("bash: : command not found\n", 127);
     }
 
@@ -900,7 +901,7 @@ export class Interpreter {
           this.ctx.state.tempExportedVars.delete(name);
         }
       }
-      transaction.finish();
+      await transaction.finish();
       return OK;
     }
 
@@ -969,12 +970,13 @@ export class Interpreter {
       cmdResult,
       node.redirections,
       preparedRedirections.targets,
+      preparedRedirections.outputEntries,
       preparedRedirections.dupSources,
       preparedRedirections.standardRoutes,
       cmdResult.internalProducerCommand ?? commandName,
       cmdResult.internalProducerOmitsShellPrefix,
     );
-    transaction.finish();
+    await transaction.finish();
 
     // If we caught a break/continue error, re-throw it after applying redirections
     if (controlFlowError) {

--- a/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
@@ -174,6 +174,26 @@ describe("optional writable file descriptions", () => {
     expect(fs.commits).toEqual(["/second:hello", "/first:"]);
   });
 
+  it("preserves independent positions for separate opens of one path", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "{ printf abc; printf Z >&2; } > /out 2> /out",
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("Zbc");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "open:truncate:/out",
+      "handle-write:/out:abc",
+      "handle-write:/out:Z",
+      "close:/out",
+      "close:/out",
+    ]);
+  });
+
   it("closes earlier successful opens when a later redirect fails", async () => {
     const fs = new RecordingWritableFs({ "/first": "previous" });
     const bash = new Bash({ fs });

--- a/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { getEncoding, toBuffer } from "../fs/encoding.js";
+import { InMemoryFs } from "../fs/in-memory-fs/in-memory-fs.js";
+import type {
+  BufferEncoding,
+  FileContent,
+  OpenWritableOptions,
+  WritableFile,
+  WriteFileOptions,
+} from "../fs/interface.js";
+
+function text(content: FileContent): string {
+  return typeof content === "string"
+    ? content
+    : new TextDecoder().decode(content);
+}
+
+class RecordingWritableFs extends InMemoryFs {
+  readonly events: string[] = [];
+  readonly commits: string[] = [];
+
+  override async writeFile(
+    path: string,
+    content: FileContent,
+    options?: WriteFileOptions | BufferEncoding,
+  ): Promise<void> {
+    this.events.push(`legacy-write:${path}:${text(content)}`);
+    await super.writeFile(path, content, options);
+  }
+
+  override async appendFile(
+    path: string,
+    content: FileContent,
+    options?: WriteFileOptions | BufferEncoding,
+  ): Promise<void> {
+    this.events.push(`legacy-append:${path}:${text(content)}`);
+    await super.appendFile(path, content, options);
+  }
+
+  async openWritable(
+    path: string,
+    options: OpenWritableOptions,
+  ): Promise<WritableFile> {
+    this.events.push(`open:${options.mode}:${path}`);
+    if (path === "/denied") throw new Error("denied");
+    if (options.mode === "truncate") {
+      await super.writeFile(path, "", "binary");
+    } else {
+      await super.appendFile(path, "", "binary");
+    }
+
+    let closed = false;
+    let position = 0;
+    return {
+      write: async (content, writeOptions) => {
+        if (closed) throw new Error("write after close");
+        this.events.push(`handle-write:${path}:${text(content)}`);
+        if (options.mode === "append") {
+          await super.appendFile(path, content, writeOptions);
+          return;
+        }
+        const existing = await super.readFileBuffer(path);
+        const added = toBuffer(content, getEncoding(writeOptions));
+        const updated = new Uint8Array(
+          Math.max(existing.length, position + added.length),
+        );
+        updated.set(existing);
+        updated.set(added, position);
+        position += added.length;
+        await super.writeFile(path, updated, "binary");
+      },
+      close: async () => {
+        if (closed) throw new Error("double close");
+        closed = true;
+        this.commits.push(`${path}:${await super.readFile(path)}`);
+        this.events.push(`close:${path}`);
+      },
+    };
+  }
+}
+
+describe("optional writable file descriptions", () => {
+  it("opens, writes, and closes a redirected output through one description", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf hello > /out");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("hello");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:hello",
+      "close:/out",
+    ]);
+    expect(fs.commits).toEqual(["/out:hello"]);
+  });
+
+  it("closes an output opened by a command that produces no output", async () => {
+    const fs = new RecordingWritableFs({ "/out": "previous" });
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("false > /out");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 1 });
+    expect(await fs.readFile("/out")).toBe("");
+    expect(fs.events).toEqual(["open:truncate:/out", "close:/out"]);
+    expect(fs.commits).toEqual(["/out:"]);
+  });
+
+  it("uses append mode without truncating existing content", async () => {
+    const fs = new RecordingWritableFs({ "/out": "before" });
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf after >> /out");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("beforeafter");
+    expect(fs.events).toEqual([
+      "open:append:/out",
+      "handle-write:/out:after",
+      "close:/out",
+    ]);
+  });
+
+  it("opens multiple redirects in source order and writes only to the final one", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf hello > /first > /second");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/first")).toBe("");
+    expect(await fs.readFile("/second")).toBe("hello");
+    expect(fs.events).toEqual([
+      "open:truncate:/first",
+      "open:truncate:/second",
+      "handle-write:/second:hello",
+      "close:/second",
+      "close:/first",
+    ]);
+    expect(fs.commits).toEqual(["/second:hello", "/first:"]);
+  });
+
+  it("closes earlier successful opens when a later redirect fails", async () => {
+    const fs = new RecordingWritableFs({ "/first": "previous" });
+    const bash = new Bash({ fs });
+
+    await expect(
+      bash.exec("printf ignored > /first > /denied"),
+    ).rejects.toThrow("denied");
+    expect(await fs.readFile("/first")).toBe("");
+    expect(fs.events).toEqual([
+      "open:truncate:/first",
+      "open:truncate:/denied",
+      "close:/first",
+    ]);
+  });
+
+  it("keeps a persistent descriptor open until the descriptor is closed", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "exec 3> /out; printf one >&3; printf two >&3; exec 3>&-",
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("onetwo");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:one",
+      "handle-write:/out:two",
+      "close:/out",
+    ]);
+  });
+
+  it("closes persistent descriptors during execution cleanup", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("exec 3> /out; printf value >&3");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("value");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
+  it("restores a persistent writer after a command-scoped descriptor override", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      [
+        "exec 3> /persistent",
+        "printf temporary 3> /temporary >&3",
+        "printf persistent >&3",
+        "exec 3>&-",
+      ].join("; "),
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/temporary")).toBe("temporary");
+    expect(await fs.readFile("/persistent")).toBe("persistent");
+    expect(fs.events).toEqual([
+      "open:truncate:/persistent",
+      "open:truncate:/temporary",
+      "handle-write:/temporary:temporary",
+      "close:/temporary",
+      "handle-write:/persistent:persistent",
+      "close:/persistent",
+    ]);
+  });
+
+  it("keeps a duplicated descriptor open until its final alias closes", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "exec 3> /out; exec 4>&3; exec 3>&-; printf value >&4; exec 4>&-",
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("value");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
+  it("keeps a named descriptor open beyond its creating command", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "true {output}>/out; printf value >&$output; exec {output}>&-",
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("value");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
+  it("keeps legacy path operations as the fallback", async () => {
+    const fs = new InMemoryFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf hello > /out");
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("hello");
+  });
+});

--- a/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
+++ b/packages/just-bash/src/interpreter/redirections.open-writable.test.ts
@@ -80,6 +80,37 @@ class RecordingWritableFs extends InMemoryFs {
   }
 }
 
+class FailingCloseFs extends RecordingWritableFs {
+  override async openWritable(
+    path: string,
+    options: OpenWritableOptions,
+  ): Promise<WritableFile> {
+    const writable = await super.openWritable(path, options);
+    return {
+      write: writable.write,
+      close: async () => {
+        await writable.close();
+        throw new Error("durable commit failed");
+      },
+    };
+  }
+}
+
+class AbortingOpenFs extends RecordingWritableFs {
+  constructor(private readonly controller: AbortController) {
+    super();
+  }
+
+  override async openWritable(
+    path: string,
+    options: OpenWritableOptions,
+  ): Promise<WritableFile> {
+    const writable = await super.openWritable(path, options);
+    this.controller.abort();
+    return writable;
+  }
+}
+
 describe("optional writable file descriptions", () => {
   it("opens, writes, and closes a redirected output through one description", async () => {
     const fs = new RecordingWritableFs();
@@ -191,6 +222,40 @@ describe("optional writable file descriptions", () => {
     ]);
   });
 
+  it("does not close a parent description when a subshell closes its copy", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "exec 3> /out; (exec 3>&-); printf value >&3; exec 3>&-",
+    );
+
+    expect(result).toMatchObject({ stdout: "", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("value");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
+  it("closes child-only persistent descriptions when isolated state is restored", async () => {
+    const fs = new RecordingWritableFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec(
+      "(exec 3> /out; printf value >&3); printf after",
+    );
+
+    expect(result).toMatchObject({ stdout: "after", stderr: "", exitCode: 0 });
+    expect(await fs.readFile("/out")).toBe("value");
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
   it("restores a persistent writer after a command-scoped descriptor override", async () => {
     const fs = new RecordingWritableFs();
     const bash = new Bash({ fs });
@@ -249,6 +314,41 @@ describe("optional writable file descriptions", () => {
       "handle-write:/out:value",
       "close:/out",
     ]);
+  });
+
+  it("reports close failures through execution cleanup", async () => {
+    const fs = new FailingCloseFs();
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf value > /out");
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "bash: execution cleanup failed\n",
+      exitCode: 126,
+    });
+    expect(fs.events).toEqual([
+      "open:truncate:/out",
+      "handle-write:/out:value",
+      "close:/out",
+    ]);
+  });
+
+  it("closes a writable acquired while execution is being cancelled", async () => {
+    const controller = new AbortController();
+    const fs = new AbortingOpenFs(controller);
+    const bash = new Bash({ fs });
+
+    const result = await bash.exec("printf value > /out", {
+      signal: controller.signal,
+    });
+
+    expect(result).toMatchObject({
+      stdout: "",
+      stderr: "bash: execution aborted\n",
+      exitCode: 124,
+    });
+    expect(fs.events).toEqual(["open:truncate:/out", "close:/out"]);
   });
 
   it("keeps legacy path operations as the fallback", async () => {

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -17,6 +17,7 @@ import {
   readBytesFrom,
   utf8ByteLength,
 } from "../encoding.js";
+import type { WritableFile } from "../fs/interface.js";
 import type { ExecResult } from "../types.js";
 import {
   ControlFlowError,
@@ -32,6 +33,7 @@ import {
 } from "./expansion.js";
 import {
   closeFd,
+  closeUnusedWritables,
   dupFd,
   type FdEntry,
   type FdSnapshot,
@@ -120,6 +122,7 @@ export type PreparedDupSources = Map<number, PreparedDupSource>;
 
 export type PreparedRedirections = {
   targets: ExpandedRedirectTargets;
+  outputEntries: Map<number, FdEntry>;
   dupSources: PreparedDupSources;
   standardRoutes: Map<number, FdEntry>;
   stdin: string | undefined;
@@ -136,6 +139,8 @@ export const EXEC_REDIRECTION_POLICY: RedirectionPolicy = "persistent";
 
 type RedirectionTransactionState = {
   numericSnapshot: FdSnapshot;
+  outputEntries: Map<number, FdEntry>;
+  openedWritables: WritableFile[];
   fdVariableSnapshot: FdSnapshot;
   standardSnapshot: FdSnapshot;
   standardClosedSnapshot: Map<number, boolean>;
@@ -146,7 +151,7 @@ type RedirectionTransactionState = {
 
 export type RedirectionTransaction = {
   prepare: (inheritedStdin?: string) => Promise<PreparedRedirections>;
-  finish: () => void;
+  finish: () => Promise<void>;
 };
 
 const fdLimitError = (ctx: InterpreterContext): ExecutionLimitError =>
@@ -200,8 +205,39 @@ const getDupSource = (
     : null;
 };
 
+function manageWritable(
+  ctx: InterpreterContext,
+  writable: WritableFile,
+): WritableFile {
+  let closePromise: Promise<void> | undefined;
+  let unregisterCleanup = (): void => undefined;
+  const managed: WritableFile = {
+    write: (content, options) => {
+      if (closePromise) {
+        return Promise.reject(new Error("cannot write to a closed file"));
+      }
+      return writable.write(content, options);
+    },
+    close: () => {
+      if (!closePromise) {
+        unregisterCleanup();
+        try {
+          closePromise = Promise.resolve(writable.close());
+        } catch (error) {
+          closePromise = Promise.reject(error);
+        }
+      }
+      return closePromise;
+    },
+  };
+  unregisterCleanup = ctx.executionScope.registerCleanup(() => managed.close());
+  return managed;
+}
+
 async function openOutputEntry(
   ctx: InterpreterContext,
+  transaction: RedirectionTransactionState,
+  index: number,
   target: string,
   append: boolean,
   isClobber: boolean,
@@ -218,13 +254,27 @@ async function openOutputEntry(
       error: makeResult("", "bash: /dev/full: No space left on device\n", 1),
     };
   }
+  const opened = (entry: FdEntry): { entry: FdEntry } => {
+    transaction.outputEntries.set(index, entry);
+    return { entry };
+  };
   if (target === "/dev/stdout") {
-    return { entry: { kind: "dup-out", sourceFd: 1 } };
+    return opened({ kind: "dup-out", sourceFd: 1 });
   }
   if (target === "/dev/stderr") {
-    return { entry: { kind: "dup-out", sourceFd: 2 } };
+    return opened({ kind: "dup-out", sourceFd: 2 });
   }
   try {
+    if (ctx.fs.openWritable) {
+      const writable = manageWritable(
+        ctx,
+        await ctx.fs.openWritable(filePath, {
+          mode: append ? "append" : "truncate",
+        }),
+      );
+      transaction.openedWritables.push(writable);
+      return opened({ kind: "output", path: filePath, append, writable });
+    }
     if (append) await ctx.fs.appendFile(filePath, "", "binary");
     else await ctx.fs.writeFile(filePath, "", "binary");
   } catch (error) {
@@ -237,7 +287,7 @@ async function openOutputEntry(
       ),
     };
   }
-  return { entry: { kind: "output", path: filePath, append } };
+  return opened({ kind: "output", path: filePath, append });
 }
 
 async function readInputEntry(
@@ -341,6 +391,7 @@ async function prepareRedirectionsWithState(
   }
   const base = (): PreparedRedirections => ({
     targets,
+    outputEntries: transaction.outputEntries,
     dupSources,
     standardRoutes,
     stdin,
@@ -359,6 +410,7 @@ async function prepareRedirectionsWithState(
         error,
         redirections.slice(0, index),
         targets,
+        transaction.outputEntries,
         dupSources,
         standardRoutes,
       ),
@@ -571,7 +623,14 @@ async function prepareRedirectionsWithState(
               index,
             );
           }
-          const opened = await openOutputEntry(ctx, target, false, false);
+          const opened = await openOutputEntry(
+            ctx,
+            transaction,
+            index,
+            target,
+            false,
+            false,
+          );
           if (opened.error) return fail(opened.error, index);
           entry = opened.entry;
         } else {
@@ -609,6 +668,8 @@ async function prepareRedirectionsWithState(
         const append = redir.operator === ">>" || redir.operator === "&>>";
         const opened = await openOutputEntry(
           ctx,
+          transaction,
+          index,
           target,
           append,
           redir.operator === ">|",
@@ -698,7 +759,14 @@ async function prepareRedirectionsWithState(
               index,
             );
           }
-          const opened = await openOutputEntry(ctx, target, false, false);
+          const opened = await openOutputEntry(
+            ctx,
+            transaction,
+            index,
+            target,
+            false,
+            false,
+          );
           if (opened.error) return fail(opened.error, index);
           setFdEntry(ctx, fd, opened.entry as FdEntry);
           continue;
@@ -754,6 +822,8 @@ async function prepareRedirectionsWithState(
       ) {
         const opened = await openOutputEntry(
           ctx,
+          transaction,
+          index,
           target,
           redir.operator === ">>",
           redir.operator === ">|",
@@ -798,7 +868,15 @@ async function prepareRedirectionsWithState(
             index,
           );
         }
-        const opened = await openOutputEntry(ctx, target, false, false, false);
+        const opened = await openOutputEntry(
+          ctx,
+          transaction,
+          index,
+          target,
+          false,
+          false,
+          false,
+        );
         if (opened.error) return fail(opened.error, index);
         const entry = opened.entry as FdEntry;
         dupSources.set(index, {
@@ -913,6 +991,8 @@ async function prepareRedirectionsWithState(
     ) {
       const opened = await openOutputEntry(
         ctx,
+        transaction,
+        index,
         target,
         redir.operator === ">>" || redir.operator === "&>>",
         redir.operator === ">|",
@@ -967,6 +1047,8 @@ export function createRedirectionTransaction(
 ): RedirectionTransaction {
   const state: RedirectionTransactionState = {
     numericSnapshot: new Map(),
+    outputEntries: new Map(),
+    openedWritables: [],
     fdVariableSnapshot: new Map(),
     standardSnapshot: new Map(),
     standardClosedSnapshot: new Map(),
@@ -978,7 +1060,7 @@ export function createRedirectionTransaction(
   return {
     prepare: (inheritedStdin = "") =>
       prepareRedirectionsWithState(ctx, redirections, inheritedStdin, state),
-    finish: () => {
+    finish: async () => {
       if (finished) return;
       finished = true;
       if (policy !== "persistent") {
@@ -1003,6 +1085,7 @@ export function createRedirectionTransaction(
         }
         ctx.state.nextFd = state.nextFd;
       }
+      await closeUnusedWritables(ctx, state.openedWritables);
     },
   };
 }
@@ -1038,6 +1121,7 @@ export async function routeControlFlowError(
     makeResult(error.stdout, error.stderr, exitCode),
     redirections,
     prepared.targets,
+    prepared.outputEntries,
     prepared.dupSources,
     prepared.standardRoutes,
   );
@@ -1077,6 +1161,7 @@ export async function withPreparedRedirections(
         result,
         redirections,
         prepared.targets,
+        prepared.outputEntries,
         prepared.dupSources,
         prepared.standardRoutes,
       );
@@ -1091,7 +1176,7 @@ export async function withPreparedRedirections(
     await routeControlFlowError(ctx, error, redirections, prepared);
     throw error;
   } finally {
-    transaction.finish();
+    await transaction.finish();
   }
 }
 
@@ -1100,6 +1185,7 @@ export async function applyRedirections(
   result: ExecResult,
   redirections: RedirectionNode[],
   targets: ExpandedRedirectTargets,
+  outputEntries: Map<number, FdEntry> = new Map(),
   dupSources: PreparedDupSources = new Map(),
   standardRoutes: Map<number, FdEntry> = new Map(),
   writeErrorCommand = "bash",
@@ -1142,10 +1228,11 @@ export async function applyRedirections(
   // so `cmd > file 2>&1` sends stderr to `file`, `cmd 2>&1 > file` sends
   // stderr to the caller's stdout, and `cmd > all 2>&1 2> err` lets the
   // later `2> err` reclaim stderr.
+  type OutputEntry = Extract<FdEntry, { kind: "output" }>;
   type RedirectSink =
     | { kind: "live-stdout" }
     | { kind: "live-stderr" }
-    | { kind: "file"; path: string; append: boolean }
+    | { kind: "file"; entry: OutputEntry }
     | {
         kind: "descriptor";
         source: Extract<PreparedDupSource, { kind: "entry" }>;
@@ -1259,10 +1346,15 @@ export async function applyRedirections(
           break;
         }
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
+        const preparedEntry = outputEntries.get(i);
+        const entry: OutputEntry =
+          preparedEntry?.kind === "output"
+            ? preparedEntry
+            : { kind: "output", path: filePath, append: isAppend };
         if (fd === 1) {
-          fd1Sink = { kind: "file", path: filePath, append: isAppend };
+          fd1Sink = { kind: "file", entry };
         } else {
-          fd2Sink = { kind: "file", path: filePath, append: isAppend };
+          fd2Sink = { kind: "file", entry };
         }
         break;
       }
@@ -1289,16 +1381,16 @@ export async function applyRedirections(
         break;
       }
 
-      case "&>": {
-        const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        fd1Sink = { kind: "file", path: filePath, append: false };
-        fd2Sink = fd1Sink;
-        break;
-      }
-
+      case "&>":
       case "&>>": {
+        const append = redir.operator === "&>>";
         const filePath = ctx.fs.resolvePath(ctx.state.cwd, target);
-        fd1Sink = { kind: "file", path: filePath, append: true };
+        const preparedEntry = outputEntries.get(i);
+        const entry: OutputEntry =
+          preparedEntry?.kind === "output"
+            ? preparedEntry
+            : { kind: "output", path: filePath, append };
+        fd1Sink = { kind: "file", entry };
         fd2Sink = fd1Sink;
         break;
       }
@@ -1328,14 +1420,16 @@ export async function applyRedirections(
     }
     if (fd2Sink.kind === "invalid-output") pendingStderr = "";
     const deliverToFile = async (
-      sink: { path: string; append: boolean },
+      sink: Extract<RedirectSink, { kind: "file" }>,
       content: string,
       encoding: "binary" | "utf8",
     ) => {
-      if (sink.append) {
-        await ctx.fs.appendFile(sink.path, content, encoding);
+      if (sink.entry.writable) {
+        await sink.entry.writable.write(content, encoding);
+      } else if (sink.entry.append) {
+        await ctx.fs.appendFile(sink.entry.path, content, encoding);
       } else {
-        await ctx.fs.writeFile(sink.path, content, encoding);
+        await ctx.fs.writeFile(sink.entry.path, content, encoding);
       }
     };
     if (

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -205,10 +205,10 @@ const getDupSource = (
     : null;
 };
 
-function manageWritable(
+async function manageWritable(
   ctx: InterpreterContext,
   writable: WritableFile,
-): WritableFile {
+): Promise<WritableFile> {
   let closePromise: Promise<void> | undefined;
   let unregisterCleanup = (): void => undefined;
   const managed: WritableFile = {
@@ -230,7 +230,18 @@ function manageWritable(
       return closePromise;
     },
   };
-  unregisterCleanup = ctx.executionScope.registerCleanup(() => managed.close());
+  try {
+    unregisterCleanup = ctx.executionScope.registerCleanup(() =>
+      managed.close(),
+    );
+  } catch (error) {
+    try {
+      await writable.close();
+    } catch {
+      // The existing abort or limit failure remains authoritative.
+    }
+    throw error;
+  }
   return managed;
 }
 
@@ -266,7 +277,7 @@ async function openOutputEntry(
   }
   try {
     if (ctx.fs.openWritable) {
-      const writable = manageWritable(
+      const writable = await manageWritable(
         ctx,
         await ctx.fs.openWritable(filePath, {
           mode: append ? "append" : "truncate",

--- a/packages/just-bash/src/interpreter/redirections.ts
+++ b/packages/just-bash/src/interpreter/redirections.ts
@@ -151,7 +151,7 @@ type RedirectionTransactionState = {
 
 export type RedirectionTransaction = {
   prepare: (inheritedStdin?: string) => Promise<PreparedRedirections>;
-  finish: () => Promise<void>;
+  finish: () => Promise<void> | undefined;
 };
 
 const fdLimitError = (ctx: InterpreterContext): ExecutionLimitError =>
@@ -1060,8 +1060,8 @@ export function createRedirectionTransaction(
   return {
     prepare: (inheritedStdin = "") =>
       prepareRedirectionsWithState(ctx, redirections, inheritedStdin, state),
-    finish: async () => {
-      if (finished) return;
+    finish: () => {
+      if (finished) return undefined;
       finished = true;
       if (policy !== "persistent") {
         restoreFds(ctx, state.numericSnapshot);
@@ -1085,7 +1085,7 @@ export function createRedirectionTransaction(
         }
         ctx.state.nextFd = state.nextFd;
       }
-      await closeUnusedWritables(ctx, state.openedWritables);
+      return closeUnusedWritables(ctx, state.openedWritables);
     },
   };
 }
@@ -1176,7 +1176,8 @@ export async function withPreparedRedirections(
     await routeControlFlowError(ctx, error, redirections, prepared);
     throw error;
   } finally {
-    await transaction.finish();
+    const closing = transaction.finish();
+    if (closing) await closing;
   }
 }
 

--- a/packages/just-bash/src/interpreter/state-transaction.ts
+++ b/packages/just-bash/src/interpreter/state-transaction.ts
@@ -97,6 +97,7 @@ export function beginIsolatedShellState(state: InterpreterState): () => void {
     shoptOptions: state.shoptOptions,
     fileDescriptors: state.fileDescriptors,
     inputFds: state.inputFds,
+    outputWriters: state.outputWriters,
     fdAliases: state.fdAliases,
     closedStandardFds: state.closedStandardFds,
     nextFd: state.nextFd,
@@ -152,6 +153,9 @@ export function beginIsolatedShellState(state: InterpreterState): () => void {
     : undefined;
   // Travels with the descriptor table it classifies.
   state.inputFds = state.inputFds ? new Set(state.inputFds) : undefined;
+  state.outputWriters = state.outputWriters
+    ? new Map(state.outputWriters)
+    : undefined;
   state.fdAliases = cloneFdAliases(state.fdAliases);
   state.closedStandardFds = state.closedStandardFds
     ? new Set(state.closedStandardFds)

--- a/packages/just-bash/src/interpreter/state-transaction.ts
+++ b/packages/just-bash/src/interpreter/state-transaction.ts
@@ -1,5 +1,10 @@
+import { closeUnusedWritables } from "./fd-table.js";
 import { cloneArrays } from "./helpers/array.js";
-import type { CompletionSpec, InterpreterState, ShellArray } from "./types.js";
+import type {
+  CompletionSpec,
+  InterpreterContext,
+  ShellArray,
+} from "./types.js";
 
 function cloneCompletionSpec(
   spec: CompletionSpec | undefined,
@@ -84,7 +89,10 @@ function cloneLocalVarStack(
  * idempotent rollback. Process-wide accounting and PID allocation deliberately
  * remain shared with the parent execution.
  */
-export function beginIsolatedShellState(state: InterpreterState): () => void {
+export function beginIsolatedShellState(
+  ctx: InterpreterContext,
+): () => Promise<void> | undefined {
+  const state = ctx.state;
   const saved = {
     env: state.env,
     arrays: state.arrays,
@@ -98,6 +106,7 @@ export function beginIsolatedShellState(state: InterpreterState): () => void {
     fileDescriptors: state.fileDescriptors,
     inputFds: state.inputFds,
     outputWriters: state.outputWriters,
+    inheritedOutputWriters: state.inheritedOutputWriters,
     fdAliases: state.fdAliases,
     closedStandardFds: state.closedStandardFds,
     nextFd: state.nextFd,
@@ -156,6 +165,10 @@ export function beginIsolatedShellState(state: InterpreterState): () => void {
   state.outputWriters = state.outputWriters
     ? new Map(state.outputWriters)
     : undefined;
+  state.inheritedOutputWriters = new Set([
+    ...(saved.inheritedOutputWriters ?? []),
+    ...(saved.outputWriters?.values() ?? []),
+  ]);
   state.fdAliases = cloneFdAliases(state.fdAliases);
   state.closedStandardFds = state.closedStandardFds
     ? new Set(state.closedStandardFds)
@@ -212,8 +225,16 @@ export function beginIsolatedShellState(state: InterpreterState): () => void {
 
   let restored = false;
   return () => {
-    if (restored) return;
+    if (restored) return undefined;
     restored = true;
+    const childWriters = new Set(state.outputWriters?.values() ?? []);
+    const parentWriters = new Set(saved.outputWriters?.values() ?? []);
     Object.assign(state, saved);
+    for (const writable of childWriters) {
+      if (parentWriters.has(writable)) continue;
+      state.writableCloseCandidates ??= new Set();
+      state.writableCloseCandidates.add(writable);
+    }
+    return closeUnusedWritables(ctx);
   };
 }

--- a/packages/just-bash/src/interpreter/subshell-group.ts
+++ b/packages/just-bash/src/interpreter/subshell-group.ts
@@ -62,7 +62,7 @@ export async function executeSubshell(
     const entry = getFdEntry(ctx, fd);
     if (entry) parentDescriptors.set(fd, entry);
   }
-  const restoreState = beginIsolatedShellState(ctx.state);
+  const restoreState = beginIsolatedShellState(ctx);
   ctx.state.parentHasLoopContext = parentLoopDepth > 0;
   ctx.state.loopDepth = 0;
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
@@ -99,7 +99,8 @@ export async function executeSubshell(
         Math.max(consumedDescriptors.get(sourceFd) ?? 0, consumed),
       );
     }
-    restoreState();
+    const closing = restoreState();
+    if (closing) await closing;
     for (const [fd, consumed] of consumedDescriptors) {
       advanceFd(ctx, fd, consumed);
     }
@@ -350,7 +351,7 @@ export async function executeUserScript(
   }
 
   const parentLoopDepth = ctx.state.loopDepth;
-  const cleanup = beginIsolatedShellState(ctx.state);
+  const cleanup = beginIsolatedShellState(ctx);
 
   // Set up subshell-like environment
   ctx.state.parentHasLoopContext = parentLoopDepth > 0;
@@ -379,10 +380,12 @@ export async function executeUserScript(
     const parser = new Parser();
     const ast = parser.parse(content);
     const execResult = await executeScript(ast);
-    cleanup();
+    const closing = cleanup();
+    if (closing) await closing;
     return execResult;
   } catch (error) {
-    cleanup();
+    const closing = cleanup();
+    if (closing) await closing;
 
     // Executable scripts run in a subshell-like environment, so exit only
     // ends the script and returns its status to the surrounding command list.

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -9,7 +9,7 @@ import type {
   StatementNode,
 } from "../ast/types.js";
 import type { ExecutionScope } from "../execution-scope.js";
-import type { IFileSystem } from "../fs/interface.js";
+import type { IFileSystem, WritableFile } from "../fs/interface.js";
 import type { ExecutionLimits } from "../limits.js";
 import type { SecureFetch } from "../network/index.js";
 import type {
@@ -328,6 +328,10 @@ export interface IOState {
    * for one. Maintained exclusively by `fd-table.ts`.
    */
   inputFds?: Set<number>;
+  /** Writable descriptions associated with encoded output descriptor entries. */
+  outputWriters?: Map<number, WritableFile>;
+  /** Writers detached during descriptor mutation and eligible for closing. */
+  writableCloseCandidates?: Set<WritableFile>;
   /**
    * Descriptors that share one open file description because of `N<&M`, and
    * therefore share a read offset. Every member of a group maps to the same

--- a/packages/just-bash/src/interpreter/types.ts
+++ b/packages/just-bash/src/interpreter/types.ts
@@ -330,6 +330,8 @@ export interface IOState {
   inputFds?: Set<number>;
   /** Writable descriptions associated with encoded output descriptor entries. */
   outputWriters?: Map<number, WritableFile>;
+  /** Parent descriptions retained while an isolated shell mutates its fd table. */
+  inheritedOutputWriters?: Set<WritableFile>;
   /** Writers detached during descriptor mutation and eligible for closing. */
   writableCloseCandidates?: Set<WritableFile>;
   /**


### PR DESCRIPTION
## Proposal

`IFileSystem` currently exposes whole-path replacement operations (`writeFile` and `appendFile`), while Bash output redirection is based on open file descriptions with their own lifetime and write position. The interpreter therefore models `> file` as an empty `writeFile` during redirect setup followed by another `writeFile` when output is delivered.

That fallback preserves the important shell ordering, but it prevents custom filesystems from representing one open lifecycle. Remote and versioned implementations may turn redirect setup and delivery into separate durable mutations, and descriptor identity/offset behavior cannot live behind the filesystem seam.

This draft proposes one optional, asynchronous interface:

```ts
interface OpenWritableOptions {
  mode: "truncate" | "append";
}

interface WritableFile {
  write(
    content: FileContent,
    options?: WriteFileOptions | BufferEncoding,
  ): Promise<void>;
  close(): Promise<void>;
}

interface IFileSystem {
  openWritable?(
    path: string,
    options: OpenWritableOptions,
  ): Promise<WritableFile>;
}
```

The naming and exact shape are intentionally open for maintainer feedback.

## Why this is a general filesystem capability

The interface represents a writable **open file description**, rather than a redirection-specific optimization:

- each successful open returns a distinct description, even for the same path;
- duplicated shell descriptors share the same object and write position;
- `truncate` applies create/truncate before command execution;
- `append` writes at the then-current end on every write;
- command-scoped, named, numeric, duplicated, moved, and persistent descriptors share one lifecycle;
- successful opens and writes are not rolled back on command failure.

This can support real OS handles, in-memory offsets, remote upload sessions, execution-visible staging, and one durable version per open lifecycle. It also provides a future seam for commands such as `tee` and `curl -o` without making those commands aware of a particular backend.

The known independent-open offset gap described in #318 is related: once the interpreter retains actual open descriptions, a filesystem implementation can preserve independent positions instead of reducing identity to a path. This proposal does not depend on #318's output-order work.

## Compatibility

`openWritable` is optional. Existing third-party filesystems continue down the current `writeFile`/`appendFile` path with unchanged behavior.

The implementation keeps writable objects out of the public `fileDescriptors: Map<number, string>` representation. A private descriptor side table retains them across duplication, movement, scoped restoration, and isolated shell state. Descriptions are closed when no live descriptor retains them, with execution-scope cleanup as a fallback for persistent descriptors and exceptional exits.

## Current implementation

- Adds and publicly exports the optional interface types.
- Uses `openWritable` for output redirects and output descriptors when available.
- Preserves source-order redirect opens and the legacy fallback.
- Tracks descriptions through descriptor aliases, moves, snapshots, and persistent `exec` redirects.
- Awaits asynchronous close during redirection cleanup.
- Documents the custom-filesystem contract and includes a minor changeset.

## Test coverage

A custom versioned-style filesystem verifies:

- truncate and append modes;
- immediate empty state for commands with no output;
- independent positions for separate opens of the same path;
- one close/durable-commit point per opened target;
- source-order multiple redirects and cleanup after later open failure;
- persistent, named, duplicated, moved, and temporarily overridden descriptors;
- execution cleanup for descriptors left open;
- unchanged fallback behavior without the optional method.

Additional comparison fixtures cover failed-command truncation, multiple redirect targets, and duplicated descriptor lifetime against real Bash.

Upstream CI passes on the current head for:

- comparison tests;
- lint;
- typecheck and package build;
- unit tests on Node 20, 22, and 24;
- WASM tests on Node 22 and 24;
- security and dependency scans.

The two Vercel preview statuses require Vercel Labs team authorization for fork deployments; they do not report a build failure.

## Feedback requested

1. Is `openWritable` the right optional seam and name, or would maintainers prefer `openFile` with a deliberately broader option set?
2. Should this first change remain writable-only, or include readable/read-write descriptions too?
3. Should built-in filesystem implementations adopt the method in this PR, or should that follow after the custom-filesystem contract is agreed?
4. Should close failures become shell results at the redirection site, or continue through the existing execution-cleanup failure path?
