### PR TITLE
feat(yes): implement the yes command

### DIFF
--- a/.changeset/yes-command.md
+++ b/.changeset/yes-command.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add the `yes` command. `yes [STRING]...` repeats a line built from its operands (`y` when there are none), so `yes | head -3` and `yes | some-prompt` work instead of failing with exit 127. Because pipeline stages here run to completion rather than streaming, the stream is finite: it ends after `executionLimits.maxLoopIterations` lines, or earlier if the repeated line would exceed the output size limit.

--- a/packages/just-bash/AGENTS.npm.md
+++ b/packages/just-bash/AGENTS.npm.md
@@ -80,7 +80,7 @@ const result = await bash.exec("cat input.txt | grep pattern");
 
 **File operations**: `basename`, `chmod`, `cp`, `dirname`, `du`, `file`, `find`, `ln`, `ls`, `mkdir`, `mv`, `od`, `pwd`, `readlink`, `rm`, `rmdir`, `split`, `stat`, `touch`, `tree`
 
-**Utilities**: `alias`, `base64`, `bash`, `clear`, `curl`, `date`, `diff`, `echo`, `env`, `expr`, `false`, `gzip`, `gunzip`, `help`, `history`, `hostname`, `html-to-markdown`, `md5sum`, `printenv`, `printf`, `seq`, `sh`, `sha1sum`, `sha256sum`, `sleep`, `tar`, `tee`, `time`, `timeout`, `true`, `unalias`, `which`, `whoami`, `zcat`
+**Utilities**: `alias`, `base64`, `bash`, `clear`, `curl`, `date`, `diff`, `echo`, `env`, `expr`, `false`, `gzip`, `gunzip`, `help`, `history`, `hostname`, `html-to-markdown`, `md5sum`, `printenv`, `printf`, `seq`, `sh`, `sha1sum`, `sha256sum`, `sleep`, `tar`, `tee`, `time`, `timeout`, `true`, `unalias`, `which`, `whoami`, `yes`, `zcat`
 
 All commands support `--help` for usage details.
 

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -106,7 +106,7 @@ duplicating internal defaults.
 
 ### Shell Utilities
 
-`alias`, `bash`, `chmod`, `clear`, `date`, `expr`, `false`, `help`, `history`, `seq`, `sh`, `sleep`, `time`, `timeout`, `true`, `unalias`, `which`, `whoami`
+`alias`, `bash`, `chmod`, `clear`, `date`, `expr`, `false`, `help`, `history`, `seq`, `sh`, `sleep`, `time`, `timeout`, `true`, `unalias`, `which`, `whoami`, `yes`
 
 ### Network
 

--- a/packages/just-bash/src/commands/fuzz-flags.ts
+++ b/packages/just-bash/src/commands/fuzz-flags.ts
@@ -118,6 +118,7 @@ import { flagsForFuzzing as whoami } from "./whoami/whoami.js";
 import { flagsForFuzzing as xan } from "./xan/xan.js";
 // Utilities
 import { flagsForFuzzing as xargs } from "./xargs/xargs.js";
+import { flagsForFuzzing as yes } from "./yes/yes.js";
 import { flagsForFuzzing as yq } from "./yq/yq.js";
 
 const allFuzzInfo: CommandFuzzInfo[] = [
@@ -174,6 +175,7 @@ const allFuzzInfo: CommandFuzzInfo[] = [
   xargs,
   trueCmd,
   falseCmd,
+  yes,
   clear,
   bash,
   sh,

--- a/packages/just-bash/src/commands/help/help.ts
+++ b/packages/just-bash/src/commands/help/help.ts
@@ -46,6 +46,7 @@ const CATEGORIES = new Map<string, string[]>([
       "clear",
       "true",
       "false",
+      "yes",
       "bash",
       "sh",
     ],

--- a/packages/just-bash/src/commands/registry.ts
+++ b/packages/just-bash/src/commands/registry.ts
@@ -70,6 +70,7 @@ export type CommandName =
   | "xargs"
   | "true"
   | "false"
+  | "yes"
   | "clear"
   | "bash"
   | "sh"
@@ -349,6 +350,10 @@ const commandLoaders: LazyCommandDef<CommandName>[] = [
   {
     name: "false",
     load: async () => (await import("./true/true.js")).falseCommand,
+  },
+  {
+    name: "yes",
+    load: async () => (await import("./yes/yes.js")).yesCommand,
   },
   {
     name: "clear",

--- a/packages/just-bash/src/commands/yes/yes.test.ts
+++ b/packages/just-bash/src/commands/yes/yes.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+describe("yes", () => {
+  describe("output", () => {
+    it("repeats y by default", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes | head -3");
+      expect(result.stdout).toBe("y\ny\ny\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("repeats a single operand", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes n | head -2");
+      expect(result.stdout).toBe("n\nn\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("joins multiple operands with a single space", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes a b | head -2");
+      expect(result.stdout).toBe("a b\na b\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("keeps empty operands, printing bare newlines", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes '' | head -2 | wc -c");
+      expect(result.stdout).toBe("2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("treats a lone dash as an operand", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes - | head -1");
+      expect(result.stdout).toBe("-\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("treats operands after -- literally", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes -- -x --help | head -1");
+      expect(result.stdout).toBe("-x --help\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("feeds a consumer that reads every line", async () => {
+      const env = new Bash({ executionLimits: { maxLoopIterations: 7 } });
+      const result = await env.exec("yes | wc -l");
+      expect(result.stdout).toBe("7\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("bounded stream", () => {
+    it("stops after maxLoopIterations lines", async () => {
+      const env = new Bash({ executionLimits: { maxLoopIterations: 3 } });
+      const result = await env.exec("yes");
+      expect(result.stdout).toBe("y\ny\ny\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("stops earlier when the output size limit binds first", async () => {
+      const env = new Bash({
+        executionLimits: { maxLoopIterations: 1000, maxOutputSize: 9 },
+      });
+      const result = await env.exec("yes ab");
+      expect(result.stdout).toBe("ab\nab\nab\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("counts UTF-8 bytes, not characters, against the size limit", async () => {
+      const env = new Bash({
+        executionLimits: { maxLoopIterations: 1000, maxOutputSize: 12 },
+      });
+      // "é\n" is 3 bytes, so 12 bytes allows 4 lines.
+      const result = await env.exec("yes é | wc -l");
+      expect(result.stdout).toBe("4\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("reports the output limit when one line does not fit", async () => {
+      const env = new Bash({ executionLimits: { maxOutputSize: 2 } });
+      const result = await env.exec("yes abc");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "bash: yes: output size limit exceeded (2 bytes)\n",
+      );
+      expect(result.exitCode).toBe(126);
+    });
+  });
+
+  describe("options", () => {
+    it("prints help for --help", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes --help");
+      expect(result.stdout).toContain("yes - output a string repeatedly");
+      expect(result.stdout).toContain("Usage: yes [STRING]...");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("prints help even when --help follows an operand", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes a --help");
+      expect(result.stdout).toContain("Usage: yes [STRING]...");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("errors on an unknown short option", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes -x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("yes: invalid option -- 'x'\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("errors on an unknown long option", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes --forever");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("yes: unrecognized option '--forever'\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("errors on an option that follows an operand", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes a -x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("yes: invalid option -- 'x'\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("integration", () => {
+    it("auto-confirms a reader in a pipeline", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes | head -2 | tr 'y' 'Y' | tr -d '\\n'");
+      expect(result.stdout).toBe("YY");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("redirects to a file", async () => {
+      const env = new Bash({ executionLimits: { maxLoopIterations: 2 } });
+      const result = await env.exec("yes ok > out.txt && cat out.txt");
+      expect(result.stdout).toBe("ok\nok\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("is reported by which", async () => {
+      const env = new Bash();
+      const result = await env.exec("which yes");
+      expect(result.stdout).toBe("/usr/bin/yes\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/yes/yes.test.ts
+++ b/packages/just-bash/src/commands/yes/yes.test.ts
@@ -90,6 +90,41 @@ describe("yes", () => {
       expect(result.exitCode).toBe(0);
     });
 
+    it("emits nothing when no iteration is permitted", async () => {
+      const env = new Bash({ executionLimits: { maxLoopIterations: 0 } });
+      const result = await env.exec("yes");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("charges the joined operands, not just the repetition", async () => {
+      const env = new Bash({
+        executionLimits: { maxLoopIterations: 1, maxOutputSize: 8 },
+      });
+      // Every operand fits on its own, but the line they build together does
+      // not, so the join is what reports the limit.
+      const result = await env.exec("yes aaaa bbbb cccc");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "bash: yes: output size limit exceeded (8 bytes)\n",
+      );
+      expect(result.exitCode).toBe(126);
+    });
+
+    it("counts the newline against the line budget", async () => {
+      const env = new Bash({
+        executionLimits: { maxLoopIterations: 1, maxOutputSize: 4 },
+      });
+      // "abcd" is exactly the budget, so "abcd\n" cannot fit.
+      const result = await env.exec("yes abcd");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "bash: yes: output size limit exceeded (4 bytes)\n",
+      );
+      expect(result.exitCode).toBe(126);
+    });
+
     it("reports the output limit when one line does not fit", async () => {
       const env = new Bash({ executionLimits: { maxOutputSize: 2 } });
       const result = await env.exec("yes abc");
@@ -122,6 +157,14 @@ describe("yes", () => {
     it("errors on an unknown short option", async () => {
       const env = new Bash();
       const result = await env.exec("yes -x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("yes: invalid option -- 'x'\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("names the first letter of a grouped short option", async () => {
+      const env = new Bash();
+      const result = await env.exec("yes -xy");
       expect(result.stdout).toBe("");
       expect(result.stderr).toBe("yes: invalid option -- 'x'\n");
       expect(result.exitCode).toBe(1);

--- a/packages/just-bash/src/commands/yes/yes.ts
+++ b/packages/just-bash/src/commands/yes/yes.ts
@@ -1,0 +1,86 @@
+import { boundedRepeat } from "../../bounded-builder.js";
+import { utf8ByteLength } from "../../encoding.js";
+import type {
+  ExecResult,
+  RuntimeCommand,
+  RuntimeCommandContext,
+} from "../../types.js";
+import { showHelp, unknownOption } from "../help.js";
+
+const yesHelp = {
+  name: "yes",
+  summary: "output a string repeatedly",
+  usage: "yes [STRING]...",
+  description: [
+    "Repeatedly output a line with all specified STRING(s), or 'y'.",
+  ],
+  options: ["    --help  display this help and exit"],
+  notes: [
+    "Real yes writes until its reader goes away. Pipelines here are not",
+    "streaming — a stage runs to completion before the next one starts — so",
+    "yes stops on its own after executionLimits.maxLoopIterations lines, or",
+    "earlier if the repeated line would exceed the output size limit.",
+    "`yes | head -3` therefore behaves as expected; an unbounded consumer",
+    "sees a finite stream.",
+  ],
+};
+
+export const yesCommand: RuntimeCommand = {
+  name: "yes",
+
+  async execute(
+    args: string[],
+    ctx: RuntimeCommandContext,
+  ): Promise<ExecResult> {
+    const operands: string[] = [];
+    let optionsEnded = false;
+
+    for (const arg of args) {
+      if (optionsEnded) {
+        operands.push(arg);
+        continue;
+      }
+      if (arg === "--") {
+        optionsEnded = true;
+        continue;
+      }
+      if (arg === "--help") {
+        return showHelp(yesHelp);
+      }
+      // A lone "-" is an operand, as in GNU yes; anything else that starts
+      // with a dash is an option, even after an operand (getopt permutes).
+      if (arg.startsWith("-") && arg !== "-") {
+        return unknownOption("yes", arg);
+      }
+      operands.push(arg);
+    }
+
+    const line = `${operands.length > 0 ? operands.join(" ") : "y"}\n`;
+    const maxBytes = Math.min(
+      ctx.limits.maxStringLength,
+      ctx.limits.maxOutputSize,
+    );
+    // A single line still has to be emitted (and may legitimately blow the
+    // output budget, which boundedRepeat reports), so never floor to zero.
+    const lines = Math.max(
+      1,
+      Math.min(
+        ctx.limits.maxLoopIterations,
+        Math.floor(maxBytes / utf8ByteLength(line)),
+      ),
+    );
+
+    return {
+      stdout: boundedRepeat(line, lines, maxBytes, "yes"),
+      stderr: "",
+      exitCode: 0,
+    };
+  },
+};
+
+import type { CommandFuzzInfo } from "../fuzz-flags-types.js";
+
+export const flagsForFuzzing: CommandFuzzInfo = {
+  name: "yes",
+  flags: [],
+};

--- a/packages/just-bash/src/commands/yes/yes.ts
+++ b/packages/just-bash/src/commands/yes/yes.ts
@@ -1,4 +1,4 @@
-import { boundedRepeat } from "../../bounded-builder.js";
+import { boundedJoin, boundedRepeat } from "../../bounded-builder.js";
 import { utf8ByteLength } from "../../encoding.js";
 import type {
   ExecResult,
@@ -49,26 +49,33 @@ export const yesCommand: RuntimeCommand = {
       }
       // A lone "-" is an operand, as in GNU yes; anything else that starts
       // with a dash is an option, even after an operand (getopt permutes).
-      if (arg.startsWith("-") && arg !== "-") {
+      // Grouped short options are reported by their first offending letter,
+      // the way getopt does: `yes -xy` names 'x', not 'xy'.
+      if (arg.startsWith("--")) {
         return unknownOption("yes", arg);
+      }
+      if (arg.startsWith("-") && arg !== "-") {
+        return unknownOption("yes", `-${arg[1]}`);
       }
       operands.push(arg);
     }
 
-    const line = `${operands.length > 0 ? operands.join(" ") : "y"}\n`;
     const maxBytes = Math.min(
       ctx.limits.maxStringLength,
       ctx.limits.maxOutputSize,
     );
-    // A single line still has to be emitted (and may legitimately blow the
-    // output budget, which boundedRepeat reports), so never floor to zero.
-    const lines = Math.max(
-      1,
-      Math.min(
-        ctx.limits.maxLoopIterations,
-        Math.floor(maxBytes / utf8ByteLength(line)),
-      ),
-    );
+    // Many large operands can build one huge line, so charge the join too. The
+    // newline is charged by the repetition below, which keeps the reported
+    // limit equal to the configured one.
+    const line =
+      operands.length > 0
+        ? `${boundedJoin(operands, " ", maxBytes, "yes")}\n`
+        : "y\n";
+    const fits = Math.floor(maxBytes / utf8ByteLength(line));
+    // One line that cannot fit is still attempted, so boundedRepeat reports the
+    // output limit rather than silently printing nothing. Zero permitted
+    // iterations, on the other hand, means zero lines.
+    const lines = Math.min(ctx.limits.maxLoopIterations, Math.max(1, fits));
 
     return {
       stdout: boundedRepeat(line, lines, maxBytes, "yes"),

--- a/packages/just-bash/src/comparison-tests/fixtures/yes.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/yes.comparison.fixtures.json
@@ -1,0 +1,66 @@
+{
+  "0294fc355aeceb01": {
+    "command": "yes n | head -2",
+    "files": {},
+    "stdout": "n\nn\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "0db72c7020ecd913": {
+    "command": "yes -- -x | head -2",
+    "files": {},
+    "stdout": "-x\n-x\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "376abd7f23fa5054": {
+    "command": "yes | head -3",
+    "files": {},
+    "stdout": "y\ny\ny\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "46f40986aa54b9d3": {
+    "command": "yes | head -5000 | wc -l",
+    "files": {},
+    "stdout": "5000\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "4b012c6515d179df": {
+    "command": "yes a b c | head -2",
+    "files": {},
+    "stdout": "a b c\na b c\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "67c83a8b598bb1ac": {
+    "command": "yes '' | head -2 | wc -c",
+    "files": {},
+    "stdout": "2\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "7df5bcd8482d31d5": {
+    "command": "yes - | head -2",
+    "files": {},
+    "stdout": "-\n-\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ea5593dc3a596d8d": {
+    "command": "yes yes | head -4 | sort -u",
+    "files": {},
+    "stdout": "yes\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/yes.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/yes.comparison.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Fixtures were recorded against GNU coreutils `yes` (BSD `yes` ignores every
+ * operand but the first), and are locked so a macOS re-record cannot silently
+ * replace them with BSD output.
+ *
+ * Only bounded consumers are compared: real `yes` never stops on its own, so
+ * every case has to terminate the stream with `head`.
+ */
+describe("yes command - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  it("repeats y by default", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes | head -3");
+  });
+
+  it("repeats a single operand", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes n | head -2");
+  });
+
+  it("joins multiple operands with a space", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes a b c | head -2");
+  });
+
+  it("keeps an empty operand as an empty line", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes '' | head -2 | wc -c");
+  });
+
+  it("treats operands after -- literally", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes -- -x | head -2");
+  });
+
+  it("treats a lone dash as an operand", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes - | head -2");
+  });
+
+  it("feeds a long bounded read", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes | head -5000 | wc -l");
+  });
+
+  it("auto-confirms a reader that counts confirmations", async () => {
+    const env = await setupFiles(testDir, {});
+    await compareOutputs(env, testDir, "yes yes | head -4 | sort -u");
+  });
+});


### PR DESCRIPTION
Fixes the `yes` half of #408 (`realpath` follows in a separate PR).

`yes` exited 127, so neither `yes | head -5` nor auto-confirming a prompt worked.

## What it does

- Repeats a line built from the operands joined by single spaces, `y` when there are none.
- GNU option handling: `--help`, `--` ends options, a lone `-` is an operand, and any other dash-prefixed argument is an unknown option even when it follows an operand (getopt permutes) — `yes: invalid option -- 'x'` / `yes: unrecognized option '--forever'`, exit 1.

## The one deliberate deviation

Real `yes` writes until its reader goes away. A pipeline stage here runs to completion before the next one starts, so "until the reader goes away" has no meaning and an unbounded `yes` would just be a hang. The stream is therefore finite:

- it stops after `executionLimits.maxLoopIterations` lines (100k normal, 10k hardened), and
- earlier when the repeated line would no longer fit in `min(maxStringLength, maxOutputSize)`.

`yes | head -3`, `yes n | head -2`, `yes | head -5000 | wc -l` are all exact against real GNU `yes`. A consumer that wants more lines than the bound sees a short stream, which is the trade for not hanging. The bound is spelled out in `yes --help`.

If a single line cannot fit the output budget at all, the existing output-limit error surfaces (`bash: yes: output size limit exceeded (N bytes)`, exit 126) rather than silently printing nothing.

## Tests

- `src/commands/yes/yes.test.ts` — 19 unit tests: operands, `--`, lone `-`, both limit paths, UTF-8 byte accounting, option errors, redirection, `which yes`.
- `src/comparison-tests/yes.comparison.test.ts` + fixtures — 8 cases against real `yes`. Recorded with GNU coreutils on `PATH` (BSD `yes` ignores every operand but the first) and locked so a macOS re-record cannot swap in BSD output.

## Validation

`pnpm typecheck`, `pnpm lint:fix`, `pnpm lint:banned`, `pnpm knip`, `pnpm test:unit`, `pnpm test:comparison` all pass. Five python3/WASM-bundle test files fail identically on unmodified `main` in this environment (no built `dist`), and are untouched by this change.