### PR TITLE
feat(regex): pluggable engine behind UserRegex via BashOptions.regexEngine

### DIFF
--- a/.changeset/regex-engine-seam.md
+++ b/.changeset/regex-engine-seam.md
@@ -1,0 +1,17 @@
+---
+"just-bash": minor
+---
+
+Make the regex engine behind `UserRegex` pluggable
+
+Every user-provided pattern (grep, sed, awk, jq, `[[ =~ ]]`, …) is compiled and
+matched through a `RegexEngine`. re2js remains the default and the only engine
+shipped, so nothing changes for existing users. A Node host can install another
+linear-time engine — e.g. a native RE2 binding — with `setRegexEngine(engine)`;
+`getRegexEngine()` and `re2jsEngine` are exported alongside it, together with the
+`RegexEngine`, `CompiledRegex`, `RegexMatcher`, `RegexEngineFlags` types and the
+`RegexSyntaxError` an engine throws for unsupported or invalid patterns.
+
+The engine must guarantee linear-time matching for every pattern it accepts;
+`UserRegex`'s ReDoS protection is exactly that property, and `THREAT_MODEL.md`
+now says so.

--- a/.changeset/regex-engine-seam.md
+++ b/.changeset/regex-engine-seam.md
@@ -2,16 +2,19 @@
 "just-bash": minor
 ---
 
-Make the regex engine behind `UserRegex` pluggable
+Add `regexEngine` to `BashOptions`
 
 Every user-provided pattern (grep, sed, awk, jq, `[[ =~ ]]`, …) is compiled and
 matched through a `RegexEngine`. re2js remains the default and the only engine
-shipped, so nothing changes for existing users. A Node host can install another
-linear-time engine — e.g. a native RE2 binding — with `setRegexEngine(engine)`;
-`getRegexEngine()` and `re2jsEngine` are exported alongside it, together with the
-`RegexEngine`, `CompiledRegex`, `RegexMatcher`, `RegexEngineFlags` types and the
-`RegexSyntaxError` an engine throws for unsupported or invalid patterns.
+shipped, so nothing changes for existing users. A Node.js host can give an
+instance another linear-time engine — e.g. a native RE2 binding — with
+`new Bash({ regexEngine })`; the engine is scoped to that instance's executions,
+so instances with different engines can run concurrently. `re2jsEngine` is
+exported for hosts that want to wrap or fall back to the default, together with
+the `RegexEngine`, `CompiledRegex`, `RegexMatcher`, `RegexEngineFlags` types and
+the `RegexSyntaxError` an engine throws for unsupported or invalid patterns.
 
 The engine must guarantee linear-time matching for every pattern it accepts;
 `UserRegex`'s ReDoS protection is exactly that property, and `THREAT_MODEL.md`
-now says so.
+now says so. The option is Node.js only: scoping relies on `AsyncLocalStorage`,
+which the browser build does not have, so `new Bash({ regexEngine })` throws there.

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -189,7 +189,7 @@ The following components are **trusted** and outside the scope of just-bash's ru
 | Fork bomb | Recursive function calls | maxCallDepth (100) | `src/limits.ts` |
 | Command flood | Thousands of commands | maxCommandCount (10K) | `src/limits.ts` |
 | Memory exhaustion | String/array growth | maxStringLength (10MB), maxArrayElements (100K) | `src/limits.ts` |
-| Regex DoS (ReDoS) | Catastrophic backtracking | re2js (linear-time regex engine) | `src/regex/user-regex.ts` |
+| Regex DoS (ReDoS) | Catastrophic backtracking | Linear-time regex engine (re2js by default; a host-installed `RegexEngine` must keep this guarantee) | `src/regex/user-regex.ts`, `src/regex/engine.ts` |
 | process.exit() | Terminate host process | Blocked by defense-in-depth | `src/security/blocked-globals.ts` |
 | process.abort() | Crash host process | Blocked by defense-in-depth | `src/security/blocked-globals.ts` |
 | process.kill() | Signal host/other procs | Blocked by defense-in-depth | `src/security/blocked-globals.ts` |
@@ -344,7 +344,7 @@ Heredocs with variable expansion are size-limited (10MB) but nested heredocs wit
 | **Execution limits** | Primary | DoS | High — enforced at every loop/call/expansion |
 | **Prototype pollution guards** | Primary | Data integrity | Medium — requires discipline across all new code |
 | **Parser limits** | Primary | Parser DoS | High — token/depth/size/iteration limits |
-| **re2js regex engine** | Primary | ReDoS | High — linear-time guarantee (no backtracking) |
+| **Linear-time regex engine** (re2js default) | Primary | ReDoS | High — linear-time guarantee (no backtracking); `setRegexEngine` hands this guarantee to the host |
 | **Defense-in-depth** (globals) | Secondary | JS escape | Medium — monkey-patching has inherent limits |
 | **Virtual process info** | Secondary | Info disclosure | High — no real values exposed |
 | **Error sanitization** | Secondary | Info disclosure | High — systematic at FS layers + all error choke points + node:internal paths |

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -344,7 +344,7 @@ Heredocs with variable expansion are size-limited (10MB) but nested heredocs wit
 | **Execution limits** | Primary | DoS | High — enforced at every loop/call/expansion |
 | **Prototype pollution guards** | Primary | Data integrity | Medium — requires discipline across all new code |
 | **Parser limits** | Primary | Parser DoS | High — token/depth/size/iteration limits |
-| **Linear-time regex engine** (re2js default) | Primary | ReDoS | High — linear-time guarantee (no backtracking); `setRegexEngine` hands this guarantee to the host |
+| **Linear-time regex engine** (re2js default) | Primary | ReDoS | High — linear-time guarantee (no backtracking); `BashOptions.regexEngine` hands this guarantee to the host |
 | **Defense-in-depth** (globals) | Secondary | JS escape | Medium — monkey-patching has inherent limits |
 | **Virtual process info** | Secondary | Info disclosure | High — no real values exposed |
 | **Error sanitization** | Secondary | Info disclosure | High — systematic at FS layers + all error choke points + node:internal paths |

--- a/packages/just-bash/src/Bash.ts
+++ b/packages/just-bash/src/Bash.ts
@@ -66,6 +66,11 @@ import {
 import { LexerError } from "./parser/lexer.js";
 import { type ParseException, parse } from "./parser/parser.js";
 import {
+  type RegexEngine,
+  runWithRegexEngine,
+  supportsRegexEngineOption,
+} from "./regex/index.js";
+import {
   DefenseInDepthBox,
   SecurityViolationError,
 } from "./security/defense-in-depth-box.js";
@@ -168,6 +173,14 @@ export interface BashOptions {
    * Disabled by default. Can be a boolean or a config object with bootstrap code.
    */
   javascript?: boolean | JavaScriptConfig;
+  /**
+   * Engine that compiles and matches every user-provided regex pattern in this
+   * instance's scripts (grep, sed, awk, jq, `[[ =~ ]]`, …). Defaults to re2js.
+   * The engine must match in linear time for every pattern it accepts — that
+   * property is the sandbox's ReDoS protection. Node.js only: the browser build
+   * has no AsyncLocalStorage to scope the engine to an execution.
+   */
+  regexEngine?: RegexEngine;
   /**
    * Optional list of command names to register.
    * If not provided, all built-in commands are available.
@@ -320,6 +333,7 @@ export class Bash {
   private coverageWriter?: FeatureCoverageWriter;
   private jsBootstrapCode?: string;
   private invokeToolFn?: (path: string, argsJson: string) => Promise<string>;
+  private readonly regexEngine?: RegexEngine;
   // biome-ignore lint/suspicious/noExplicitAny: type-erased plugin storage for untyped API
   private transformPlugins: TransformPlugin<any>[] = [];
 
@@ -327,6 +341,12 @@ export class Bash {
   private state: InterpreterState;
 
   constructor(options: BashOptions = {}) {
+    if (options.regexEngine && !supportsRegexEngineOption()) {
+      throw new Error(
+        "regexEngine requires AsyncLocalStorage, which this runtime does not provide",
+      );
+    }
+    this.regexEngine = options.regexEngine;
     // Resolve limits before constructing the default filesystem so retained
     // virtual storage follows the same host-selected policy as execution.
     this.limits = resolveLimits(
@@ -610,14 +630,16 @@ export class Bash {
     const executionScope = new ExecutionScope(this.limits, options?.signal);
     let result: BashExecResult;
     try {
-      result = await this.execInScope(
-        commandLine,
-        options,
-        executionScope,
-        0,
-        options?.signal,
-        false, // stdinAlreadyAccounted
-        false, // defer result logging until cleanup finalizes the result
+      result = await runWithRegexEngine(this.regexEngine, () =>
+        this.execInScope(
+          commandLine,
+          options,
+          executionScope,
+          0,
+          options?.signal,
+          false, // stdinAlreadyAccounted
+          false, // defer result logging until cleanup finalizes the result
+        ),
       );
     } catch (error) {
       // Cleanup must not hide the original execution failure.

--- a/packages/just-bash/src/browser.ts
+++ b/packages/just-bash/src/browser.ts
@@ -56,6 +56,15 @@ export {
   RedirectNotAllowedError,
   TooManyRedirectsError,
 } from "./network/index.js";
+// Regex engine behind every user-provided pattern (see BashOptions.regexEngine)
+export {
+  type CompiledRegex,
+  type RegexEngine,
+  type RegexEngineFlags,
+  type RegexMatcher,
+  RegexSyntaxError,
+  re2jsEngine,
+} from "./regex/index.js";
 export type {
   BashExecResult,
   Command,

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -93,16 +93,14 @@ export {
 } from "./network/index.js";
 // Parser
 export { parse } from "./parser/parser.js";
-// Regex engine behind every user-provided pattern
+// Regex engine behind every user-provided pattern (see BashOptions.regexEngine)
 export {
   type CompiledRegex,
-  getRegexEngine,
   type RegexEngine,
   type RegexEngineFlags,
   type RegexMatcher,
   RegexSyntaxError,
   re2jsEngine,
-  setRegexEngine,
 } from "./regex/index.js";
 export type {
   CommandFinished as SandboxCommandFinished,

--- a/packages/just-bash/src/index.ts
+++ b/packages/just-bash/src/index.ts
@@ -93,6 +93,17 @@ export {
 } from "./network/index.js";
 // Parser
 export { parse } from "./parser/parser.js";
+// Regex engine behind every user-provided pattern
+export {
+  type CompiledRegex,
+  getRegexEngine,
+  type RegexEngine,
+  type RegexEngineFlags,
+  type RegexMatcher,
+  RegexSyntaxError,
+  re2jsEngine,
+  setRegexEngine,
+} from "./regex/index.js";
 export type {
   CommandFinished as SandboxCommandFinished,
   OutputMessage,

--- a/packages/just-bash/src/regex/engine-context.ts
+++ b/packages/just-bash/src/regex/engine-context.ts
@@ -1,0 +1,44 @@
+// Which RegexEngine the current execution uses. `Bash.exec` runs the script
+// inside `runWithRegexEngine`, and every UserRegex created underneath — from
+// grep down to awk's field splitter — resolves the engine from here, so no
+// call site has to thread it. Outside any execution, and in the browser build
+// (which has no AsyncLocalStorage), the default engine applies.
+
+import * as nodeAsyncHooks from "node:async_hooks";
+import type { RegexEngine } from "./engine.js";
+import { re2jsEngine } from "./re2js-engine.js";
+
+declare const __BROWSER__: boolean | undefined;
+const IS_BROWSER = typeof __BROWSER__ !== "undefined" && __BROWSER__;
+
+type EngineStorage = {
+  run<R>(store: RegexEngine, callback: () => R): R;
+  getStore(): RegexEngine | undefined;
+};
+
+let engineStorage: EngineStorage | null = null;
+if (!IS_BROWSER) {
+  try {
+    engineStorage = new nodeAsyncHooks.AsyncLocalStorage<RegexEngine>();
+  } catch {
+    // Not available (edge runtimes, restricted environments)
+  }
+}
+
+export function supportsRegexEngineOption(): boolean {
+  return engineStorage !== null;
+}
+
+export function currentRegexEngine(): RegexEngine {
+  return engineStorage?.getStore() ?? re2jsEngine;
+}
+
+export function runWithRegexEngine<R>(
+  engine: RegexEngine | undefined,
+  fn: () => R,
+): R {
+  if (!engine || !engineStorage) {
+    return fn();
+  }
+  return engineStorage.run(engine, fn);
+}

--- a/packages/just-bash/src/regex/engine-context.ts
+++ b/packages/just-bash/src/regex/engine-context.ts
@@ -37,8 +37,13 @@ export function runWithRegexEngine<R>(
   engine: RegexEngine | undefined,
   fn: () => R,
 ): R {
-  if (!engine || !engineStorage) {
+  if (!engine) {
     return fn();
+  }
+  if (!engineStorage) {
+    throw new Error(
+      "regexEngine requires AsyncLocalStorage, which this runtime does not provide",
+    );
   }
   return engineStorage.run(engine, fn);
 }

--- a/packages/just-bash/src/regex/engine.test.ts
+++ b/packages/just-bash/src/regex/engine.test.ts
@@ -45,6 +45,18 @@ class HostRegExpMatcher implements RegexMatcher {
     return this.match?.[index] ?? null;
   }
 
+  groups(): (string | null)[] {
+    return this.match ? [...this.match].map((g) => g ?? null) : [];
+  }
+
+  namedGroups(): Record<string, string | null> {
+    const named: Record<string, string | null> = Object.create(null);
+    for (const [name, value] of Object.entries(this.match?.groups ?? {})) {
+      named[name] = value ?? null;
+    }
+    return named;
+  }
+
   reset(input: string): void {
     this.input = input;
     this.match = null;
@@ -71,22 +83,7 @@ const hostRegExpEngine: RegexEngine = {
     } catch (e) {
       throw new RegexSyntaxError((e as Error).message);
     }
-    const groupCount = (new RegExp(`${pattern}|`).exec("")?.length ?? 1) - 1;
-    const names = [...pattern.matchAll(/\(\?<([A-Za-z_$][\w$]*)>/g)].map(
-      (m) => m[1],
-    );
-    const namedGroups: Record<string, number> = {};
-    // Named groups are numbered in order of their opening parenthesis; this
-    // reference adapter only supports patterns whose groups are all named or
-    // all unnamed, which is what the tests below use.
-    names.forEach((name, i) => {
-      namedGroups[name as string] = i + 1;
-    });
-    return {
-      groupCount: () => groupCount,
-      namedGroups: () => namedGroups,
-      matcher: (input) => new HostRegExpMatcher(regex, input),
-    };
+    return { matcher: (input) => new HostRegExpMatcher(regex, input) };
   },
 };
 

--- a/packages/just-bash/src/regex/engine.test.ts
+++ b/packages/just-bash/src/regex/engine.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  type CompiledRegex,
+  type RegexEngine,
+  type RegexEngineFlags,
+  type RegexMatcher,
+  RegexSyntaxError,
+} from "./engine.js";
+import { re2jsEngine } from "./re2js-engine.js";
+import {
+  createUserRegex,
+  getRegexEngine,
+  setRegexEngine,
+} from "./user-regex.js";
+
+// Test-only reference adapter over the host RegExp. It exists to prove the
+// RegexMatcher/CompiledRegex surface is sufficient for every UserRegex
+// operation; it is deliberately not exported, since it backtracks.
+class HostRegExpMatcher implements RegexMatcher {
+  private match: RegExpExecArray | null = null;
+
+  constructor(
+    private readonly regex: RegExp,
+    private input: string,
+  ) {}
+
+  find(start = 0): boolean {
+    if (start > this.input.length) {
+      this.match = null;
+      return false;
+    }
+    this.regex.lastIndex = start;
+    this.match = this.regex.exec(this.input);
+    return this.match !== null;
+  }
+
+  start(group = 0): number {
+    return this.indices()[group]?.[0] ?? -1;
+  }
+
+  end(group = 0): number {
+    return this.indices()[group]?.[1] ?? -1;
+  }
+
+  group(index = 0): string | null {
+    return this.match?.[index] ?? null;
+  }
+
+  reset(input: string): void {
+    this.input = input;
+    this.match = null;
+  }
+
+  private indices(): Array<[number, number] | undefined> {
+    const indices = (
+      this.match as
+        | (RegExpExecArray & { indices?: Array<[number, number]> })
+        | null
+    )?.indices;
+    return indices ?? [];
+  }
+}
+
+const hostRegExpEngine: RegexEngine = {
+  compile(pattern: string, flags: RegexEngineFlags): CompiledRegex {
+    let regex: RegExp;
+    try {
+      regex = new RegExp(
+        pattern,
+        `gd${flags.ignoreCase ? "i" : ""}${flags.multiline ? "m" : ""}${flags.dotAll ? "s" : ""}`,
+      );
+    } catch (e) {
+      throw new RegexSyntaxError((e as Error).message);
+    }
+    const groupCount = (new RegExp(`${pattern}|`).exec("")?.length ?? 1) - 1;
+    const names = [...pattern.matchAll(/\(\?<([A-Za-z_$][\w$]*)>/g)].map(
+      (m) => m[1],
+    );
+    const namedGroups: Record<string, number> = {};
+    // Named groups are numbered in order of their opening parenthesis; this
+    // reference adapter only supports patterns whose groups are all named or
+    // all unnamed, which is what the tests below use.
+    names.forEach((name, i) => {
+      namedGroups[name as string] = i + 1;
+    });
+    return {
+      groupCount: () => groupCount,
+      namedGroups: () => namedGroups,
+      matcher: (input) => new HostRegExpMatcher(regex, input),
+    };
+  },
+};
+
+describe("regex engine seam", () => {
+  afterEach(() => {
+    setRegexEngine(re2jsEngine);
+  });
+
+  it("defaults to re2js and returns the previous engine on install", () => {
+    expect(getRegexEngine()).toBe(re2jsEngine);
+    const previous = setRegexEngine(hostRegExpEngine);
+    expect(previous).toBe(re2jsEngine);
+    expect(getRegexEngine()).toBe(hostRegExpEngine);
+  });
+
+  it("routes compilation and flags through the installed engine", () => {
+    const seen: Array<{ pattern: string; flags: RegexEngineFlags }> = [];
+    setRegexEngine({
+      compile(pattern, flags) {
+        seen.push({ pattern, flags });
+        return re2jsEngine.compile(pattern, flags);
+      },
+    });
+
+    const regex = createUserRegex("a.b", "gims");
+    expect(regex.test("A\nB")).toBe(true);
+    expect(seen).toEqual([
+      {
+        pattern: "a.b",
+        flags: { ignoreCase: true, multiline: true, dotAll: true },
+      },
+    ]);
+  });
+
+  it("wraps the engine's RegexSyntaxError in the standard invalid-pattern message", () => {
+    setRegexEngine({
+      compile() {
+        throw new RegexSyntaxError("engine says no");
+      },
+    });
+    expect(() => createUserRegex("x")).toThrow(
+      /^Invalid regular expression: \/x\/: engine says no/,
+    );
+  });
+
+  it("still explains unsupported lookahead when a custom engine rejects it", () => {
+    setRegexEngine({
+      compile() {
+        throw new RegexSyntaxError("unsupported");
+      },
+    });
+    expect(() => createUserRegex("(?=x)")).toThrow(/Lookahead/);
+  });
+
+  it("lets other engine errors propagate untouched", () => {
+    setRegexEngine({
+      compile() {
+        throw new TypeError("engine crashed");
+      },
+    });
+    expect(() => createUserRegex("x")).toThrow(TypeError);
+  });
+
+  describe("every UserRegex operation works against a non-default engine", () => {
+    it("test, exec, search", () => {
+      setRegexEngine(hostRegExpEngine);
+      const regex = createUserRegex("(\\d+)-(\\d+)", "i");
+      expect(regex.test("id 12-34")).toBe(true);
+      const match = regex.exec("id 12-34");
+      expect(match && [...match]).toEqual(["12-34", "12", "34"]);
+      expect(match?.index).toBe(3);
+      expect(regex.search("id 12-34")).toBe(3);
+      expect(regex.search("nothing")).toBe(-1);
+    });
+
+    it("global match, replace with $n, callback replace, split, matchAll", () => {
+      setRegexEngine(hostRegExpEngine);
+      const global = createUserRegex("(\\d)", "g");
+      expect(global.match("a1b2c3")).toEqual(["1", "2", "3"]);
+      expect(global.replace("a1b2c3", "[$1]")).toBe("a[1]b[2]c[3]");
+      expect(global.replace("a1b2c3", (m) => `<${m}>`)).toBe("a<1>b<2>c<3>");
+      expect(global.split("a1b2c3")).toEqual(["a", "b", "c", ""]);
+      expect([...global.matchAll("a1b2")].map((m) => [m[0], m.index])).toEqual([
+        ["1", 1],
+        ["2", 3],
+      ]);
+    });
+
+    it("named groups and zero-length matches", () => {
+      setRegexEngine(hostRegExpEngine);
+      const named = createUserRegex("(?<year>\\d{4})-(?<month>\\d{2})");
+      expect(named.exec("on 2026-09")?.groups).toEqual({
+        year: "2026",
+        month: "09",
+      });
+
+      const empty = createUserRegex("x*", "g");
+      expect(empty.replace("abc", "-")).toBe("-a-b-c-");
+      expect(empty.match("abc")).toEqual(["", "", "", ""]);
+    });
+
+    it("lastIndex advances with exec on a global pattern", () => {
+      setRegexEngine(hostRegExpEngine);
+      const regex = createUserRegex("a", "g");
+      expect(regex.exec("aXa")?.index).toBe(0);
+      expect(regex.lastIndex).toBe(1);
+      expect(regex.exec("aXa")?.index).toBe(2);
+      expect(regex.exec("aXa")).toBeNull();
+      expect(regex.lastIndex).toBe(0);
+    });
+
+    it("reuses one matcher across inputs through reset", () => {
+      setRegexEngine(hostRegExpEngine);
+      const regex = createUserRegex("b");
+      expect(regex.test("abc")).toBe(true);
+      expect(regex.test("xyz")).toBe(false);
+      expect(regex.search("aab")).toBe(2);
+    });
+  });
+});

--- a/packages/just-bash/src/regex/engine.test.ts
+++ b/packages/just-bash/src/regex/engine.test.ts
@@ -1,4 +1,6 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+import { matchGlob } from "../utils/glob.js";
 import {
   type CompiledRegex,
   type RegexEngine,
@@ -6,12 +8,9 @@ import {
   type RegexMatcher,
   RegexSyntaxError,
 } from "./engine.js";
+import { currentRegexEngine, runWithRegexEngine } from "./engine-context.js";
 import { re2jsEngine } from "./re2js-engine.js";
-import {
-  createUserRegex,
-  getRegexEngine,
-  setRegexEngine,
-} from "./user-regex.js";
+import { createUserRegex } from "./user-regex.js";
 
 // Test-only reference adapter over the host RegExp. It exists to prove the
 // RegexMatcher/CompiledRegex surface is sufficient for every UserRegex
@@ -91,70 +90,145 @@ const hostRegExpEngine: RegexEngine = {
   },
 };
 
-describe("regex engine seam", () => {
-  afterEach(() => {
-    setRegexEngine(re2jsEngine);
+interface Recorded {
+  pattern: string;
+  flags: RegexEngineFlags;
+}
+
+// Delegates to re2js but records every compile, so tests can see which engine
+// an execution resolved without changing behaviour.
+function recordingEngine(): RegexEngine & { seen: Recorded[] } {
+  const seen: Recorded[] = [];
+  return {
+    seen,
+    compile(pattern, flags) {
+      seen.push({ pattern, flags });
+      return re2jsEngine.compile(pattern, flags);
+    },
+  };
+}
+
+describe("regexEngine option", () => {
+  it("defaults to re2js outside and inside an execution", async () => {
+    expect(currentRegexEngine()).toBe(re2jsEngine);
+    const result = await new Bash().exec(`[[ x =~ ^x$ ]] && echo matched`);
+    expect(result.stdout).toBe("matched\n");
   });
 
-  it("defaults to re2js and returns the previous engine on install", () => {
-    expect(getRegexEngine()).toBe(re2jsEngine);
-    const previous = setRegexEngine(hostRegExpEngine);
-    expect(previous).toBe(re2jsEngine);
-    expect(getRegexEngine()).toBe(hostRegExpEngine);
-  });
+  it("routes every pattern of an execution through the instance's engine", async () => {
+    const engine = recordingEngine();
+    const bash = new Bash({ regexEngine: engine });
 
-  it("routes compilation and flags through the installed engine", () => {
-    const seen: Array<{ pattern: string; flags: RegexEngineFlags }> = [];
-    setRegexEngine({
-      compile(pattern, flags) {
-        seen.push({ pattern, flags });
-        return re2jsEngine.compile(pattern, flags);
-      },
-    });
+    const result = await bash.exec(
+      [
+        `printf 'Abc\\nxyz\\n' | grep -iE 'a.c'`,
+        `echo 'k1=v1;k2=v2' | awk -F'[;=]' '{ print $4 }'`,
+        `[[ ord-42 =~ ^([a-z]+)-([0-9]+)$ ]] && echo "\${BASH_REMATCH[2]}"`,
+        `echo hello | sed -E 's/l+/L/'`,
+      ].join("\n"),
+    );
 
-    const regex = createUserRegex("a.b", "gims");
-    expect(regex.test("A\nB")).toBe(true);
-    expect(seen).toEqual([
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("Abc\nv2\n42\nheLo\n");
+    const patterns = engine.seen.map((entry) => entry.pattern);
+    expect(patterns).toContain("a.c");
+    expect(patterns).toContain("[;=]");
+    expect(patterns).toContain("^([a-z]+)-([0-9]+)$");
+    expect(patterns).toContain("l+");
+    expect(engine.seen.find((entry) => entry.pattern === "a.c")?.flags).toEqual(
       {
-        pattern: "a.b",
-        flags: { ignoreCase: true, multiline: true, dotAll: true },
+        ignoreCase: true,
+        multiline: false,
+        dotAll: false,
+        unicode: false,
       },
-    ]);
-  });
-
-  it("wraps the engine's RegexSyntaxError in the standard invalid-pattern message", () => {
-    setRegexEngine({
-      compile() {
-        throw new RegexSyntaxError("engine says no");
-      },
-    });
-    expect(() => createUserRegex("x")).toThrow(
-      /^Invalid regular expression: \/x\/: engine says no/,
     );
   });
 
-  it("still explains unsupported lookahead when a custom engine rejects it", () => {
-    setRegexEngine({
+  it("keeps concurrently executing instances on their own engines", async () => {
+    const first = recordingEngine();
+    const second = recordingEngine();
+    const script = (tag: string) =>
+      `sleep 0.01; echo ${tag} | grep -E '^${tag}$'; sleep 0.01; echo ${tag} | grep -E '${tag}+'`;
+
+    const [a, b] = await Promise.all([
+      new Bash({ regexEngine: first }).exec(script("first")),
+      new Bash({ regexEngine: second }).exec(script("second")),
+    ]);
+
+    expect(a.stdout).toBe("first\nfirst\n");
+    expect(b.stdout).toBe("second\nsecond\n");
+    expect(first.seen.map((entry) => entry.pattern)).toEqual([
+      "^first$",
+      "first+",
+    ]);
+    expect(second.seen.map((entry) => entry.pattern)).toEqual([
+      "^second$",
+      "second+",
+    ]);
+  });
+
+  it("does not leak the engine past the execution", async () => {
+    const engine = recordingEngine();
+    await new Bash({ regexEngine: engine }).exec("echo x | grep x");
+    expect(currentRegexEngine()).toBe(re2jsEngine);
+    createUserRegex("after");
+    expect(engine.seen.map((entry) => entry.pattern)).toEqual(["x"]);
+  });
+
+  it("passes the u flag to the engine", () => {
+    const engine = recordingEngine();
+    runWithRegexEngine(engine, () => createUserRegex("\\u{1F600}", "u"));
+    expect(engine.seen[0]?.flags.unicode).toBe(true);
+  });
+
+  it("keeps glob caches separate per engine", () => {
+    const first = recordingEngine();
+    const second = recordingEngine();
+    runWithRegexEngine(first, () => matchGlob("a.txt", "*.txt"));
+    runWithRegexEngine(first, () => matchGlob("b.txt", "*.txt"));
+    runWithRegexEngine(second, () => matchGlob("c.txt", "*.txt"));
+    expect(first.seen.length).toBe(1);
+    expect(second.seen.length).toBe(1);
+  });
+
+  it("wraps the engine's RegexSyntaxError in the standard invalid-pattern message", async () => {
+    const engine: RegexEngine = {
       compile() {
-        throw new RegexSyntaxError("unsupported");
+        throw new RegexSyntaxError("engine says no");
       },
-    });
-    expect(() => createUserRegex("(?=x)")).toThrow(/Lookahead/);
+    };
+    expect(() =>
+      runWithRegexEngine(engine, () => createUserRegex("x")),
+    ).toThrow(/^Invalid regular expression: \/x\/: engine says no/);
+    expect(() =>
+      runWithRegexEngine(engine, () => createUserRegex("(?=x)")),
+    ).toThrow(/Lookahead/);
+
+    const result = await new Bash({ regexEngine: engine }).exec(
+      "echo x | grep x",
+    );
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toMatch(/grep: invalid regular expression/);
   });
 
   it("lets other engine errors propagate untouched", () => {
-    setRegexEngine({
+    const engine: RegexEngine = {
       compile() {
         throw new TypeError("engine crashed");
       },
-    });
-    expect(() => createUserRegex("x")).toThrow(TypeError);
+    };
+    expect(() =>
+      runWithRegexEngine(engine, () => createUserRegex("x")),
+    ).toThrow(TypeError);
   });
 
   describe("every UserRegex operation works against a non-default engine", () => {
+    const withHost = <T>(fn: () => T): T =>
+      runWithRegexEngine(hostRegExpEngine, fn);
+
     it("test, exec, search", () => {
-      setRegexEngine(hostRegExpEngine);
-      const regex = createUserRegex("(\\d+)-(\\d+)", "i");
+      const regex = withHost(() => createUserRegex("(\\d+)-(\\d+)", "i"));
       expect(regex.test("id 12-34")).toBe(true);
       const match = regex.exec("id 12-34");
       expect(match && [...match]).toEqual(["12-34", "12", "34"]);
@@ -164,8 +238,7 @@ describe("regex engine seam", () => {
     });
 
     it("global match, replace with $n, callback replace, split, matchAll", () => {
-      setRegexEngine(hostRegExpEngine);
-      const global = createUserRegex("(\\d)", "g");
+      const global = withHost(() => createUserRegex("(\\d)", "g"));
       expect(global.match("a1b2c3")).toEqual(["1", "2", "3"]);
       expect(global.replace("a1b2c3", "[$1]")).toBe("a[1]b[2]c[3]");
       expect(global.replace("a1b2c3", (m) => `<${m}>`)).toBe("a<1>b<2>c<3>");
@@ -177,21 +250,21 @@ describe("regex engine seam", () => {
     });
 
     it("named groups and zero-length matches", () => {
-      setRegexEngine(hostRegExpEngine);
-      const named = createUserRegex("(?<year>\\d{4})-(?<month>\\d{2})");
+      const named = withHost(() =>
+        createUserRegex("(?<year>\\d{4})-(?<month>\\d{2})"),
+      );
       expect(named.exec("on 2026-09")?.groups).toEqual({
         year: "2026",
         month: "09",
       });
 
-      const empty = createUserRegex("x*", "g");
+      const empty = withHost(() => createUserRegex("x*", "g"));
       expect(empty.replace("abc", "-")).toBe("-a-b-c-");
       expect(empty.match("abc")).toEqual(["", "", "", ""]);
     });
 
     it("lastIndex advances with exec on a global pattern", () => {
-      setRegexEngine(hostRegExpEngine);
-      const regex = createUserRegex("a", "g");
+      const regex = withHost(() => createUserRegex("a", "g"));
       expect(regex.exec("aXa")?.index).toBe(0);
       expect(regex.lastIndex).toBe(1);
       expect(regex.exec("aXa")?.index).toBe(2);
@@ -200,11 +273,26 @@ describe("regex engine seam", () => {
     });
 
     it("reuses one matcher across inputs through reset", () => {
-      setRegexEngine(hostRegExpEngine);
-      const regex = createUserRegex("b");
+      const regex = withHost(() => createUserRegex("b"));
       expect(regex.test("abc")).toBe(true);
       expect(regex.test("xyz")).toBe(false);
       expect(regex.search("aab")).toBe(2);
+    });
+
+    it("runs whole scripts end to end with the same output as the default engine", async () => {
+      const script = [
+        `echo 'ord-12 pending 34' | sed -E 's/(ord)-([0-9]+) (\\w+) ([0-9]+)/\\3:\\2:\\4:\\1/'`,
+        `echo 'a1b22c333' | grep -oE '[0-9]+' | tr '\\n' ,; echo`,
+        `printf '%s\\n' shipped pending delivered | awk '/^(ship|deliv)/ { n++ } END { print n }'`,
+        `echo '{"id":"ord-7"}' | jq -r '.id | capture("(?<k>[a-z]+)-(?<n>[0-9]+)") | .n'`,
+        `for f in a.txt b.md; do case $f in *.txt) echo T;; *) echo O;; esac; done`,
+      ].join("\n");
+      const expected = await new Bash().exec(script);
+      const actual = await new Bash({ regexEngine: hostRegExpEngine }).exec(
+        script,
+      );
+      expect(expected.stderr).toBe("");
+      expect(actual).toEqual(expected);
     });
   });
 });

--- a/packages/just-bash/src/regex/engine.ts
+++ b/packages/just-bash/src/regex/engine.ts
@@ -1,0 +1,56 @@
+/**
+ * Pluggable engine behind UserRegex.
+ *
+ * Every user-provided pattern (grep, sed, awk, jq, `[[ =~ ]]`, …) is compiled
+ * and matched through one engine. The default is re2js, a pure-JS RE2 port,
+ * which runs everywhere just-bash runs. A host may install another engine —
+ * e.g. a native RE2 binding on Node — to trade portability for speed.
+ *
+ * Security contract for any installed engine: matching must be linear in the
+ * input length for every pattern the engine accepts. UserRegex's ReDoS
+ * protection is exactly this property; an engine that backtracks removes it.
+ */
+
+export interface RegexEngineFlags {
+  ignoreCase: boolean;
+  multiline: boolean;
+  dotAll: boolean;
+}
+
+/**
+ * Cursor over one input string. Modelled on RE2JS's Matcher so the default
+ * adapter is a thin wrapper and the higher-level operations in UserRegex stay
+ * engine-agnostic.
+ */
+export interface RegexMatcher {
+  /** Search from `start` (default 0). On success, start/end/group describe the match. */
+  find(start?: number): boolean;
+  start(group?: number): number;
+  end(group?: number): number;
+  /** Text of a capture group; null when the group did not participate. */
+  group(index?: number): string | null;
+  /** Point at a new input and rewind, reusing this matcher's allocations. */
+  reset(input: string): void;
+}
+
+export interface CompiledRegex {
+  groupCount(): number;
+  /** Capture group name → index. Empty when the pattern has no named groups. */
+  namedGroups(): Record<string, number>;
+  matcher(input: string): RegexMatcher;
+}
+
+export interface RegexEngine {
+  /**
+   * `pattern` is in JavaScript RegExp syntax. Throws RegexSyntaxError when the
+   * pattern is invalid or uses a feature the engine does not support.
+   */
+  compile(pattern: string, flags: RegexEngineFlags): CompiledRegex;
+}
+
+export class RegexSyntaxError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RegexSyntaxError";
+  }
+}

--- a/packages/just-bash/src/regex/engine.ts
+++ b/packages/just-bash/src/regex/engine.ts
@@ -3,8 +3,9 @@
  *
  * Every user-provided pattern (grep, sed, awk, jq, `[[ =~ ]]`, …) is compiled
  * and matched through one engine. The default is re2js, a pure-JS RE2 port,
- * which runs everywhere just-bash runs. A host may install another engine —
- * e.g. a native RE2 binding on Node — to trade portability for speed.
+ * which runs everywhere just-bash runs. A host may give a `Bash` instance
+ * another engine — e.g. a native RE2 binding on Node — via
+ * `new Bash({ regexEngine })` to trade portability for speed.
  *
  * Security contract for any installed engine: matching must be linear in the
  * input length for every pattern the engine accepts. UserRegex's ReDoS
@@ -15,6 +16,8 @@ export interface RegexEngineFlags {
   ignoreCase: boolean;
   multiline: boolean;
   dotAll: boolean;
+  /** JavaScript `u`: the pattern uses Unicode escapes such as `\u{1F600}`. */
+  unicode: boolean;
 }
 
 /**

--- a/packages/just-bash/src/regex/engine.ts
+++ b/packages/just-bash/src/regex/engine.ts
@@ -21,25 +21,44 @@ export interface RegexEngineFlags {
 }
 
 /**
- * Cursor over one input string. Modelled on RE2JS's Matcher so the default
- * adapter is a thin wrapper and the higher-level operations in UserRegex stay
- * engine-agnostic.
+ * Cursor over one input string. A cursor rather than an allocated match object
+ * because UserRegex drives many matches per line (`s///g`, `gsub`) and the
+ * default engine can serve them allocation-free; the accessors below are only
+ * meaningful after a `find` that returned true, and UserRegex never calls them
+ * otherwise.
  */
 export interface RegexMatcher {
-  /** Search from `start` (default 0). On success, start/end/group describe the match. */
+  /**
+   * Search for the next match at or after `start` (default 0). Returns false —
+   * and leaves the cursor without a current match — when there is none or when
+   * `start` is past the end of the input.
+   */
   find(start?: number): boolean;
+  /** Start offset of the current match (`group` 0) or of a capture group. */
   start(group?: number): number;
+  /** End offset (exclusive) of the current match or of a capture group. */
   end(group?: number): number;
-  /** Text of a capture group; null when the group did not participate. */
+  /**
+   * Text of the current match (`index` 0) or of a capture group; null when the
+   * group did not participate or `index` exceeds the pattern's group count.
+   */
   group(index?: number): string | null;
+  /**
+   * Every group of the current match: `[0]` is the whole match, then one entry
+   * per capture group in pattern order, null for non-participating groups.
+   * Allocates, so UserRegex calls it only where it builds a result array.
+   */
+  groups(): (string | null)[];
+  /**
+   * Named groups of the current match, name → text (null when the group did
+   * not participate). Empty when the pattern has no named groups.
+   */
+  namedGroups(): Record<string, string | null>;
   /** Point at a new input and rewind, reusing this matcher's allocations. */
   reset(input: string): void;
 }
 
 export interface CompiledRegex {
-  groupCount(): number;
-  /** Capture group name → index. Empty when the pattern has no named groups. */
-  namedGroups(): Record<string, number>;
   matcher(input: string): RegexMatcher;
 }
 

--- a/packages/just-bash/src/regex/index.ts
+++ b/packages/just-bash/src/regex/index.ts
@@ -22,14 +22,17 @@ export {
   type RegexMatcher,
   RegexSyntaxError,
 } from "./engine.js";
+export {
+  currentRegexEngine,
+  runWithRegexEngine,
+  supportsRegexEngineOption,
+} from "./engine-context.js";
 export { re2jsEngine } from "./re2js-engine.js";
 export {
   ConstantRegex,
   createUserRegex,
-  getRegexEngine,
   type RegexLike,
   type ReplaceCallback,
-  setRegexEngine,
   UserRegex,
   type UserRegexLimits,
 } from "./user-regex.js";

--- a/packages/just-bash/src/regex/index.ts
+++ b/packages/just-bash/src/regex/index.ts
@@ -2,7 +2,7 @@
  * Centralized regex handling for user-provided patterns.
  *
  * This module provides ReDoS-safe regex execution for all user-provided patterns.
- * Currently uses native JavaScript RegExp, designed to be swapped to RE2.
+ * Matching runs through a pluggable RegexEngine; re2js is the default.
  *
  * Usage:
  *   import { createUserRegex, UserRegex } from '../regex/index.js';
@@ -16,10 +16,20 @@
  */
 
 export {
+  type CompiledRegex,
+  type RegexEngine,
+  type RegexEngineFlags,
+  type RegexMatcher,
+  RegexSyntaxError,
+} from "./engine.js";
+export { re2jsEngine } from "./re2js-engine.js";
+export {
   ConstantRegex,
   createUserRegex,
+  getRegexEngine,
   type RegexLike,
   type ReplaceCallback,
+  setRegexEngine,
   UserRegex,
   type UserRegexLimits,
 } from "./user-regex.js";

--- a/packages/just-bash/src/regex/re2js-engine.ts
+++ b/packages/just-bash/src/regex/re2js-engine.ts
@@ -45,14 +45,8 @@ class Re2jsMatcherAdapter implements RegexMatcher {
   }
 
   reset(input: string): void {
-    // Swap the cached Utf16MatcherInput's charSequence in-place to avoid
-    // allocating a new Matcher per call. RE2JS's resetMatcherInput is not
-    // safe with raw strings (the constructor wraps strings via
-    // MatcherInput.utf16, but resetMatcherInput assigns its argument
-    // directly and then calls .length() as a method, which throws on a
-    // raw string). MatcherInput is not exported, so we mutate the existing
-    // wrapper's charSequence field — Matcher.reset() reads matcherInput.length()
-    // afterwards, so the new length is picked up correctly.
+    // re2js's resetMatcherInput throws on raw strings and MatcherInput is not
+    // exported, so retarget the existing wrapper; reset() re-reads its length.
     // biome-ignore lint/suspicious/noExplicitAny: reaching into re2js internals
     (this.matcher as any).matcherInput.charSequence = input;
     this.matcher.reset();

--- a/packages/just-bash/src/regex/re2js-engine.ts
+++ b/packages/just-bash/src/regex/re2js-engine.ts
@@ -26,7 +26,10 @@ function convertFlags(flags: RegexEngineFlags): number {
 }
 
 class Re2jsMatcherAdapter implements RegexMatcher {
-  constructor(private readonly matcher: Re2jsMatcher) {}
+  constructor(
+    private readonly re2: RE2JS,
+    private readonly matcher: Re2jsMatcher,
+  ) {}
 
   find(start?: number): boolean {
     return this.matcher.find(start);
@@ -40,8 +43,28 @@ class Re2jsMatcherAdapter implements RegexMatcher {
     return this.matcher.end(group);
   }
 
-  group(index?: number): string | null {
+  group(index = 0): string | null {
+    if (index > this.re2.groupCount()) {
+      return null;
+    }
     return this.matcher.group(index);
+  }
+
+  groups(): (string | null)[] {
+    const count = this.re2.groupCount();
+    const groups = new Array<string | null>(count + 1);
+    for (let i = 0; i <= count; i++) {
+      groups[i] = this.matcher.group(i);
+    }
+    return groups;
+  }
+
+  namedGroups(): Record<string, string | null> {
+    const named: Record<string, string | null> = Object.create(null);
+    for (const [name, index] of Object.entries(this.re2.namedGroups())) {
+      named[name] = this.matcher.group(index);
+    }
+    return named;
   }
 
   reset(input: string): void {
@@ -56,16 +79,8 @@ class Re2jsMatcherAdapter implements RegexMatcher {
 class Re2jsCompiledRegex implements CompiledRegex {
   constructor(private readonly re2: RE2JS) {}
 
-  groupCount(): number {
-    return this.re2.groupCount();
-  }
-
-  namedGroups(): Record<string, number> {
-    return this.re2.namedGroups();
-  }
-
   matcher(input: string): RegexMatcher {
-    return new Re2jsMatcherAdapter(this.re2.matcher(input));
+    return new Re2jsMatcherAdapter(this.re2, this.re2.matcher(input));
   }
 }
 

--- a/packages/just-bash/src/regex/re2js-engine.ts
+++ b/packages/just-bash/src/regex/re2js-engine.ts
@@ -1,0 +1,91 @@
+// Default engine: re2js, a pure-JS port of RE2.
+
+import { RE2JS, RE2JSSyntaxException } from "re2js";
+import {
+  type CompiledRegex,
+  type RegexEngine,
+  type RegexEngineFlags,
+  type RegexMatcher,
+  RegexSyntaxError,
+} from "./engine.js";
+
+type Re2jsMatcher = ReturnType<RE2JS["matcher"]>;
+
+function convertFlags(flags: RegexEngineFlags): number {
+  let re2Flags = 0;
+  if (flags.ignoreCase) {
+    re2Flags |= RE2JS.CASE_INSENSITIVE;
+  }
+  if (flags.multiline) {
+    re2Flags |= RE2JS.MULTILINE;
+  }
+  if (flags.dotAll) {
+    re2Flags |= RE2JS.DOTALL;
+  }
+  return re2Flags;
+}
+
+class Re2jsMatcherAdapter implements RegexMatcher {
+  constructor(private readonly matcher: Re2jsMatcher) {}
+
+  find(start?: number): boolean {
+    return this.matcher.find(start);
+  }
+
+  start(group?: number): number {
+    return this.matcher.start(group);
+  }
+
+  end(group?: number): number {
+    return this.matcher.end(group);
+  }
+
+  group(index?: number): string | null {
+    return this.matcher.group(index);
+  }
+
+  reset(input: string): void {
+    // Swap the cached Utf16MatcherInput's charSequence in-place to avoid
+    // allocating a new Matcher per call. RE2JS's resetMatcherInput is not
+    // safe with raw strings (the constructor wraps strings via
+    // MatcherInput.utf16, but resetMatcherInput assigns its argument
+    // directly and then calls .length() as a method, which throws on a
+    // raw string). MatcherInput is not exported, so we mutate the existing
+    // wrapper's charSequence field — Matcher.reset() reads matcherInput.length()
+    // afterwards, so the new length is picked up correctly.
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into re2js internals
+    (this.matcher as any).matcherInput.charSequence = input;
+    this.matcher.reset();
+  }
+}
+
+class Re2jsCompiledRegex implements CompiledRegex {
+  constructor(private readonly re2: RE2JS) {}
+
+  groupCount(): number {
+    return this.re2.groupCount();
+  }
+
+  namedGroups(): Record<string, number> {
+    return this.re2.namedGroups();
+  }
+
+  matcher(input: string): RegexMatcher {
+    return new Re2jsMatcherAdapter(this.re2.matcher(input));
+  }
+}
+
+export const re2jsEngine: RegexEngine = {
+  compile(pattern, flags) {
+    try {
+      return new Re2jsCompiledRegex(
+        RE2JS.compile(RE2JS.translateRegExp(pattern), convertFlags(flags)),
+      );
+    } catch (e) {
+      if (e instanceof RE2JSSyntaxException) {
+        throw new RegexSyntaxError(e.message || "");
+      }
+      throw e;
+    }
+  },
+};

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -150,6 +150,52 @@ export class UserRegex implements RegexLike {
     return output.build();
   }
 
+  private captureGroups(matcher: RegexMatcher): string[] {
+    const groupCount = this._compiled.groupCount();
+    const groups: string[] = [];
+    for (let i = 1; i <= groupCount; i++) {
+      groups.push(matcher.group(i) as string);
+    }
+    return groups;
+  }
+
+  // Null-prototype so a group named __proto__ cannot pollute the result.
+  // `missing` stands in for groups that did not participate; null omits them.
+  private namedGroupValues(
+    matcher: RegexMatcher,
+    missing: string | null,
+  ): Record<string, string> | undefined {
+    const entries = Object.entries(this._compiled.namedGroups());
+    if (entries.length === 0) {
+      return undefined;
+    }
+    const groups: Record<string, string> = Object.create(null);
+    for (const [name, index] of entries) {
+      const value = matcher.group(index) ?? missing;
+      if (value !== null) {
+        groups[name] = value;
+      }
+    }
+    return groups;
+  }
+
+  private buildMatchArray(
+    matcher: RegexMatcher,
+    input: string,
+  ): RegExpExecArray {
+    const result = [
+      matcher.group(0) ?? "",
+      ...this.captureGroups(matcher),
+    ] as unknown as RegExpExecArray;
+    result.index = matcher.start(0);
+    result.input = input;
+    const groups = this.namedGroupValues(matcher, null);
+    if (groups) {
+      result.groups = groups;
+    }
+    return result;
+  }
+
   private acquireMatcher(input: string): RegexMatcher {
     if (this._matcher === null) {
       this._matcher = this._compiled.matcher(input);
@@ -242,37 +288,7 @@ export class UserRegex implements RegexLike {
       return null;
     }
 
-    // Build result array
-    const groupCount = this._compiled.groupCount();
-    const result: string[] = [];
-
-    // Group 0 is the full match
-    result.push(matcher.group(0) ?? "");
-
-    // Add capture groups
-    for (let i = 1; i <= groupCount; i++) {
-      const group = matcher.group(i);
-      result.push(group as string);
-    }
-
-    // Add RegExpExecArray properties
-    const execResult = result as unknown as RegExpExecArray;
-    execResult.index = matcher.start(0);
-    execResult.input = input;
-
-    // Add named groups if any
-    const namedGroups = this._compiled.namedGroups();
-    if (namedGroups && Object.keys(namedGroups).length > 0) {
-      // Use Object.create(null) to prevent prototype pollution from names like __proto__
-      const groups: { [key: string]: string } = Object.create(null);
-      for (const [name, index] of Object.entries(namedGroups)) {
-        const value = matcher.group(index as number);
-        if (value !== null) {
-          groups[name] = value;
-        }
-      }
-      execResult.groups = groups;
-    }
+    const execResult = this.buildMatchArray(matcher, input);
 
     // Update lastIndex for global regex
     if (this._global) {
@@ -370,34 +386,20 @@ export class UserRegex implements RegexLike {
     let lastEnd = 0;
     let pos = 0;
     let matchCount = 0;
-    const groupCount = this._compiled.groupCount();
-    const namedGroups = this._compiled.namedGroups();
 
     while (matcher.find(pos)) {
-      // Add text before match
       this.assertResultCount(++matchCount);
       result.append(input.slice(lastEnd, matcher.start(0)));
 
-      // Build callback arguments
-      const args: (string | number | Record<string, string>)[] = [];
+      // Same argument list as String.prototype.replace hands its callback.
       const fullMatch = matcher.group(0) ?? "";
-
-      // Add capture groups
-      for (let i = 1; i <= groupCount; i++) {
-        args.push(matcher.group(i) as string);
-      }
-
-      // Add index and input
-      args.push(matcher.start(0));
-      args.push(input);
-
-      // Add named groups if present
-      if (namedGroups && Object.keys(namedGroups).length > 0) {
-        // Use Object.create(null) to prevent prototype pollution from names like __proto__
-        const groups: Record<string, string> = Object.create(null);
-        for (const [name, index] of Object.entries(namedGroups)) {
-          groups[name] = matcher.group(index as number) ?? "";
-        }
+      const args: (string | number | Record<string, string>)[] = [
+        ...this.captureGroups(matcher),
+        matcher.start(0),
+        input,
+      ];
+      const groups = this.namedGroupValues(matcher, "");
+      if (groups) {
         args.push(groups);
       }
 
@@ -480,39 +482,12 @@ export class UserRegex implements RegexLike {
     // UserRegex instance between two `next()` calls (acquireMatcher would
     // reset/repoint it). Use a fresh Matcher to keep iterator state private.
     const matcher = this._compiled.matcher(input);
-    const groupCount = this._compiled.groupCount();
-    const namedGroups = this._compiled.namedGroups();
     let pos = 0;
     let resultCount = 0;
 
     while (matcher.find(pos)) {
       this.assertResultCount(++resultCount);
-      // Build result array
-      const result: string[] = [];
-      result.push(matcher.group(0) ?? "");
-
-      for (let i = 1; i <= groupCount; i++) {
-        result.push(matcher.group(i) as string);
-      }
-
-      const execResult = result as unknown as RegExpMatchArray;
-      execResult.index = matcher.start(0);
-      execResult.input = input;
-
-      // Add named groups if any
-      if (namedGroups && Object.keys(namedGroups).length > 0) {
-        // Use Object.create(null) to prevent prototype pollution from names like __proto__
-        const groups: { [key: string]: string } = Object.create(null);
-        for (const [name, index] of Object.entries(namedGroups)) {
-          const value = matcher.group(index as number);
-          if (value !== null) {
-            groups[name] = value;
-          }
-        }
-        execResult.groups = groups;
-      }
-
-      yield execResult;
+      yield this.buildMatchArray(matcher, input);
 
       pos = matcher.end(0);
       // Prevent infinite loop on zero-length matches

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -2,15 +2,22 @@
  * UserRegex - Centralized regex handling for user-provided patterns
  *
  * This module provides a single point of control for all user-provided regex
- * execution. Uses RE2JS for ReDoS protection via linear-time matching.
+ * execution. Matching goes through the installed RegexEngine (re2js by
+ * default) for ReDoS protection via linear-time matching.
  *
  * All user-provided regex patterns should go through this module.
  * Internal patterns (those we control) can use ConstantRegex for the same interface.
  */
 
-import { RE2JS, RE2JSSyntaxException } from "re2js";
 import { BoundedStringBuilder } from "../bounded-builder.js";
 import { ExecutionLimitError } from "../interpreter/errors.js";
+import {
+  type CompiledRegex,
+  type RegexEngine,
+  type RegexMatcher,
+  RegexSyntaxError,
+} from "./engine.js";
+import { re2jsEngine } from "./re2js-engine.js";
 
 const DEFAULT_MAX_REGEX_RESULTS = 1_000_000;
 const DEFAULT_MAX_REGEX_OUTPUT_BYTES = 64 * 1024 * 1024;
@@ -51,38 +58,29 @@ export interface RegexLike {
   lastIndex: number;
 }
 
+let engine: RegexEngine = re2jsEngine;
+
 /**
- * Convert string flags to RE2JS numeric flags.
- * RE2 doesn't support the 'g' flag - we handle global matching manually.
+ * Install the engine every UserRegex compiles and matches through, process-wide.
+ * Returns the previously installed engine. The engine must guarantee
+ * linear-time matching; see RegexEngine.
  */
-function convertFlags(flags: string): number {
-  let re2Flags = 0;
-  if (flags.includes("i")) {
-    re2Flags |= RE2JS.CASE_INSENSITIVE;
-  }
-  if (flags.includes("m")) {
-    re2Flags |= RE2JS.MULTILINE;
-  }
-  if (flags.includes("s")) {
-    re2Flags |= RE2JS.DOTALL;
-  }
-  return re2Flags;
+export function setRegexEngine(next: RegexEngine): RegexEngine {
+  const previous = engine;
+  engine = next;
+  return previous;
+}
+
+export function getRegexEngine(): RegexEngine {
+  return engine;
 }
 
 /**
- * Translate a JavaScript regex pattern to RE2-compatible syntax.
- * Uses RE2JS.translateRegExp to handle syntax differences.
- */
-function translatePattern(pattern: string): string {
-  return RE2JS.translateRegExp(pattern);
-}
-
-/**
- * A wrapper around RE2JS that provides a RegExp-compatible interface.
- * Uses RE2 for linear-time matching, providing ReDoS protection.
+ * A wrapper around the installed RegexEngine that provides a RegExp-compatible
+ * interface. The engine guarantees linear-time matching, providing ReDoS protection.
  */
 export class UserRegex implements RegexLike {
-  private readonly _re2: RE2JS;
+  private readonly _re2: CompiledRegex;
   private readonly _pattern: string;
   private readonly _flags: string;
   private readonly _global: boolean;
@@ -91,12 +89,10 @@ export class UserRegex implements RegexLike {
   private _lastIndex = 0;
   // Cache native RegExp for compatibility - created lazily
   private _nativeRegex: RegExp | null = null;
-  // Reusable RE2 Matcher to avoid per-call allocation in tight grep loops.
+  // Reusable matcher to avoid per-call allocation in tight grep loops.
   // Matcher allocation dominates regex.test/exec cost when called once per line
-  // across thousands of lines. We mutate charSequence in-place (not resetMatcherInput,
-  // which is broken in re2js 1.2.1 — see acquireMatcher).
-  private _matcher: ReturnType<RE2JS["matcher"]> | null = null;
-  private _matcherInput: string | null = null;
+  // across thousands of lines.
+  private _matcher: RegexMatcher | null = null;
   private readonly maxResults: number;
   private readonly maxOutputBytes: number;
   private readonly signal?: AbortSignal;
@@ -112,7 +108,7 @@ export class UserRegex implements RegexLike {
   }
 
   private expandReplacement(
-    matcher: ReturnType<RE2JS["matcher"]>,
+    matcher: RegexMatcher,
     replacement: string,
   ): string {
     const output = new BoundedStringBuilder(
@@ -161,26 +157,12 @@ export class UserRegex implements RegexLike {
     return output.build();
   }
 
-  private acquireMatcher(input: string): ReturnType<RE2JS["matcher"]> {
+  private acquireMatcher(input: string): RegexMatcher {
     if (this._matcher === null) {
       this._matcher = this._re2.matcher(input);
-      this._matcherInput = input;
       return this._matcher;
     }
-    if (this._matcherInput !== input) {
-      // Swap the cached Utf16MatcherInput's charSequence in-place to avoid
-      // allocating a new Matcher per call. RE2JS's resetMatcherInput is not
-      // safe with raw strings (the constructor wraps strings via
-      // MatcherInput.utf16, but resetMatcherInput assigns its argument
-      // directly and then calls .length() as a method, which throws on a
-      // raw string). MatcherInput is not exported, so we mutate the existing
-      // wrapper's charSequence field — Matcher.reset() reads matcherInput.length()
-      // afterwards, so the new length is picked up correctly.
-      // biome-ignore lint/suspicious/noExplicitAny: reaching into re2js internals
-      (this._matcher as any).matcherInput.charSequence = input;
-      this._matcherInput = input;
-    }
-    this._matcher.reset();
+    this._matcher.reset(input);
     return this._matcher;
   }
 
@@ -204,11 +186,13 @@ export class UserRegex implements RegexLike {
     }
 
     try {
-      const translatedPattern = translatePattern(pattern);
-      const re2Flags = convertFlags(flags);
-      this._re2 = RE2JS.compile(translatedPattern, re2Flags);
+      this._re2 = engine.compile(pattern, {
+        ignoreCase: this._ignoreCase,
+        multiline: this._multiline,
+        dotAll: flags.includes("s"),
+      });
     } catch (e) {
-      if (e instanceof RE2JSSyntaxException) {
+      if (e instanceof RegexSyntaxError) {
         // Provide helpful error messages for unsupported RE2 features
         const msg = e.message || "";
         let explanation = "";

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -2,7 +2,7 @@
  * UserRegex - Centralized regex handling for user-provided patterns
  *
  * This module provides a single point of control for all user-provided regex
- * execution. Matching goes through the installed RegexEngine (re2js by
+ * execution. Matching goes through the execution's RegexEngine (re2js by
  * default) for ReDoS protection via linear-time matching.
  *
  * All user-provided regex patterns should go through this module.
@@ -13,11 +13,10 @@ import { BoundedStringBuilder } from "../bounded-builder.js";
 import { ExecutionLimitError } from "../interpreter/errors.js";
 import {
   type CompiledRegex,
-  type RegexEngine,
   type RegexMatcher,
   RegexSyntaxError,
 } from "./engine.js";
-import { re2jsEngine } from "./re2js-engine.js";
+import { currentRegexEngine } from "./engine-context.js";
 
 const DEFAULT_MAX_REGEX_RESULTS = 1_000_000;
 const DEFAULT_MAX_REGEX_OUTPUT_BYTES = 64 * 1024 * 1024;
@@ -58,26 +57,10 @@ export interface RegexLike {
   lastIndex: number;
 }
 
-let engine: RegexEngine = re2jsEngine;
-
 /**
- * Install the engine every UserRegex compiles and matches through, process-wide.
- * Returns the previously installed engine. The engine must guarantee
- * linear-time matching; see RegexEngine.
- */
-export function setRegexEngine(next: RegexEngine): RegexEngine {
-  const previous = engine;
-  engine = next;
-  return previous;
-}
-
-export function getRegexEngine(): RegexEngine {
-  return engine;
-}
-
-/**
- * A wrapper around the installed RegexEngine that provides a RegExp-compatible
- * interface. The engine guarantees linear-time matching, providing ReDoS protection.
+ * A wrapper around the current execution's RegexEngine that provides a
+ * RegExp-compatible interface. The engine guarantees linear-time matching,
+ * providing ReDoS protection.
  */
 export class UserRegex implements RegexLike {
   private readonly _re2: CompiledRegex;
@@ -186,10 +169,11 @@ export class UserRegex implements RegexLike {
     }
 
     try {
-      this._re2 = engine.compile(pattern, {
+      this._re2 = currentRegexEngine().compile(pattern, {
         ignoreCase: this._ignoreCase,
         multiline: this._multiline,
         dotAll: flags.includes("s"),
+        unicode: flags.includes("u"),
       });
     } catch (e) {
       if (e instanceof RegexSyntaxError) {

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -13,6 +13,7 @@ import { BoundedStringBuilder } from "../bounded-builder.js";
 import { ExecutionLimitError } from "../interpreter/errors.js";
 import {
   type CompiledRegex,
+  type RegexEngineFlags,
   type RegexMatcher,
   RegexSyntaxError,
 } from "./engine.js";
@@ -57,13 +58,22 @@ export interface RegexLike {
   lastIndex: number;
 }
 
+function engineFlagsFrom(flags: string): RegexEngineFlags {
+  return {
+    ignoreCase: flags.includes("i"),
+    multiline: flags.includes("m"),
+    dotAll: flags.includes("s"),
+    unicode: flags.includes("u"),
+  };
+}
+
 /**
  * A wrapper around the current execution's RegexEngine that provides a
  * RegExp-compatible interface. The engine guarantees linear-time matching,
  * providing ReDoS protection.
  */
 export class UserRegex implements RegexLike {
-  private readonly _re2: CompiledRegex;
+  private readonly _compiled: CompiledRegex;
   private readonly _pattern: string;
   private readonly _flags: string;
   private readonly _global: boolean;
@@ -98,8 +108,8 @@ export class UserRegex implements RegexLike {
       this.maxOutputBytes,
       "regular expression replacement",
     );
-    const groupCount = this._re2.groupCount();
-    const namedGroups = this._re2.namedGroups();
+    const groupCount = this._compiled.groupCount();
+    const namedGroups = this._compiled.namedGroups();
     for (let index = 0; index < replacement.length; index++) {
       const char = replacement[index];
       if (char === "\\" && index + 1 < replacement.length) {
@@ -142,7 +152,7 @@ export class UserRegex implements RegexLike {
 
   private acquireMatcher(input: string): RegexMatcher {
     if (this._matcher === null) {
-      this._matcher = this._re2.matcher(input);
+      this._matcher = this._compiled.matcher(input);
       return this._matcher;
     }
     this._matcher.reset(input);
@@ -169,12 +179,10 @@ export class UserRegex implements RegexLike {
     }
 
     try {
-      this._re2 = currentRegexEngine().compile(pattern, {
-        ignoreCase: this._ignoreCase,
-        multiline: this._multiline,
-        dotAll: flags.includes("s"),
-        unicode: flags.includes("u"),
-      });
+      this._compiled = currentRegexEngine().compile(
+        pattern,
+        engineFlagsFrom(flags),
+      );
     } catch (e) {
       if (e instanceof RegexSyntaxError) {
         // Provide helpful error messages for unsupported RE2 features
@@ -235,7 +243,7 @@ export class UserRegex implements RegexLike {
     }
 
     // Build result array
-    const groupCount = this._re2.groupCount();
+    const groupCount = this._compiled.groupCount();
     const result: string[] = [];
 
     // Group 0 is the full match
@@ -253,7 +261,7 @@ export class UserRegex implements RegexLike {
     execResult.input = input;
 
     // Add named groups if any
-    const namedGroups = this._re2.namedGroups();
+    const namedGroups = this._compiled.namedGroups();
     if (namedGroups && Object.keys(namedGroups).length > 0) {
       // Use Object.create(null) to prevent prototype pollution from names like __proto__
       const groups: { [key: string]: string } = Object.create(null);
@@ -325,7 +333,7 @@ export class UserRegex implements RegexLike {
     }
 
     if (typeof replacement === "string") {
-      const matcher = this._re2.matcher(input);
+      const matcher = this._compiled.matcher(input);
       const output = new BoundedStringBuilder(
         this.maxOutputBytes,
         "regular expression replacement",
@@ -358,12 +366,12 @@ export class UserRegex implements RegexLike {
       this.maxOutputBytes,
       "regular expression replacement",
     );
-    const matcher = this._re2.matcher(input);
+    const matcher = this._compiled.matcher(input);
     let lastEnd = 0;
     let pos = 0;
     let matchCount = 0;
-    const groupCount = this._re2.groupCount();
-    const namedGroups = this._re2.namedGroups();
+    const groupCount = this._compiled.groupCount();
+    const namedGroups = this._compiled.namedGroups();
 
     while (matcher.find(pos)) {
       // Add text before match
@@ -432,7 +440,7 @@ export class UserRegex implements RegexLike {
         ? this.maxResults
         : Math.min(limit, this.maxResults);
     const result: string[] = [];
-    const matcher = this._re2.matcher(input);
+    const matcher = this._compiled.matcher(input);
     let lastEnd = 0;
     let searchFrom = 0;
     while (result.length < effectiveLimit && matcher.find(searchFrom)) {
@@ -471,9 +479,9 @@ export class UserRegex implements RegexLike {
     // would be corrupted if a caller interleaves any other method on the same
     // UserRegex instance between two `next()` calls (acquireMatcher would
     // reset/repoint it). Use a fresh Matcher to keep iterator state private.
-    const matcher = this._re2.matcher(input);
-    const groupCount = this._re2.groupCount();
-    const namedGroups = this._re2.namedGroups();
+    const matcher = this._compiled.matcher(input);
+    const groupCount = this._compiled.groupCount();
+    const namedGroups = this._compiled.namedGroups();
     let pos = 0;
     let resultCount = 0;
 

--- a/packages/just-bash/src/regex/user-regex.ts
+++ b/packages/just-bash/src/regex/user-regex.ts
@@ -108,8 +108,10 @@ export class UserRegex implements RegexLike {
       this.maxOutputBytes,
       "regular expression replacement",
     );
-    const groupCount = this._compiled.groupCount();
-    const namedGroups = this._compiled.namedGroups();
+    // Resolved on first use: most replacements are literal and the string
+    // `s///g` path runs this once per match.
+    let groups: (string | null)[] | undefined;
+    let namedGroups: Record<string, string | null> | undefined;
     for (let index = 0; index < replacement.length; index++) {
       const char = replacement[index];
       if (char === "\\" && index + 1 < replacement.length) {
@@ -124,15 +126,17 @@ export class UserRegex implements RegexLike {
         const end = replacement.indexOf("}", index + 2);
         if (end !== -1) {
           const name = replacement.slice(index + 2, end);
-          const groupIndex = namedGroups?.[name];
-          if (groupIndex !== undefined) {
-            output.append(matcher.group(groupIndex) ?? "");
+          namedGroups ??= matcher.namedGroups();
+          if (name in namedGroups) {
+            output.append(namedGroups[name] ?? "");
             index = end;
             continue;
           }
         }
       }
       if (/\d/.test(replacement[index + 1])) {
+        groups ??= matcher.groups();
+        const groupCount = groups.length - 1;
         let end = index + 1;
         let group = 0;
         while (end < replacement.length && /\d/.test(replacement[end])) {
@@ -141,7 +145,7 @@ export class UserRegex implements RegexLike {
           group = candidate;
           end++;
         }
-        output.append(matcher.group(group) ?? "");
+        output.append(groups[group] ?? "");
         index = end - 1;
         continue;
       }
@@ -151,12 +155,7 @@ export class UserRegex implements RegexLike {
   }
 
   private captureGroups(matcher: RegexMatcher): string[] {
-    const groupCount = this._compiled.groupCount();
-    const groups: string[] = [];
-    for (let i = 1; i <= groupCount; i++) {
-      groups.push(matcher.group(i) as string);
-    }
-    return groups;
+    return matcher.groups().slice(1) as string[];
   }
 
   // Null-prototype so a group named __proto__ cannot pollute the result.
@@ -165,13 +164,13 @@ export class UserRegex implements RegexLike {
     matcher: RegexMatcher,
     missing: string | null,
   ): Record<string, string> | undefined {
-    const entries = Object.entries(this._compiled.namedGroups());
+    const entries = Object.entries(matcher.namedGroups());
     if (entries.length === 0) {
       return undefined;
     }
     const groups: Record<string, string> = Object.create(null);
-    for (const [name, index] of entries) {
-      const value = matcher.group(index) ?? missing;
+    for (const [name, text] of entries) {
+      const value = text ?? missing;
       if (value !== null) {
         groups[name] = value;
       }
@@ -571,8 +570,11 @@ export class UserRegex implements RegexLike {
 
 /**
  * Create a UserRegex from a pattern string and flags.
- * This is the primary entry point for user-provided regex patterns.
- * Uses RE2 for ReDoS protection.
+ * This is the primary entry point for user-provided regex patterns. The
+ * pattern is compiled by the engine of the `Bash` execution this is called
+ * from (`BashOptions.regexEngine`); outside any execution, or in the browser
+ * build, that is re2js. Either way the engine matches in linear time, which is
+ * the ReDoS protection.
  *
  * @param pattern - The regex pattern string
  * @param flags - Optional regex flags (g, i, m, s, u)

--- a/packages/just-bash/src/utils/glob.ts
+++ b/packages/just-bash/src/utils/glob.ts
@@ -18,7 +18,7 @@ import {
 const GLOB_CACHE_MAX = 2048;
 const globRegexCaches = new WeakMap<RegexEngine, Map<string, RegexLike>>();
 
-function globRegexCache(): Map<string, RegexLike> {
+function globRegexCacheForCurrentEngine(): Map<string, RegexLike> {
   const engine = currentRegexEngine();
   let cache = globRegexCaches.get(engine);
   if (!cache) {
@@ -72,7 +72,7 @@ export function matchGlob(
 
   // Build cache key
   const cacheKey = opts.ignoreCase ? `i:${cleanPattern}` : cleanPattern;
-  const cache = globRegexCache();
+  const cache = globRegexCacheForCurrentEngine();
   let re = cache.get(cacheKey);
 
   if (!re) {

--- a/packages/just-bash/src/utils/glob.ts
+++ b/packages/just-bash/src/utils/glob.ts
@@ -4,12 +4,29 @@
  * Used by grep, find, and other commands that need glob matching.
  */
 
-import { createUserRegex, type RegexLike } from "../regex/index.js";
+import {
+  createUserRegex,
+  currentRegexEngine,
+  type RegexEngine,
+  type RegexLike,
+} from "../regex/index.js";
 
-// Cache compiled regexes for glob patterns (key: pattern + flags).
-// Bounded to prevent unbounded memory growth from diverse patterns.
+// Cache compiled regexes for glob patterns (key: pattern + flags), one cache
+// per regex engine so an execution never matches through another engine's
+// compiled pattern. Bounded to prevent unbounded memory growth from diverse
+// patterns.
 const GLOB_CACHE_MAX = 2048;
-const globRegexCache = new Map<string, RegexLike>();
+const globRegexCaches = new WeakMap<RegexEngine, Map<string, RegexLike>>();
+
+function globRegexCache(): Map<string, RegexLike> {
+  const engine = currentRegexEngine();
+  let cache = globRegexCaches.get(engine);
+  if (!cache) {
+    cache = new Map();
+    globRegexCaches.set(engine, cache);
+  }
+  return cache;
+}
 
 export interface MatchGlobOptions {
   /** Case-insensitive matching */
@@ -55,16 +72,17 @@ export function matchGlob(
 
   // Build cache key
   const cacheKey = opts.ignoreCase ? `i:${cleanPattern}` : cleanPattern;
-  let re = globRegexCache.get(cacheKey);
+  const cache = globRegexCache();
+  let re = cache.get(cacheKey);
 
   if (!re) {
     re = globToRegex(cleanPattern, opts.ignoreCase);
-    if (globRegexCache.size >= GLOB_CACHE_MAX) {
+    if (cache.size >= GLOB_CACHE_MAX) {
       // Evict oldest entry (first key in insertion order)
-      const oldest = globRegexCache.keys().next().value;
-      if (oldest !== undefined) globRegexCache.delete(oldest);
+      const oldest = cache.keys().next().value;
+      if (oldest !== undefined) cache.delete(oldest);
     }
-    globRegexCache.set(cacheKey, re);
+    cache.set(cacheKey, re);
   }
 
   return re.test(name);


### PR DESCRIPTION
## Summary

`UserRegex` compiled and matched through `re2js` directly. This PR puts a small
engine interface between them, keeps re2js as the default and only shipped
engine, and lets a Node host give a `Bash` instance another **linear-time**
engine. Nothing changes for existing users: same code path, same behaviour,
same dependencies.

```ts
import { Bash, RegexSyntaxError, type RegexEngine } from "just-bash";

const bash = new Bash({ regexEngine: myEngine }); // e.g. a native RE2 binding
```

## Why

re2js is the right default: pure JS, runs in every runtime just-bash targets,
and carries the ReDoS guarantee. But it inherits RE2J's design, which has no
DFA — unanchored searches run the Pike VM, one thread per alternative, one step
per input character. On the shape an LLM agent writes most (`grep -iE
'a|b|c|…'`, `jq 'select(.x | test("a|b|c"; "i"))'`) that is the whole cost:

| 200k JSON lines, one search per line | V8 RegExp (unsafe) | re2js | native RE2 |
|---|---|---|---|
| `urgent\|asap\|priority\|escalat\|critical\|blocker\|p0\|sev1`, flag `i` | 15 ms | **14 071 ms** | 139 ms |
| same pattern anchored with `^` | 4 ms | 268 ms | 94 ms |
| `"status":"[a-z]+"` with replacement | 17 ms | 1 201 ms | 275 ms |
| literal `"status":"shipped"` | 30 ms | 333 ms | 121 ms |

Adding `^` makes re2js 52× faster on the same pattern; native RE2 moves 1.5×.
We hit the first row in production — an agent-authored jq `test()` over 170k
rows blocked a Node service's event loop for 19.6 s. A host that runs on Node
only can trade re2js's portability for RE2's DFA; just-bash should not have to
choose for everyone, and should certainly not take a native dependency. Hence a
seam, not a swap.

## Design

- `RegexEngine.compile(pattern, flags) → CompiledRegex`; `CompiledRegex.matcher(input) → RegexMatcher`,
  a cursor with `find(start)` / `start(g)` / `end(g)` / `group(i)` / `groups()` /
  `namedGroups()` / `reset(input)`. A cursor rather than an allocated match
  object because `UserRegex` drives many matches per line (`s///g`, `gsub`) and
  the default engine serves them allocation-free — measured: an
  `exec(input, start) → Match` shape costs re2js +10% on `test` loops and +21% on
  40-matches-per-line `gsub`. Group metadata lives on the match (`groups()`,
  `namedGroups()`), not on the compiled pattern: a native RE2 binding or the
  host `RegExp` cannot report a group count without compiling a probe, but
  every engine has the current match's groups at hand. Every higher-level
  operation — `test`/`exec`/`match`/`replace`/`split`/`matchAll`, named groups,
  `lastIndex`, zero-length handling, the reusable-matcher optimisation — is
  engine-agnostic; the re2js-specific `matcherInput.charSequence` retargeting
  moved into the adapter's `reset(input)`.
- `pattern` is passed in JavaScript RegExp syntax; each engine owns its own
  translation (re2js keeps calling `RE2JS.translateRegExp`).
- Engines signal invalid/unsupported patterns with `RegexSyntaxError`;
  `UserRegex` wraps it into the existing `Invalid regular expression: /…/: …`
  message with the lookahead/backreference explanations, so error output is
  identical across engines. Other errors propagate untouched.
- The engine is a `BashOptions` field, scoped to that instance's executions.
  `Bash.exec` runs the script inside an `AsyncLocalStorage` holding the engine
  and `UserRegex` resolves it from there, so none of the ~60 `createUserRegex`
  call sites (awk field splitting, sed, parameter expansion, `case` globs, …)
  change, and instances with different engines run concurrently without
  interference (tested). Same mechanism the defense-in-depth box already uses
  for its execution context. Node.js only: the browser build has no
  `AsyncLocalStorage`, so `new Bash({ regexEngine })` throws there with a clear
  message; everything else in the browser build is unchanged.
- The glob regex cache in `utils/glob.ts` is keyed per engine (`WeakMap` from
  engine to cache), so an execution never matches through a pattern another
  engine compiled.
- `RegexEngineFlags` carries `ignoreCase`, `multiline`, `dotAll` and `unicode`.
- Exported from both entry points: `re2jsEngine`, `RegexSyntaxError`, and the
  `RegexEngine` / `CompiledRegex` / `RegexMatcher` / `RegexEngineFlags` types.

**Security contract.** An installed engine must match in linear time for every
pattern it accepts; that property *is* `UserRegex`'s ReDoS protection. The
interface docs say so and `THREAT_MODEL.md` §3.7 and the mitigation table now
name the engine as the holder of that guarantee rather than re2js specifically.

## What is deliberately not in this PR

- **No native engine.** A `re2` (node-re2) adapter is ~40 lines and lives with
  the host; a reference implementation is below. Shipping it here would add a
  native dependency and a prebuilt-binary install step to a package whose
  point is running everywhere.

## Tests

`src/regex/engine.test.ts` (14 tests):

- default engine is re2js outside and inside an execution
- one `Bash` with a recording engine: grep, awk `-F` regex, `[[ =~ ]]` and sed
  all compile through it, with flags (`i`) carried
- two instances with different engines executing concurrently (interleaved
  with `sleep`) each see exactly their own patterns; the engine does not leak
  past the execution
- `u` reaches the engine; glob caches are separate per engine
- an engine's `RegexSyntaxError` gets the standard message (also observed as
  `grep: invalid regular expression` through a script); other errors propagate
- a **test-only** reference adapter over the host `RegExp` (deliberately not
  exported — it backtracks) exercises every `UserRegex` operation through the
  seam: `test`/`exec`/`search`, global `match`, `$n` and callback `replace`,
  `split`, `matchAll`, named groups, zero-length matches, `lastIndex`
  progression, matcher reuse across inputs — and a five-command script that
  produces output identical to the default engine

Existing `user-regex.test.ts` (73) passes unchanged. Full run of the regex
consumers — grep, sed, awk, jq/query-engine, rg, find, interpreter, utils,
`Bash.test.ts` — 3579 passed. `pnpm build` including the browser bundle.

`pnpm lint`, `pnpm knip`, `tsc --noEmit` clean.

## Validation with a real second engine

I ran 15 scripts end to end (sed with groups, grep `-c`/`-o`/`-iE`, awk `~` and
`gsub`, jq `test`/`capture`/`gsub`, `[[ =~ ]]` with `BASH_REMATCH`, `case`
globs, `find -regex`, plus the invalid-pattern error paths) with re2js and with
a node-re2 adapter. **All 15 produce byte-identical stdout, stderr and exit
codes.** Timing on a 20 MB / 200k-line file, with the compile cache from #399
applied:

| script | re2js | node-re2 adapter |
|---|---|---|
| `grep -ciE 'urgent\|asap\|…\|pending'` | 2158 ms | 303 ms (7.1×) |
| `sed -E 's/"status":"[a-z]+"/…/'` | 3536 ms | 2142 ms (1.7×) |
| `grep -c '"status":"shipped"'` | 352 ms | 203 ms (1.7×) |
| `jq 'select(.status \| test("ship\|deliv";"i"))'` | 1847 ms | 1528 ms (1.2×) |
| `jq '.note \| gsub("x";"y")'` (40 matches/line) | 671 ms | 1408 ms (0.5×) |
| `awk '{n+=gsub(/x/,"y")}'` | 89 ms | 174 ms (0.5×) |

The last two rows are worth stating plainly: node-re2's `exec` costs ~1.1 µs
per call at the JS↔C++ boundary, so shapes with many matches per line are
slower natively than in re2js, which stays in JS. A host should choose an
engine for its workload; this PR only makes the choice possible.

Compile cost is comparable (re2js 9–23 µs, node-re2 7–37 µs per pattern), so
#399's compile cache matters equally for both. This PR is independent of #399;
if both land, the cache keys on the engine flags and wraps `engine.compile` —
I'll rebase whichever goes second.

<details>
<summary>Reference adapter: node-re2 (host-side, not part of this PR)</summary>

```js
import RE2 from "re2";
import { RegexSyntaxError } from "just-bash";

const text = (v) => (v == null ? null : typeof v === "string" ? v : v.toString("latin1"));

class Matcher {
  #regex; #input; #match = null;
  constructor(regex, input) { this.#regex = regex; this.#input = input; }
  find(start = 0) {
    if (start > this.#input.length) return (this.#match = null, false);
    this.#regex.lastIndex = start;
    return (this.#match = this.#regex.exec(this.#input)) !== null;
  }
  start(g = 0) { return this.#match?.indices?.[g]?.[0] ?? -1; }
  end(g = 0) { return this.#match?.indices?.[g]?.[1] ?? -1; }
  group(i = 0) { return text(this.#match?.[i]); }
  groups() { return this.#match ? [...this.#match].map(text) : []; }
  namedGroups() {
    const named = Object.create(null);
    for (const [name, value] of Object.entries(this.#match?.groups ?? {})) named[name] = text(value);
    return named;
  }
  reset(input) { this.#input = input; this.#match = null; }
}

export const nodeRe2Engine = {
  compile(pattern, { ignoreCase, multiline, dotAll }) {
    let regex;
    try {
      regex = new RE2(pattern, `gd${ignoreCase ? "i" : ""}${multiline ? "m" : ""}${dotAll ? "s" : ""}`);
    } catch (e) {
      throw new RegexSyntaxError(e.message);
    }
    return { matcher: (input) => new Matcher(regex, input) };
  },
};
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
