### PR TITLE
feat(realpath): implement the realpath command

### DIFF
--- a/.changeset/realpath-command.md
+++ b/.changeset/realpath-command.md
@@ -1,0 +1,5 @@
+---
+"just-bash": minor
+---
+
+Add the `realpath` command. Canonicalizes names against the virtual filesystem — resolving `.`, `..` and symlinks — instead of exiting 127, with GNU's `-e`, `-m`, `-s`/`--no-symlinks`, `-L`, `-P`, `-q`, `-z`, `--relative-to` and `--relative-base`, GNU's default policy that every component but the last must exist, and GNU's diagnostics for a missing component, a path descending through a regular file, and a symlink loop.

--- a/packages/just-bash/AGENTS.npm.md
+++ b/packages/just-bash/AGENTS.npm.md
@@ -78,7 +78,7 @@ const result = await bash.exec("cat input.txt | grep pattern");
 
 **Data processing**: `jq` (JSON), `js-exec` (JavaScript/TypeScript via QuickJS), `python3`/`python` (Python via WASM/CPython), `sqlite3` (SQLite), `xan` (CSV), `yq` (YAML/XML/TOML/CSV)
 
-**File operations**: `basename`, `chmod`, `cp`, `dirname`, `du`, `file`, `find`, `ln`, `ls`, `mkdir`, `mv`, `od`, `pwd`, `readlink`, `rm`, `rmdir`, `split`, `stat`, `touch`, `tree`
+**File operations**: `basename`, `chmod`, `cp`, `dirname`, `du`, `file`, `find`, `ln`, `ls`, `mkdir`, `mv`, `od`, `pwd`, `readlink`, `realpath`, `rm`, `rmdir`, `split`, `stat`, `touch`, `tree`
 
 **Utilities**: `alias`, `base64`, `bash`, `clear`, `curl`, `date`, `diff`, `echo`, `env`, `expr`, `false`, `gzip`, `gunzip`, `help`, `history`, `hostname`, `html-to-markdown`, `md5sum`, `printenv`, `printf`, `seq`, `sh`, `sha1sum`, `sha256sum`, `sleep`, `tar`, `tee`, `time`, `timeout`, `true`, `unalias`, `which`, `whoami`, `zcat`
 

--- a/packages/just-bash/README.md
+++ b/packages/just-bash/README.md
@@ -102,7 +102,7 @@ duplicating internal defaults.
 
 ### Navigation & Environment
 
-`basename`, `cd`, `dirname`, `du`, `echo`, `env`, `export`, `find`, `hostname`, `printenv`, `pwd`, `tee`
+`basename`, `cd`, `dirname`, `du`, `echo`, `env`, `export`, `find`, `hostname`, `printenv`, `pwd`, `realpath`, `tee`
 
 ### Shell Utilities
 

--- a/packages/just-bash/src/commands/fuzz-flags.ts
+++ b/packages/just-bash/src/commands/fuzz-flags.ts
@@ -82,6 +82,7 @@ import { flagsForFuzzing as printf } from "./printf/printf.js";
 // Navigation
 import { flagsForFuzzing as pwd } from "./pwd/pwd.js";
 import { flagsForFuzzing as readlink } from "./readlink/readlink.js";
+import { flagsForFuzzing as realpath } from "./realpath/realpath.js";
 import { flagsForFuzzing as rev } from "./rev/rev.js";
 import { flagsForFuzzing as rg } from "./rg/rg.js";
 import { flagsForFuzzing as rm } from "./rm/rm.js";
@@ -135,6 +136,7 @@ const allFuzzInfo: CommandFuzzInfo[] = [
   chmod,
   pwd,
   readlink,
+  realpath,
   head,
   tail,
   wc,

--- a/packages/just-bash/src/commands/help/help.ts
+++ b/packages/just-bash/src/commands/help/help.ts
@@ -31,7 +31,10 @@ const CATEGORIES = new Map<string, string[]>([
     ["grep", "sed", "awk", "sort", "uniq", "cut", "tr", "tee", "diff"],
   ],
   ["Search", ["find"]],
-  ["Navigation & paths", ["pwd", "basename", "dirname", "tree", "du"]],
+  [
+    "Navigation & paths",
+    ["pwd", "basename", "dirname", "realpath", "tree", "du"],
+  ],
   [
     "Environment & shell",
     [

--- a/packages/just-bash/src/commands/realpath/canonicalize.ts
+++ b/packages/just-bash/src/commands/realpath/canonicalize.ts
@@ -1,37 +1,312 @@
-import type { IFileSystem } from "../../fs/interface.js";
-import { MAX_SYMLINK_DEPTH, normalizePath } from "../../fs/path-utils.js";
+import type { FsStat, IFileSystem } from "../../fs/interface.js";
+import { MAX_SYMLINK_DEPTH } from "../../fs/path-utils.js";
 import type { FileTraversalBudget } from "../../fs/traversal.js";
+import {
+  ExecutionAbortedError,
+  ExecutionLimitError,
+} from "../../interpreter/errors.js";
 
 /**
  * How much of the path has to exist.
  *
  * - `default`: every component but the last (GNU's default)
  * - `existing`: all of it (`-e`)
- * - `missing`: none of it (`-m`)
+ * - `missing`: none of it, and nothing fails (`-m`)
  */
 export type ExistencePolicy = "default" | "existing" | "missing";
 
 export interface CanonicalizeOptions {
   existence: ExistencePolicy;
-  /** `-s` / `--no-symlinks`: expand nothing, resolve `.` and `..` textually. */
+  /** `-s` / `--no-symlinks`: name components stay unexpanded. */
   noSymlinks: boolean;
-  /** `-L` / `--logical`: resolve `..` before symlinks instead of after. */
+  /** `-L` / `--logical`: resolve `..` components before symlinks. */
   logical: boolean;
 }
 
-export type CanonicalizeFailure = "ENOENT" | "ENOTDIR" | "ELOOP";
+export type CanonicalizeFailure = "ENOENT" | "ENOTDIR" | "ELOOP" | "EACCES";
 
 export type CanonicalizeResult =
   | { ok: true; path: string }
   | { ok: false; code: CanonicalizeFailure };
 
-/** Path components with `.` and empty segments dropped; `..` is significant. */
+/**
+ * Path components, empty segments dropped. `.` is kept: it is not a no-op,
+ * because `file/.` has to fail the way `file/x` does.
+ */
 function splitComponents(path: string): string[] {
-  return path.split("/").filter((part) => part !== "" && part !== ".");
+  return path.split("/").filter((part) => part !== "");
 }
 
 function parentOf(resolved: string): string {
   return resolved.slice(0, resolved.lastIndexOf("/"));
+}
+
+/** Limits and cancellation belong to the caller, never to path resolution. */
+function rethrowExecutionErrors(error: unknown): void {
+  if (
+    error instanceof ExecutionLimitError ||
+    error instanceof ExecutionAbortedError
+  ) {
+    throw error;
+  }
+}
+
+/** The failure realpath reports for a filesystem error, or a missing entry. */
+function failureFor(error: unknown): CanonicalizeFailure | "missing" {
+  rethrowExecutionErrors(error);
+  const message = error instanceof Error ? error.message : String(error);
+  switch (/^([A-Z]+):/.exec(message)?.[1]) {
+    case "ENOENT":
+      return "missing";
+    case "ENOTDIR":
+      return "ENOTDIR";
+    case "ELOOP":
+      return "ELOOP";
+    case "EACCES":
+    case "EPERM":
+      return "EACCES";
+    default:
+      // An unexplained failure must not read as a resolvable name.
+      return "ENOENT";
+  }
+}
+
+/** Stat with symlinks followed; `undefined` when the entry cannot be read. */
+async function statFollowing(
+  fs: IFileSystem,
+  path: string,
+): Promise<FsStat | undefined> {
+  try {
+    return await fs.stat(path === "" ? "/" : path);
+  } catch (error) {
+    rethrowExecutionErrors(error);
+    return undefined;
+  }
+}
+
+/**
+ * Where an absolute symlink target starts.
+ *
+ * MountableFs stores a mounted filesystem's absolute targets relative to that
+ * filesystem's own root, so restarting at the global root would leave the
+ * mount and name a different file. Asking the filesystem to resolve the link
+ * puts the answer back in the global namespace; every single-root backend
+ * returns exactly what restarting at the root produces, and a link the
+ * backend cannot resolve (dangling, blocked, looping) falls back to it.
+ */
+async function absoluteTargetBase(
+  fs: IFileSystem,
+  linkPath: string,
+): Promise<{ resolved: string; consumesTarget: boolean }> {
+  try {
+    return { resolved: await fs.realpath(linkPath), consumesTarget: true };
+  } catch (error) {
+    rethrowExecutionErrors(error);
+    return { resolved: "", consumesTarget: false };
+  }
+}
+
+/**
+ * Resolve `input` against the filesystem, expanding symlinks as they are
+ * encountered unless `noSymlinks` is set.
+ */
+async function walk(
+  fs: IFileSystem,
+  cwd: string,
+  input: string,
+  options: CanonicalizeOptions,
+  budget: FileTraversalBudget,
+): Promise<CanonicalizeResult> {
+  const absolute = input.startsWith("/") ? input : `${cwd}/${input}`;
+  const expand = !options.noSymlinks;
+  const tolerateMissing = options.existence === "missing";
+  // A trailing slash asserts the name is a directory.
+  let requireDirectory = input.endsWith("/");
+
+  let queue = splitComponents(absolute);
+  let index = 0;
+  let resolved = "";
+  let depth = 0;
+  let symlinkHops = 0;
+
+  /** Whether a component that does not exist ends resolution with ENOENT. */
+  const missingIsFatal = (isLast: boolean): boolean => {
+    // Without expansion GNU checks no intermediate component; `-e` is left to
+    // the existence check on the finished name.
+    if (options.noSymlinks) return false;
+    if (options.existence === "existing") return true;
+    return !isLast;
+  };
+
+  while (index < queue.length) {
+    const component = queue[index++];
+    budget.visit(depth);
+
+    // `.` only asserts that what precedes it is a directory, which the
+    // component before it already checked by seeing a component remaining.
+    if (component === ".") continue;
+
+    if (component === "..") {
+      resolved = parentOf(resolved);
+      depth = Math.max(0, depth - 1);
+      continue;
+    }
+
+    const candidate = `${resolved}/${component}`;
+    const isLast = index === queue.length;
+    const needsDirectory = !isLast || requireDirectory;
+
+    let entry: FsStat;
+    try {
+      entry = await fs.lstat(candidate);
+    } catch (error) {
+      const failure = failureFor(error);
+      if (!tolerateMissing) {
+        if (failure !== "missing") return { ok: false, code: failure };
+        if (missingIsFatal(isLast)) return { ok: false, code: "ENOENT" };
+      }
+      resolved = candidate;
+      depth++;
+      continue;
+    }
+
+    if (entry.isSymbolicLink && expand) {
+      if (++symlinkHops > MAX_SYMLINK_DEPTH) {
+        // `-m` promises never to fail, so a loop leaves the link unexpanded.
+        if (!tolerateMissing) return { ok: false, code: "ELOOP" };
+        resolved = candidate;
+        depth++;
+        continue;
+      }
+
+      let target: string;
+      try {
+        target = await fs.readlink(candidate);
+      } catch (error) {
+        const failure = failureFor(error);
+        if (tolerateMissing) {
+          resolved = candidate;
+          depth++;
+          continue;
+        }
+        return { ok: false, code: failure === "missing" ? "ENOENT" : failure };
+      }
+
+      const remaining = queue.length - index;
+      // A target ending in a slash carries the directory requirement, but
+      // only when the link is the last thing being named.
+      if (remaining === 0 && target.endsWith("/")) requireDirectory = true;
+
+      const targetComponents = splitComponents(target);
+      // Charge the expanded path before allocating it, so an oversized target
+      // trips the traversal budget instead of the allocator.
+      budget.checkpoint(targetComponents.length + remaining);
+
+      if (target.startsWith("/")) {
+        const base = await absoluteTargetBase(fs, candidate);
+        resolved = base.resolved;
+        depth = splitComponents(resolved).length;
+        if (base.consumesTarget) {
+          // The filesystem resolved the whole link, so the target components
+          // are already accounted for; only the directory test is left.
+          if (needsDirectory && !tolerateMissing) {
+            const followed = await statFollowing(fs, resolved);
+            if (followed !== undefined && !followed.isDirectory) {
+              return { ok: false, code: "ENOTDIR" };
+            }
+          }
+          queue = queue.slice(index);
+          index = 0;
+          continue;
+        }
+      }
+
+      queue = targetComponents.concat(queue.slice(index));
+      index = 0;
+      continue;
+    }
+
+    resolved = candidate;
+    depth++;
+
+    // An unexpanded symlink is still followed for the directory test: that is
+    // how GNU makes `realpath -s link/x` ENOTDIR while `-s dirlink/x` passes.
+    const followed =
+      entry.isSymbolicLink && !expand
+        ? await statFollowing(fs, candidate)
+        : entry;
+
+    if (
+      needsDirectory &&
+      !tolerateMissing &&
+      followed !== undefined &&
+      !followed.isDirectory
+    ) {
+      return { ok: false, code: "ENOTDIR" };
+    }
+  }
+
+  const path = resolved === "" ? "/" : resolved;
+
+  // Nothing above checked existence when components are left unexpanded.
+  if (options.noSymlinks && options.existence === "existing") {
+    if ((await statFollowing(fs, path)) === undefined) {
+      return { ok: false, code: "ENOENT" };
+    }
+  }
+
+  return { ok: true, path };
+}
+
+/**
+ * Cancel `X/..` pairs before any symlink is expanded (`-L`), which is only
+ * allowed when `X` is an existing directory — GNU rejects `-L link/..` for a
+ * link to a file and `-L nosuch/..` for a name that is not there.
+ */
+async function canonicalizeLogical(
+  fs: IFileSystem,
+  cwd: string,
+  input: string,
+  options: CanonicalizeOptions,
+  budget: FileTraversalBudget,
+): Promise<CanonicalizeResult> {
+  const absolute = input.startsWith("/") ? input : `${cwd}/${input}`;
+  const physical: CanonicalizeOptions = { ...options, logical: false };
+  const kept: string[] = [];
+
+  const requireDirectoryPrefix = async (): Promise<CanonicalizeResult> => {
+    if (options.existence === "missing") return { ok: true, path: "" };
+    // The trailing slash makes the prefix a directory requirement, and
+    // `existing` makes its absence an error.
+    return walk(
+      fs,
+      cwd,
+      `/${kept.join("/")}/`,
+      { ...physical, existence: "existing" },
+      budget,
+    );
+  };
+
+  for (const component of splitComponents(absolute)) {
+    budget.visit(kept.length);
+
+    if (component !== "." && component !== "..") {
+      kept.push(component);
+      continue;
+    }
+
+    // `..` at the root is the root, and needs no directory above it.
+    if (component === ".." && kept.length === 0) continue;
+
+    const prefix = await requireDirectoryPrefix();
+    if (!prefix.ok) return prefix;
+    if (component === "..") kept.pop();
+  }
+
+  const logicalPath = `/${kept.join("/")}${
+    input.endsWith("/") && kept.length > 0 ? "/" : ""
+  }`;
+  return walk(fs, cwd, logicalPath, physical, budget);
 }
 
 /**
@@ -52,83 +327,7 @@ export async function canonicalize(
     // GNU rejects the empty name outright, in every mode.
     return { ok: false, code: "ENOENT" };
   }
-
-  const absolute = input.startsWith("/") ? input : `${cwd}/${input}`;
-  // A trailing slash asserts the name is a directory.
-  const requireDirectory = input.endsWith("/");
-
-  if (options.noSymlinks) {
-    const path = normalizePath(absolute);
-    if (options.existence === "existing" && !(await fs.exists(path))) {
-      return { ok: false, code: "ENOENT" };
-    }
-    return { ok: true, path };
-  }
-
-  // In logical mode `..` is cancelled against the written path before any
-  // symlink is read, which normalizePath already does.
-  const queue = splitComponents(
-    options.logical ? normalizePath(absolute) : absolute,
-  );
-  let resolved = "";
-  let index = 0;
-  let symlinkHops = 0;
-
-  while (index < queue.length) {
-    const component = queue[index++];
-    budget.visit(index);
-
-    if (component === "..") {
-      resolved = parentOf(resolved);
-      continue;
-    }
-
-    const candidate = `${resolved}/${component}`;
-    const stat = await fs.lstat(candidate).catch(() => undefined);
-    const isLastComponent = index === queue.length;
-
-    if (!stat) {
-      if (
-        options.existence === "existing" ||
-        (options.existence === "default" && !isLastComponent)
-      ) {
-        return { ok: false, code: "ENOENT" };
-      }
-      resolved = candidate;
-      continue;
-    }
-
-    if (stat.isSymbolicLink) {
-      if (++symlinkHops > MAX_SYMLINK_DEPTH) {
-        // `-m` promises never to fail, so a loop leaves the link unexpanded
-        // instead of reporting ELOOP.
-        if (options.existence === "missing") {
-          resolved = candidate;
-          continue;
-        }
-        return { ok: false, code: "ELOOP" };
-      }
-      const target = await fs.readlink(candidate);
-      const targetComponents = splitComponents(target);
-      if (target.startsWith("/")) {
-        resolved = "";
-      }
-      // The link itself was never written to `resolved`, so a relative target
-      // resolves against the directory holding it, as it should.
-      queue.splice(index, 0, ...targetComponents);
-      continue;
-    }
-
-    resolved = candidate;
-
-    if (
-      !stat.isDirectory &&
-      options.existence !== "missing" &&
-      (!isLastComponent || requireDirectory)
-    ) {
-      return { ok: false, code: "ENOTDIR" };
-    }
-  }
-
-  return { ok: true, path: resolved === "" ? "/" : resolved };
+  return options.logical
+    ? canonicalizeLogical(fs, cwd, input, options, budget)
+    : walk(fs, cwd, input, options, budget);
 }

--- a/packages/just-bash/src/commands/realpath/canonicalize.ts
+++ b/packages/just-bash/src/commands/realpath/canonicalize.ts
@@ -1,0 +1,134 @@
+import type { IFileSystem } from "../../fs/interface.js";
+import { MAX_SYMLINK_DEPTH, normalizePath } from "../../fs/path-utils.js";
+import type { FileTraversalBudget } from "../../fs/traversal.js";
+
+/**
+ * How much of the path has to exist.
+ *
+ * - `default`: every component but the last (GNU's default)
+ * - `existing`: all of it (`-e`)
+ * - `missing`: none of it (`-m`)
+ */
+export type ExistencePolicy = "default" | "existing" | "missing";
+
+export interface CanonicalizeOptions {
+  existence: ExistencePolicy;
+  /** `-s` / `--no-symlinks`: expand nothing, resolve `.` and `..` textually. */
+  noSymlinks: boolean;
+  /** `-L` / `--logical`: resolve `..` before symlinks instead of after. */
+  logical: boolean;
+}
+
+export type CanonicalizeFailure = "ENOENT" | "ENOTDIR" | "ELOOP";
+
+export type CanonicalizeResult =
+  | { ok: true; path: string }
+  | { ok: false; code: CanonicalizeFailure };
+
+/** Path components with `.` and empty segments dropped; `..` is significant. */
+function splitComponents(path: string): string[] {
+  return path.split("/").filter((part) => part !== "" && part !== ".");
+}
+
+function parentOf(resolved: string): string {
+  return resolved.slice(0, resolved.lastIndexOf("/"));
+}
+
+/**
+ * Resolve `input` to an absolute path the way GNU `realpath` does.
+ *
+ * Components are walked one at a time rather than handed to `fs.realpath()`
+ * so that `-e`/`-m`, `-s` and `-L` can each apply their own existence and
+ * symlink policy, and so a failure can be reported with the errno GNU prints.
+ */
+export async function canonicalize(
+  fs: IFileSystem,
+  cwd: string,
+  input: string,
+  options: CanonicalizeOptions,
+  budget: FileTraversalBudget,
+): Promise<CanonicalizeResult> {
+  if (input === "") {
+    // GNU rejects the empty name outright, in every mode.
+    return { ok: false, code: "ENOENT" };
+  }
+
+  const absolute = input.startsWith("/") ? input : `${cwd}/${input}`;
+  // A trailing slash asserts the name is a directory.
+  const requireDirectory = input.endsWith("/");
+
+  if (options.noSymlinks) {
+    const path = normalizePath(absolute);
+    if (options.existence === "existing" && !(await fs.exists(path))) {
+      return { ok: false, code: "ENOENT" };
+    }
+    return { ok: true, path };
+  }
+
+  // In logical mode `..` is cancelled against the written path before any
+  // symlink is read, which normalizePath already does.
+  const queue = splitComponents(
+    options.logical ? normalizePath(absolute) : absolute,
+  );
+  let resolved = "";
+  let index = 0;
+  let symlinkHops = 0;
+
+  while (index < queue.length) {
+    const component = queue[index++];
+    budget.visit(index);
+
+    if (component === "..") {
+      resolved = parentOf(resolved);
+      continue;
+    }
+
+    const candidate = `${resolved}/${component}`;
+    const stat = await fs.lstat(candidate).catch(() => undefined);
+    const isLastComponent = index === queue.length;
+
+    if (!stat) {
+      if (
+        options.existence === "existing" ||
+        (options.existence === "default" && !isLastComponent)
+      ) {
+        return { ok: false, code: "ENOENT" };
+      }
+      resolved = candidate;
+      continue;
+    }
+
+    if (stat.isSymbolicLink) {
+      if (++symlinkHops > MAX_SYMLINK_DEPTH) {
+        // `-m` promises never to fail, so a loop leaves the link unexpanded
+        // instead of reporting ELOOP.
+        if (options.existence === "missing") {
+          resolved = candidate;
+          continue;
+        }
+        return { ok: false, code: "ELOOP" };
+      }
+      const target = await fs.readlink(candidate);
+      const targetComponents = splitComponents(target);
+      if (target.startsWith("/")) {
+        resolved = "";
+      }
+      // The link itself was never written to `resolved`, so a relative target
+      // resolves against the directory holding it, as it should.
+      queue.splice(index, 0, ...targetComponents);
+      continue;
+    }
+
+    resolved = candidate;
+
+    if (
+      !stat.isDirectory &&
+      options.existence !== "missing" &&
+      (!isLastComponent || requireDirectory)
+    ) {
+      return { ok: false, code: "ENOTDIR" };
+    }
+  }
+
+  return { ok: true, path: resolved === "" ? "/" : resolved };
+}

--- a/packages/just-bash/src/commands/realpath/realpath.basic.test.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.basic.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/** A tree with a file, a nested directory and no symlinks. */
+async function setup(): Promise<Bash> {
+  const env = new Bash({
+    files: {
+      "/work/sub/f.txt": "hi\n",
+      "/work/other/g.txt": "there\n",
+    },
+    cwd: "/work",
+  });
+  return env;
+}
+
+describe("realpath", () => {
+  describe("default mode", () => {
+    it("resolves a relative operand against the working directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("keeps an absolute operand absolute", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath /work/sub/f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("collapses . and .. and duplicate slashes", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath ./sub/..//other/./g.txt");
+      expect(result.stdout).toBe("/work/other/g.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves . to the working directory and / to itself", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath . /");
+      expect(result.stdout).toBe("/work\n/\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("strips a trailing slash from a directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/");
+      expect(result.stdout).toBe("/work/sub\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("stops .. at the root", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath /../../work/sub");
+      expect(result.stdout).toBe("/work/sub\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("accepts a missing last component", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/new.txt");
+      expect(result.stdout).toBe("/work/sub/new.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("accepts a missing last component with a trailing slash", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/newdir/");
+      expect(result.stdout).toBe("/work/sub/newdir\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a missing intermediate component", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath nosuch/f.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/f.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a path that descends through a regular file", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt/x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/x: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a regular file named with a trailing slash", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt/");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects the empty operand, quoting it like GNU", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath ''");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: '': No such file or directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("-e / --canonicalize-existing", () => {
+    it("prints an existing path", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -e sub/f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a missing last component", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath --canonicalize-existing new.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: new.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("-m / --canonicalize-missing", () => {
+    it("prints a fully missing path", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m nosuch/deep/x");
+      expect(result.stdout).toBe("/work/nosuch/deep/x\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("still cancels .. inside a missing path", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m nosuch/../x");
+      expect(result.stdout).toBe("/work/x\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("does not mind descending through a regular file", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m sub/f.txt/x");
+      expect(result.stdout).toBe("/work/sub/f.txt/x\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("takes the last of -e and -m", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -e -m x && realpath -m -e x");
+      expect(result.stdout).toBe("/work/x\n");
+      expect(result.stderr).toBe("realpath: x: No such file or directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("operands", () => {
+    it("requires at least one operand", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: missing operand\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("prints every resolvable operand and fails once", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt nosuch/y other/g.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n/work/other/g.txt\n");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/y: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("treats operands after -- literally", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m -- -e");
+      expect(result.stdout).toBe("/work/-e\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("treats a lone dash as an operand", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m -");
+      expect(result.stdout).toBe("/work/-\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/realpath/realpath.dot-components.test.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.dot-components.test.ts
@@ -1,0 +1,248 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * `.` and `..` are not free: GNU requires whatever precedes them to be a
+ * directory, so `file/.` fails exactly like `file/x` does. A trailing slash
+ * asserts the same thing, but tolerates a name that is not there at all.
+ */
+async function setup(): Promise<Bash> {
+  const env = new Bash({
+    files: { "/work/sub/f.txt": "hi\n", "/work/real/deep/g.txt": "there\n" },
+    cwd: "/work",
+  });
+  const created = await env.exec(
+    [
+      "ln -s sub/f.txt link",
+      "ln -s real slink",
+      // A target that names a regular file as a directory.
+      "ln -s 'sub/f.txt/' fileslash",
+      // A target that names a missing directory.
+      "ln -s 'nosuch/' missingslash",
+    ].join(" && "),
+  );
+  expect(created.exitCode).toBe(0);
+  return env;
+}
+
+describe("realpath . and .. components", () => {
+  describe("through a regular file", () => {
+    it("rejects file/.", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt/.");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/.: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects file/..", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/f.txt/..");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/..: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a symlink to a file named with a trailing slash", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath link/");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: link/: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("accepts file/. under -m", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m sub/f.txt/.");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("through a missing name", () => {
+    it("rejects nosuch/.", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath nosuch/.");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/.: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects nosuch/..", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath nosuch/..");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/..: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("still accepts a missing name with a trailing slash", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath nosuchdir/");
+      expect(result.stdout).toBe("/work/nosuchdir\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("through a directory", () => {
+    it("accepts dir/.", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -e sub/.");
+      expect(result.stdout).toBe("/work/sub\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("accepts dir/.. through a symlinked directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath slink/deep/..");
+      expect(result.stdout).toBe("/work/real\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("keeps . in the middle of a path harmless", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath sub/./f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("symlink targets ending in a slash", () => {
+    it("rejects a target that names a regular file as a directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath fileslash");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: fileslash: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("tolerates a target that names a missing directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath missingslash");
+      expect(result.stdout).toBe("/work/nosuch\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("ignores the requirement under -m", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m fileslash");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("-s keeps the directory requirement", () => {
+    it("rejects an unexpanded path through a regular file", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s sub/f.txt/x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/x: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a trailing slash on a regular file", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s -e sub/f.txt/");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("follows a symlink for the directory test only", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s link/..");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: link/..: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("accepts an unexpanded path through a symlinked directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s slink/deep");
+      expect(result.stdout).toBe("/work/slink/deep\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("checks no intermediate component for existence", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s nosuch/x/y");
+      expect(result.stdout).toBe("/work/nosuch/x/y\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("checks the finished name under -e", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s -e nosuch/x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/x: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("-L validates what it cancels", () => {
+    it("rejects a link to a regular file before ..", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L link/..");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: link/..: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a missing name before ..", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L nosuch/..");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: nosuch/..: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("cancels a missing name under -m", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L -m nosuch/..");
+      expect(result.stdout).toBe("/work\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a regular file before .", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L sub/f.txt/.");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: sub/f.txt/.: Not a directory\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("leaves .. at the root at the root", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L /..");
+      expect(result.stdout).toBe("/\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("cancels a symlinked directory and resolves the rest", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L slink/../sub/f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/realpath/realpath.filesystems.test.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.filesystems.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+import { MountableFs } from "../../fs/mountable-fs/mountable-fs.js";
+
+/** An InMemoryFs whose `lstat` is refused for one name. */
+class DeniedLstatFs extends InMemoryFs {
+  constructor(
+    files: Record<string, string>,
+    private readonly denied: string,
+  ) {
+    super(files);
+  }
+
+  override async lstat(path: string) {
+    if (path === this.denied) {
+      throw new Error(`EACCES: permission denied, lstat '${path}'`);
+    }
+    return super.lstat(path);
+  }
+}
+
+describe("realpath across filesystems", () => {
+  describe("MountableFs", () => {
+    /**
+     * A mounted filesystem stores its own absolute symlink targets relative to
+     * its root, so `/secret.txt` inside the mount is `/data/secret.txt` in the
+     * shell. Resolution has to stay inside the mount and agree with what
+     * reading the link actually opens.
+     */
+    async function mounted(): Promise<Bash> {
+      const mount = new InMemoryFs({ "/secret.txt": "mounted\n" });
+      await mount.symlink("/secret.txt", "/link");
+      await mount.symlink("/nowhere.txt", "/dangling");
+      const fs = new MountableFs({
+        base: new InMemoryFs({ "/secret.txt": "base\n" }),
+      });
+      fs.mount("/data", mount);
+      return new Bash({ fs, cwd: "/" });
+    }
+
+    it("keeps an absolute symlink target inside the mount", async () => {
+      const env = await mounted();
+      const result = await env.exec("realpath /data/link");
+      expect(result.stdout).toBe("/data/secret.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("names the file that reading the link opens", async () => {
+      const env = await mounted();
+      const result = await env.exec(
+        'cat /data/link && cat "$(realpath /data/link)"',
+      );
+      expect(result.stdout).toBe("mounted\nmounted\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves a name below the mounted symlink target", async () => {
+      const env = await mounted();
+      const result = await env.exec("realpath -m /data/link/deeper");
+      expect(result.stdout).toBe("/data/secret.txt/deeper\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a name below a mounted symlink to a regular file", async () => {
+      const env = await mounted();
+      const result = await env.exec("realpath /data/link/deeper");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: /data/link/deeper: Not a directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    /**
+     * A dangling absolute target cannot be resolved through the filesystem, and
+     * `IFileSystem` exposes no way to ask which mount a path belongs to, so the
+     * name falls back to the global root. Documented here so the behaviour is a
+     * decision rather than a surprise.
+     */
+    it("falls back to the global root for a dangling mounted symlink", async () => {
+      const env = await mounted();
+      const result = await env.exec("realpath /data/dangling");
+      expect(result.stdout).toBe("/nowhere.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("filesystem errors", () => {
+    it("reports a refused component instead of calling it missing", async () => {
+      const fs = new DeniedLstatFs({ "/work/f.txt": "hi\n" }, "/work/denied");
+      const env = new Bash({ fs, cwd: "/work" });
+      const result = await env.exec("realpath denied");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: denied: Permission denied\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("reports a refused component under -e too", async () => {
+      const fs = new DeniedLstatFs({ "/work/f.txt": "hi\n" }, "/work/denied");
+      const env = new Bash({ fs, cwd: "/work" });
+      const result = await env.exec("realpath -e denied/x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: denied/x: Permission denied\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("ignores a refused component under -m, which never fails", async () => {
+      const fs = new DeniedLstatFs({ "/work/f.txt": "hi\n" }, "/work/denied");
+      const env = new Bash({ fs, cwd: "/work" });
+      const result = await env.exec("realpath -m denied/x");
+      expect(result.stdout).toBe("/work/denied/x\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("limits", () => {
+    it("charges an oversized symlink target before expanding it", async () => {
+      const fs = new InMemoryFs({ "/work/f.txt": "hi\n" });
+      await fs.symlink(`${"a/".repeat(5000)}f.txt`, "/work/link");
+      const env = new Bash({
+        fs,
+        cwd: "/work",
+        executionLimits: { maxTraversalWork: 1000 },
+      });
+      const result = await env.exec("realpath link");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "bash: realpath: path resolution limit exceeded (1000)\n",
+      );
+      expect(result.exitCode).toBe(126);
+    });
+
+    it("bounds the diagnostics of many failing operands", async () => {
+      const env = new Bash({
+        files: { "/work/f.txt": "hi\n" },
+        cwd: "/work",
+        executionLimits: { maxOutputSize: 120 },
+      });
+      // Every empty operand fails without touching the filesystem, so only the
+      // output accounting can stop the diagnostics from growing.
+      const result = await env.exec("realpath '' '' '' '' '' '' '' '' '' ''");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "bash: realpath: output size limit exceeded (120 bytes)\n",
+      );
+      expect(result.exitCode).toBe(126);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/realpath/realpath.options.test.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.options.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+function setup(): Bash {
+  return new Bash({
+    files: {
+      "/work/sub/f.txt": "hi\n",
+      "/work/other/deep/g.txt": "there\n",
+    },
+    cwd: "/work",
+  });
+}
+
+describe("realpath options", () => {
+  describe("-q / --quiet", () => {
+    it("suppresses the diagnostic but keeps the exit status", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -q nosuch/x");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("still prints resolvable operands", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --quiet nosuch/x sub/f.txt");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("-z / --zero", () => {
+    it("terminates every name with NUL", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -z sub/f.txt other | wc -c");
+      // "/work/sub/f.txt\0" (16) + "/work/other\0" (12)
+      expect(result.stdout).toBe("28\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("combines with other short flags", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -zm nosuch");
+      expect(result.stdout).toBe("/work/nosuch\0");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("--relative-to", () => {
+    it("prints a name below the directory relative to it", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --relative-to=/work sub/f.txt");
+      expect(result.stdout).toBe("sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("accepts the value as a separate argument", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --relative-to /work sub/f.txt");
+      expect(result.stdout).toBe("sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("climbs out of the directory with ..", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-to=/work/sub other/deep/g.txt",
+      );
+      expect(result.stdout).toBe("../other/deep/g.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("prints . when the name is the directory itself", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-to=/work/sub /work/sub",
+      );
+      expect(result.stdout).toBe(".\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("applies to every operand", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-to=/work sub/f.txt other/deep/g.txt",
+      );
+      expect(result.stdout).toBe("sub/f.txt\nother/deep/g.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves the directory under the same existence policy", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-to=/work/nosuch/deep sub/f.txt",
+      );
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: /work/nosuch/deep: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("accepts a missing directory under -m", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath -m --relative-to=/work/nosuch/deep sub/f.txt",
+      );
+      expect(result.stdout).toBe("../../sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("reports a missing value", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --relative-to");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: option '--relative-to' requires an argument\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("--relative-base", () => {
+    it("prints a relative name below the base", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --relative-base=/work sub/f.txt");
+      expect(result.stdout).toBe("sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("prints an absolute name outside the base", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-base=/work/other sub/f.txt",
+      );
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("anchors output at --relative-to while the name stays under the base", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-base=/work --relative-to=/work/sub other/deep",
+      );
+      expect(result.stdout).toBe("../other/deep\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("drops both options when --relative-to is outside the base", async () => {
+      const env = setup();
+      const result = await env.exec(
+        "realpath --relative-base=/work/other --relative-to=/work/sub other/deep",
+      );
+      expect(result.stdout).toBe("/work/other/deep\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("makes every name relative when the base is the root", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --relative-base=/ sub/f.txt");
+      expect(result.stdout).toBe("work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("unknown options", () => {
+    it("rejects an unknown short option", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -x sub/f.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: invalid option -- 'x'\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects an unknown short option inside a bundle", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -ex sub/f.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: invalid option -- 'x'\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects an unknown long option", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --canonical sub/f.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: unrecognized option '--canonical'\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("rejects a value given to a flag", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --quiet=1 sub/f.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe("realpath: unrecognized option '--quiet'\n");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("--help", () => {
+    it("describes the command", async () => {
+      const env = setup();
+      const result = await env.exec("realpath --help");
+      expect(result.stdout).toContain(
+        "realpath - print the resolved absolute file name",
+      );
+      expect(result.stdout).toContain("Usage: realpath [OPTION]... FILE...");
+      expect(result.stdout).toContain("--relative-base=DIR");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("wins over other options", async () => {
+      const env = setup();
+      const result = await env.exec("realpath -e nosuch --help");
+      expect(result.stdout).toContain("Usage: realpath [OPTION]... FILE...");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("integration", () => {
+    it("is reported by which", async () => {
+      const env = setup();
+      const result = await env.exec("which realpath");
+      expect(result.stdout).toBe("/usr/bin/realpath\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("feeds a command substitution", async () => {
+      const env = setup();
+      const result = await env.exec('cd sub && cat "$(realpath f.txt)"');
+      expect(result.stdout).toBe("hi\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/realpath/realpath.symlinks.test.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.symlinks.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * /work/sub/f.txt      regular file
+ * /work/real/deep/     regular directory
+ * /work/link       ->  sub/f.txt      (relative)
+ * /work/abs        ->  /work/sub/f.txt
+ * /work/slink      ->  real           (directory link)
+ * /work/deeplink   ->  /work/real/deep
+ * /work/dangling   ->  nowhere
+ * /work/hop        ->  link           (link to a link)
+ */
+async function setup(): Promise<Bash> {
+  const env = new Bash({
+    files: { "/work/sub/f.txt": "hi\n", "/work/real/deep/g.txt": "there\n" },
+    cwd: "/work",
+  });
+  const setupResult = await env.exec(
+    [
+      "ln -s sub/f.txt link",
+      "ln -s /work/sub/f.txt abs",
+      "ln -s real slink",
+      "ln -s /work/real/deep deeplink",
+      "ln -s nowhere dangling",
+      "ln -s link hop",
+    ].join(" && "),
+  );
+  expect(setupResult.exitCode).toBe(0);
+  return env;
+}
+
+describe("realpath symlinks", () => {
+  describe("resolution", () => {
+    it("follows a relative symlink", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath link");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("follows an absolute symlink", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath abs");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("follows a chain of symlinks", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath hop");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("follows a symlinked directory in the middle of a path", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath slink/deep/g.txt");
+      expect(result.stdout).toBe("/work/real/deep/g.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves a missing name under a symlinked directory", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath slink/deep/new.txt");
+      expect(result.stdout).toBe("/work/real/deep/new.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("names the target of a dangling symlink by default", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath dangling");
+      expect(result.stdout).toBe("/work/nowhere\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a dangling symlink under -e", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -e dangling");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: dangling: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("names the target of a dangling symlink under -m", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -m dangling");
+      expect(result.stdout).toBe("/work/nowhere\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("-s / --no-symlinks", () => {
+    it("leaves a symlink unexpanded", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s link");
+      expect(result.stdout).toBe("/work/link\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("leaves a symlinked directory component unexpanded", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath --no-symlinks slink/deep");
+      expect(result.stdout).toBe("/work/slink/deep\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("still resolves . and .. textually", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath --strip ./sub/../slink/deep");
+      expect(result.stdout).toBe("/work/slink/deep\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("checks nothing for existence without -e", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s nosuch/deep/x");
+      expect(result.stdout).toBe("/work/nosuch/deep/x\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("checks the final name with -e, following the symlink", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -s -e link");
+      expect(result.stdout).toBe("/work/link\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("rejects a dangling symlink with -s -e", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -se dangling");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: dangling: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("-L / -P", () => {
+    it("resolves .. after the symlink by default", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath deeplink/..");
+      expect(result.stdout).toBe("/work/real\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves .. before the symlink with -L", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L deeplink/..");
+      expect(result.stdout).toBe("/work\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("takes the last of -L and -P", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L -P deeplink/..");
+      expect(result.stdout).toBe("/work/real\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves the remainder of a logical path normally", async () => {
+      const env = await setup();
+      const result = await env.exec("realpath -L deeplink/../real/deep/g.txt");
+      expect(result.stdout).toBe("/work/real/deep/g.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("reports a component that the logical path removed the link from", async () => {
+      const env = await setup();
+      // `deeplink/..` is /work logically, and /work has no `deep`.
+      const result = await env.exec("realpath -L deeplink/../deep/g.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: deeplink/../deep/g.txt: No such file or directory\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+  });
+
+  describe("loops", () => {
+    it("reports a symlink loop", async () => {
+      const env = await setup();
+      await env.exec("ln -s loopb loopa && ln -s loopa loopb");
+      const result = await env.exec("realpath loopa");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: loopa: Too many levels of symbolic links\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("reports a symlink pointing at itself", async () => {
+      const env = await setup();
+      await env.exec("ln -s self self");
+      const result = await env.exec("realpath self");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "realpath: self: Too many levels of symbolic links\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("leaves a looping link unexpanded under -m", async () => {
+      const env = await setup();
+      await env.exec("ln -s loopb loopa && ln -s loopa loopb");
+      const result = await env.exec("realpath -m loopa");
+      expect(result.stdout).toBe("/work/loopa\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("resolves a long but finite chain", async () => {
+      const env = await setup();
+      const chain = await env.exec(
+        'p=sub/f.txt; for i in $(seq 1 30); do ln -s "$p" "c$i"; p="c$i"; done',
+      );
+      expect(chain.exitCode).toBe(0);
+      const result = await env.exec("realpath c30");
+      expect(result.stdout).toBe("/work/sub/f.txt\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/realpath/realpath.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.ts
@@ -1,0 +1,315 @@
+import { BoundedStringBuilder } from "../../bounded-builder.js";
+import { FileTraversalBudget } from "../../fs/traversal.js";
+import type {
+  ExecResult,
+  RuntimeCommand,
+  RuntimeCommandContext,
+} from "../../types.js";
+import { showHelp, unknownOption } from "../help.js";
+import { nullPrototype } from "../query-engine/safe-object.js";
+import {
+  type CanonicalizeFailure,
+  type CanonicalizeOptions,
+  canonicalize,
+} from "./canonicalize.js";
+import { isUnder, relativeTo } from "./relative.js";
+
+const realpathHelp = {
+  name: "realpath",
+  summary: "print the resolved absolute file name",
+  usage: "realpath [OPTION]... FILE...",
+  options: [
+    "-e, --canonicalize-existing  all components of the path must exist",
+    "-m, --canonicalize-missing   no component of the path need exist",
+    "-L, --logical                resolve '..' components before symlinks",
+    "-P, --physical               resolve symlinks as encountered (default)",
+    "-q, --quiet                  suppress messages for missing files",
+    "-s, --strip, --no-symlinks   don't expand symlinks",
+    "-z, --zero                   end each output line with NUL, not newline",
+    "    --relative-to=DIR        print the resolved path relative to DIR",
+    "    --relative-base=DIR      print absolute paths unless below DIR",
+    "    --help                   display this help and exit",
+  ],
+  notes: ["Without -e or -m every component but the last has to exist."],
+};
+
+const FAILURE_MESSAGES = nullPrototype<Record<CanonicalizeFailure, string>>({
+  ENOENT: "No such file or directory",
+  ENOTDIR: "Not a directory",
+  ELOOP: "Too many levels of symbolic links",
+});
+
+interface ParsedArgs {
+  options: CanonicalizeOptions;
+  quiet: boolean;
+  zero: boolean;
+  relativeTo?: string;
+  relativeBase?: string;
+  operands: string[];
+}
+
+type ParseResult =
+  | { ok: true; parsed: ParsedArgs }
+  | { ok: false; result: ExecResult };
+
+function optionRequiresArgument(option: string): ExecResult {
+  return {
+    stdout: "",
+    stderr: `realpath: option '${option}' requires an argument\n`,
+    exitCode: 1,
+  };
+}
+
+function parseArgs(args: string[]): ParseResult {
+  const parsed: ParsedArgs = {
+    options: { existence: "default", noSymlinks: false, logical: false },
+    quiet: false,
+    zero: false,
+    operands: [],
+  };
+
+  const applyShortFlag = (
+    flag: string,
+    raw: string,
+  ): ExecResult | undefined => {
+    switch (flag) {
+      case "e":
+        parsed.options.existence = "existing";
+        return undefined;
+      case "m":
+        parsed.options.existence = "missing";
+        return undefined;
+      case "s":
+        parsed.options.noSymlinks = true;
+        return undefined;
+      case "L":
+        parsed.options.logical = true;
+        return undefined;
+      case "P":
+        parsed.options.logical = false;
+        return undefined;
+      case "q":
+        parsed.quiet = true;
+        return undefined;
+      case "z":
+        parsed.zero = true;
+        return undefined;
+      default:
+        return unknownOption("realpath", raw);
+    }
+  };
+
+  let optionsEnded = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+
+    if (optionsEnded || arg === "-" || !arg.startsWith("-")) {
+      parsed.operands.push(arg);
+      continue;
+    }
+
+    if (arg === "--") {
+      optionsEnded = true;
+      continue;
+    }
+
+    if (arg === "--help") {
+      return { ok: false, result: showHelp(realpathHelp) };
+    }
+
+    if (arg.startsWith("--")) {
+      const separator = arg.indexOf("=");
+      const name = separator === -1 ? arg : arg.slice(0, separator);
+      const inlineValue =
+        separator === -1 ? undefined : arg.slice(separator + 1);
+
+      if (name === "--relative-to" || name === "--relative-base") {
+        const value = inlineValue ?? args[++i];
+        if (value === undefined) {
+          return { ok: false, result: optionRequiresArgument(name) };
+        }
+        if (name === "--relative-to") {
+          parsed.relativeTo = value;
+        } else {
+          parsed.relativeBase = value;
+        }
+        continue;
+      }
+
+      if (inlineValue !== undefined) {
+        return { ok: false, result: unknownOption("realpath", name) };
+      }
+
+      switch (name) {
+        case "--canonicalize-existing":
+          parsed.options.existence = "existing";
+          continue;
+        case "--canonicalize-missing":
+          parsed.options.existence = "missing";
+          continue;
+        case "--strip":
+        case "--no-symlinks":
+          parsed.options.noSymlinks = true;
+          continue;
+        case "--logical":
+          parsed.options.logical = true;
+          continue;
+        case "--physical":
+          parsed.options.logical = false;
+          continue;
+        case "--quiet":
+          parsed.quiet = true;
+          continue;
+        case "--zero":
+          parsed.zero = true;
+          continue;
+        default:
+          return { ok: false, result: unknownOption("realpath", name) };
+      }
+    }
+
+    for (const flag of arg.slice(1)) {
+      const failure = applyShortFlag(flag, `-${flag}`);
+      if (failure) return { ok: false, result: failure };
+    }
+  }
+
+  return { ok: true, parsed };
+}
+
+export const realpathCommand: RuntimeCommand = {
+  name: "realpath",
+
+  async execute(
+    args: string[],
+    ctx: RuntimeCommandContext,
+  ): Promise<ExecResult> {
+    const parseResult = parseArgs(args);
+    if (!parseResult.ok) return parseResult.result;
+    const { options, quiet, zero, operands } = parseResult.parsed;
+
+    if (operands.length === 0) {
+      return {
+        stdout: "",
+        stderr: "realpath: missing operand\n",
+        exitCode: 1,
+      };
+    }
+
+    const budget = new FileTraversalBudget({
+      limits: ctx.limits,
+      signal: ctx.signal,
+      executionScope: ctx.executionScope,
+      site: "realpath",
+      label: "path resolution",
+    });
+
+    const fail = (operand: string, code: CanonicalizeFailure): string => {
+      if (quiet) return "";
+      // GNU quotes a name only when it would otherwise be unreadable, which
+      // for realpath operands means the empty name.
+      const name = operand === "" ? "''" : operand;
+      return `realpath: ${name}: ${FAILURE_MESSAGES[code]}\n`;
+    };
+
+    // GNU canonicalizes both directory options up front and gives up on the
+    // whole invocation when one of them cannot be resolved.
+    const resolveDirectoryOption = async (
+      operand: string | undefined,
+    ): Promise<
+      { ok: true; path?: string } | { ok: false; result: ExecResult }
+    > => {
+      if (operand === undefined) return { ok: true };
+      const resolved = await canonicalize(
+        ctx.fs,
+        ctx.cwd,
+        operand,
+        options,
+        budget,
+      );
+      if (resolved.ok) return { ok: true, path: resolved.path };
+      return {
+        ok: false,
+        result: {
+          stdout: "",
+          stderr: fail(operand, resolved.code),
+          exitCode: 1,
+        },
+      };
+    };
+
+    const resolvedBase = await resolveDirectoryOption(
+      parseResult.parsed.relativeBase,
+    );
+    if (!resolvedBase.ok) return resolvedBase.result;
+    const resolvedAnchor = await resolveDirectoryOption(
+      parseResult.parsed.relativeTo,
+    );
+    if (!resolvedAnchor.ok) return resolvedAnchor.result;
+
+    let base = resolvedBase.path;
+    let anchor = resolvedAnchor.path;
+
+    // --relative-to only applies while it is itself below --relative-base;
+    // otherwise both are dropped and names print absolute.
+    if (base !== undefined && anchor !== undefined && !isUnder(base, anchor)) {
+      base = undefined;
+      anchor = undefined;
+    } else if (base !== undefined && anchor === undefined) {
+      anchor = base;
+    }
+
+    const output = new BoundedStringBuilder(
+      Math.min(ctx.limits.maxStringLength, ctx.limits.maxOutputSize),
+      "realpath",
+    );
+    let stderr = "";
+    let failed = false;
+
+    for (const operand of operands) {
+      const resolved = await canonicalize(
+        ctx.fs,
+        ctx.cwd,
+        operand,
+        options,
+        budget,
+      );
+      if (!resolved.ok) {
+        failed = true;
+        stderr += fail(operand, resolved.code);
+        continue;
+      }
+      const printable =
+        anchor !== undefined &&
+        (base === undefined || isUnder(base, resolved.path))
+          ? relativeTo(anchor, resolved.path)
+          : resolved.path;
+      output.append(printable).append(zero ? "\0" : "\n");
+    }
+
+    return {
+      stdout: output.build(),
+      stderr,
+      exitCode: failed ? 1 : 0,
+    };
+  },
+};
+
+import type { CommandFuzzInfo } from "../fuzz-flags-types.js";
+
+export const flagsForFuzzing: CommandFuzzInfo = {
+  name: "realpath",
+  flags: [
+    { flag: "-e", type: "boolean" },
+    { flag: "-m", type: "boolean" },
+    { flag: "-s", type: "boolean" },
+    { flag: "-L", type: "boolean" },
+    { flag: "-P", type: "boolean" },
+    { flag: "-q", type: "boolean" },
+    { flag: "-z", type: "boolean" },
+    { flag: "--relative-to", type: "value", valueHint: "path" },
+    { flag: "--relative-base", type: "value", valueHint: "path" },
+  ],
+  needsArgs: true,
+};

--- a/packages/just-bash/src/commands/realpath/realpath.ts
+++ b/packages/just-bash/src/commands/realpath/realpath.ts
@@ -37,6 +37,7 @@ const FAILURE_MESSAGES = nullPrototype<Record<CanonicalizeFailure, string>>({
   ENOENT: "No such file or directory",
   ENOTDIR: "Not a directory",
   ELOOP: "Too many levels of symbolic links",
+  EACCES: "Permission denied",
 });
 
 interface ParsedArgs {
@@ -197,6 +198,11 @@ export const realpathCommand: RuntimeCommand = {
       };
     }
 
+    const outputLimit = Math.min(
+      ctx.limits.maxStringLength,
+      ctx.limits.maxOutputSize,
+    );
+
     const budget = new FileTraversalBudget({
       limits: ctx.limits,
       signal: ctx.signal,
@@ -260,11 +266,10 @@ export const realpathCommand: RuntimeCommand = {
       anchor = base;
     }
 
-    const output = new BoundedStringBuilder(
-      Math.min(ctx.limits.maxStringLength, ctx.limits.maxOutputSize),
-      "realpath",
-    );
-    let stderr = "";
+    const output = new BoundedStringBuilder(outputLimit, "realpath");
+    // Diagnostics are charged too: an operand can fail without touching the
+    // filesystem (the empty name), so nothing else bounds this.
+    const diagnostics = new BoundedStringBuilder(outputLimit, "realpath");
     let failed = false;
 
     for (const operand of operands) {
@@ -277,7 +282,7 @@ export const realpathCommand: RuntimeCommand = {
       );
       if (!resolved.ok) {
         failed = true;
-        stderr += fail(operand, resolved.code);
+        diagnostics.append(fail(operand, resolved.code));
         continue;
       }
       const printable =
@@ -290,7 +295,7 @@ export const realpathCommand: RuntimeCommand = {
 
     return {
       stdout: output.build(),
-      stderr,
+      stderr: diagnostics.build(),
       exitCode: failed ? 1 : 0,
     };
   },

--- a/packages/just-bash/src/commands/realpath/relative.ts
+++ b/packages/just-bash/src/commands/realpath/relative.ts
@@ -1,0 +1,29 @@
+/** True when `path` is `base` itself or below it. */
+export function isUnder(base: string, path: string): boolean {
+  return base === "/" || path === base || path.startsWith(`${base}/`);
+}
+
+/**
+ * Express canonical `path` relative to canonical `base`, as GNU
+ * `realpath --relative-to` does: `.` when they are the same, and `..` hops
+ * when `path` is outside `base`.
+ */
+export function relativeTo(base: string, path: string): string {
+  if (path === base) return ".";
+
+  const baseParts = base.split("/").filter(Boolean);
+  const pathParts = path.split("/").filter(Boolean);
+
+  let shared = 0;
+  while (
+    shared < baseParts.length &&
+    shared < pathParts.length &&
+    baseParts[shared] === pathParts[shared]
+  ) {
+    shared++;
+  }
+
+  const hops = baseParts.slice(shared).fill("..");
+  const parts = [...hops, ...pathParts.slice(shared)];
+  return parts.length === 0 ? "." : parts.join("/");
+}

--- a/packages/just-bash/src/commands/registry.ts
+++ b/packages/just-bash/src/commands/registry.ts
@@ -31,6 +31,7 @@ export type CommandName =
   | "chmod"
   | "pwd"
   | "readlink"
+  | "realpath"
   | "head"
   | "tail"
   | "wc"
@@ -179,6 +180,10 @@ const commandLoaders: LazyCommandDef<CommandName>[] = [
   {
     name: "readlink",
     load: async () => (await import("./readlink/readlink.js")).readlinkCommand,
+  },
+  {
+    name: "realpath",
+    load: async () => (await import("./realpath/realpath.js")).realpathCommand,
   },
 
   // File viewing

--- a/packages/just-bash/src/comparison-tests/fixtures/realpath-path-semantics.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/realpath-path-semantics.comparison.fixtures.json
@@ -1,0 +1,233 @@
+{
+  "0e06a45d71ca833d": {
+    "command": "realpath -L nosuch/.. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: nosuch/..: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "29354e67cd4a9ca3": {
+    "command": "realpath -m --relative-to=. sub/f.txt/.",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "3bd019c317305215": {
+    "command": "realpath nosuch/. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: nosuch/.: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "55ed3cb17bb7c150": {
+    "command": "ln -s sub/f.txt link && realpath link/ 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: link/: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "86f76a5279f1744e": {
+    "command": "realpath -s sub/f.txt/x 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/f.txt/x: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "8e30bb174031f583": {
+    "command": "ln -s 'nosuch/' missingslash && realpath --relative-to=. missingslash",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "nosuch\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "929b20a93617410d": {
+    "command": "ln -s sub/f.txt link && realpath -s link/.. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: link/..: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "99390dcc70f63396": {
+    "command": "realpath -s --relative-to=. nosuch/x/y",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "nosuch/x/y\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "a871ba4e66c3f225": {
+    "command": "realpath -L -m --relative-to=. nosuch/..",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": ".\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "aa6e506363652f79": {
+    "command": "ln -s other/deep d && realpath -s --relative-to=. d/g.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "d/g.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b5bef6e9c63a2fab": {
+    "command": "ln -s other/deep d && realpath -L --relative-to=. d/../sub/f.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b7bb2c1255e252fc": {
+    "command": "realpath -L /..",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "/\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "beb7d5429f9c85f4": {
+    "command": "realpath -L --relative-to=. sub/./f.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c162795d59925a17": {
+    "command": "realpath sub/f.txt/.. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/f.txt/..: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d324ab0ef3fbd008": {
+    "command": "realpath sub/f.txt/. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/f.txt/.: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d7bbea594e7b23d8": {
+    "command": "realpath -s sub/f.txt/ 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/f.txt/: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e3ba8e4864b5c07c": {
+    "command": "realpath --relative-to=. nosuchdir/",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "nosuchdir\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e643114b6c0f4a36": {
+    "command": "ln -s sub/f.txt link && realpath -L link/.. 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: link/..: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f4e121c35395bf23": {
+    "command": "realpath -e --relative-to=. sub/.",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ff4f4b731f4675a3": {
+    "command": "ln -s 'sub/f.txt/' fileslash && realpath fileslash 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: fileslash: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ffa42c6887c513d6": {
+    "command": "realpath -s -e nosuch/x 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: nosuch/x: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/fixtures/realpath.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/realpath.comparison.fixtures.json
@@ -1,0 +1,288 @@
+{
+  "072a58f73b962c54": {
+    "command": "realpath -m --relative-to=. nosuch/../x",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "x\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "1d3a951b53d671d2": {
+    "command": "realpath --relative-base=other sub/f.txt | grep -c '^/'",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "26675749c68cbe0c": {
+    "command": "realpath --relative-base=. other/deep/g.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "other/deep/g.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "26d0415d3bcf6cd9": {
+    "command": "ln -s nowhere dangling && realpath -e dangling 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: dangling: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "2839d4954103cd5c": {
+    "command": "ln -s other/deep d && realpath --relative-to=. d/..",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "other\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "36a6eb986ed47253": {
+    "command": "ln -s sub/f.txt link && realpath -s --relative-to=. link",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "link\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "3cecd582f8a02824": {
+    "command": "realpath nosuch/f.txt 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: nosuch/f.txt: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "430e58051674f2f8": {
+    "command": "realpath --relative-to=. ./sub/..//other/./deep/g.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "other/deep/g.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "52430bebecd1188a": {
+    "command": "ln -s loopb loopa && ln -s loopa loopb && realpath loopa 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: loopa: Too many levels of symbolic links\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "52621034b99858ae": {
+    "command": "realpath sub/f.txt/x 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/f.txt/x: Not a directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "5ba422da0ec084c0": {
+    "command": "realpath --relative-to=. sub/f.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "68a638804888c66b": {
+    "command": "realpath -q nosuch/x 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "rc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "964086536581f701": {
+    "command": "realpath --relative-to=sub sub",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": ".\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "968176c64a58b459": {
+    "command": "realpath --relative-to=. other/deep/",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "other/deep\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "98d9356c7b5e1acc": {
+    "command": "ln -s nowhere dangling && realpath --relative-to=. dangling",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "nowhere\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "9979adfba14dc109": {
+    "command": "ln -s other/deep d && realpath -L --relative-to=. d/..",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": ".\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "9a5a6f915ea3c56f": {
+    "command": "realpath -e --relative-to=. sub/f.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "a3fb762c08120f3c": {
+    "command": "realpath -e sub/new.txt 2>&1; echo rc=$?",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "realpath: sub/new.txt: No such file or directory\nrc=1\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "b4a64f47b31cab37": {
+    "command": "realpath --relative-to=. sub/new.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/new.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "c6dafcc7cce88e76": {
+    "command": "realpath -z --relative-to=. sub/f.txt other | wc -c",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "16\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "ca4a14636da79ad4": {
+    "command": "realpath --relative-to=sub other/deep/g.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "../other/deep/g.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "d86a083ef962234f": {
+    "command": "realpath --relative-to sub sub/f.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e3454a8d292bcd39": {
+    "command": "ln -s sub/f.txt link && realpath --relative-to=. link",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "e6c800d217d62971": {
+    "command": "ln -s other/deep d && realpath --relative-to=. d/g.txt",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "other/deep/g.txt\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f22bd4654978d18f": {
+    "command": "realpath -m --relative-to=. nosuch/deep/x",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "nosuch/deep/x\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  },
+  "f3bacef073ef5aa5": {
+    "command": "realpath --relative-to=. sub/f.txt other/deep",
+    "files": {
+      "sub/f.txt": "hi\n",
+      "other/deep/g.txt": "there\n"
+    },
+    "stdout": "sub/f.txt\nother/deep\n",
+    "stderr": "",
+    "exitCode": 0,
+    "locked": true
+  }
+}

--- a/packages/just-bash/src/comparison-tests/realpath-path-semantics.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/realpath-path-semantics.comparison.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * The parts of GNU `realpath` that are easy to get wrong: `.` and `..` require
+ * a directory in front of them, a trailing slash requires one too but tolerates
+ * a name that is absent, `-s` still refuses to descend through a non-directory,
+ * and `-L` validates whatever it cancels.
+ *
+ * Fixtures were recorded against GNU coreutils (BSD `realpath` only understands
+ * `-q`) and are locked so a macOS re-record cannot replace them.
+ */
+describe("realpath path semantics - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const files = {
+    "sub/f.txt": "hi\n",
+    "other/deep/g.txt": "there\n",
+  };
+
+  describe(". and .. components", () => {
+    it("rejects file/.", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath sub/f.txt/. 2>&1; echo rc=$?",
+      );
+    });
+
+    it("rejects file/..", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath sub/f.txt/.. 2>&1; echo rc=$?",
+      );
+    });
+
+    it("rejects a missing name before .", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath nosuch/. 2>&1; echo rc=$?");
+    });
+
+    it("accepts file/. under -m", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -m --relative-to=. sub/f.txt/.",
+      );
+    });
+
+    it("accepts dir/. under -e", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath -e --relative-to=. sub/.");
+    });
+
+    it("tolerates a trailing slash on a missing name", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath --relative-to=. nosuchdir/");
+    });
+  });
+
+  describe("symlinks named as directories", () => {
+    it("rejects a trailing slash on a link to a file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s sub/f.txt link && realpath link/ 2>&1; echo rc=$?",
+      );
+    });
+
+    it("rejects a target that names a regular file as a directory", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s 'sub/f.txt/' fileslash && realpath fileslash 2>&1; echo rc=$?",
+      );
+    });
+
+    it("tolerates a target that names a missing directory", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s 'nosuch/' missingslash && realpath --relative-to=. missingslash",
+      );
+    });
+  });
+
+  describe("-s keeps the directory requirement", () => {
+    it("refuses to descend through a regular file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -s sub/f.txt/x 2>&1; echo rc=$?",
+      );
+    });
+
+    it("refuses a trailing slash on a regular file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -s sub/f.txt/ 2>&1; echo rc=$?",
+      );
+    });
+
+    it("follows a link only for the directory test", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s sub/f.txt link && realpath -s link/.. 2>&1; echo rc=$?",
+      );
+    });
+
+    it("descends through a link to a directory", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s other/deep d && realpath -s --relative-to=. d/g.txt",
+      );
+    });
+
+    it("checks no intermediate component for existence", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -s --relative-to=. nosuch/x/y",
+      );
+    });
+
+    it("checks the finished name under -e", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -s -e nosuch/x 2>&1; echo rc=$?",
+      );
+    });
+  });
+
+  describe("-L validates what it cancels", () => {
+    it("rejects a link to a regular file before ..", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s sub/f.txt link && realpath -L link/.. 2>&1; echo rc=$?",
+      );
+    });
+
+    it("rejects a missing name before ..", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -L nosuch/.. 2>&1; echo rc=$?",
+      );
+    });
+
+    it("cancels a missing name under -m", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -L -m --relative-to=. nosuch/..",
+      );
+    });
+
+    it("keeps . harmless in the middle of a path", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -L --relative-to=. sub/./f.txt",
+      );
+    });
+
+    it("leaves .. at the root at the root", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath -L /..");
+    });
+
+    it("cancels a link to a directory and resolves the rest", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s other/deep d && realpath -L --relative-to=. d/../sub/f.txt",
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/comparison-tests/realpath.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/realpath.comparison.test.ts
@@ -1,0 +1,266 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Fixtures were recorded against GNU coreutils `realpath` (BSD `realpath` only
+ * understands `-q`) and are locked so a macOS re-record cannot replace them.
+ *
+ * Every case prints names relative to the test directory, because the absolute
+ * answer necessarily differs between the real temporary directory and the
+ * virtual filesystem.
+ */
+describe("realpath command - Real Bash Comparison", () => {
+  let testDir: string;
+
+  beforeEach(async () => {
+    testDir = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDir);
+  });
+
+  const files = {
+    "sub/f.txt": "hi\n",
+    "other/deep/g.txt": "there\n",
+  };
+
+  describe("canonicalization", () => {
+    it("resolves a relative name", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath --relative-to=. sub/f.txt");
+    });
+
+    it("collapses . and .. and duplicate slashes", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to=. ./sub/..//other/./deep/g.txt",
+      );
+    });
+
+    it("strips a trailing slash from a directory", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to=. other/deep/",
+      );
+    });
+
+    it("accepts a missing last component", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to=. sub/new.txt",
+      );
+    });
+
+    it("reports a missing intermediate component", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath nosuch/f.txt 2>&1; echo rc=$?",
+      );
+    });
+
+    it("reports a path descending through a regular file", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath sub/f.txt/x 2>&1; echo rc=$?",
+      );
+    });
+
+    it("resolves several operands at once", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to=. sub/f.txt other/deep",
+      );
+    });
+  });
+
+  describe("existence policies", () => {
+    it("-e rejects a missing name", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -e sub/new.txt 2>&1; echo rc=$?",
+      );
+    });
+
+    it("-e accepts an existing name", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -e --relative-to=. sub/f.txt",
+      );
+    });
+
+    it("-m accepts a fully missing path", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -m --relative-to=. nosuch/deep/x",
+      );
+    });
+
+    it("-m cancels .. inside a missing path", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -m --relative-to=. nosuch/../x",
+      );
+    });
+
+    it("-q suppresses the diagnostic", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -q nosuch/x 2>&1; echo rc=$?",
+      );
+    });
+  });
+
+  describe("symlinks", () => {
+    it("follows a relative symlink", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s sub/f.txt link && realpath --relative-to=. link",
+      );
+    });
+
+    it("follows a symlinked directory component", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s other/deep d && realpath --relative-to=. d/g.txt",
+      );
+    });
+
+    it("names the target of a dangling symlink", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s nowhere dangling && realpath --relative-to=. dangling",
+      );
+    });
+
+    it("rejects a dangling symlink under -e", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s nowhere dangling && realpath -e dangling 2>&1; echo rc=$?",
+      );
+    });
+
+    it("-s leaves a symlink unexpanded", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s sub/f.txt link && realpath -s --relative-to=. link",
+      );
+    });
+
+    it("-L resolves .. before the symlink", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s other/deep d && realpath -L --relative-to=. d/..",
+      );
+    });
+
+    it("resolves .. after the symlink by default", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s other/deep d && realpath --relative-to=. d/..",
+      );
+    });
+
+    it("reports a symlink loop", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "ln -s loopb loopa && ln -s loopa loopb && realpath loopa 2>&1; echo rc=$?",
+      );
+    });
+  });
+
+  describe("relative output", () => {
+    it("climbs out of the anchor directory", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to=sub other/deep/g.txt",
+      );
+    });
+
+    it("prints . for the anchor itself", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(env, testDir, "realpath --relative-to=sub sub");
+    });
+
+    it("takes the anchor as a separate argument", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-to sub sub/f.txt",
+      );
+    });
+
+    it("keeps names outside --relative-base absolute", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-base=other sub/f.txt | grep -c '^/'",
+      );
+    });
+
+    it("makes names under --relative-base relative", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath --relative-base=. other/deep/g.txt",
+      );
+    });
+
+    it("-z terminates each name with NUL", async () => {
+      const env = await setupFiles(testDir, files);
+      await compareOutputs(
+        env,
+        testDir,
+        "realpath -z --relative-to=. sub/f.txt other | wc -c",
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes the `realpath` half of #408. The `yes` half is #409.

Canonicalizing a name had no clean substitute: `realpath` exited 127, and the usual fallback `cd "$(dirname "$x")" && pwd` moves the shell.

## Behaviour

Resolution walks the path one component at a time against the virtual filesystem instead of delegating to `fs.realpath()`, because each mode needs its own existence and symlink policy and a failure has to carry the errno GNU prints.

| mode | policy |
| --- | --- |
| default | every component but the last must exist |
| `-e` / `--canonicalize-existing` | all of it must exist, including through the final symlink |
| `-m` / `--canonicalize-missing` | none of it need exist, and nothing fails: a symlink loop leaves the link unexpanded rather than reporting ELOOP, matching GNU |
| `-s` / `--strip` / `--no-symlinks` | purely textual; existence checked only under `-e`, and then by following the link |
| `-L` / `-P` | `..` cancelled before or after symlink expansion |

Also `-q`, `-z`, `--relative-to=DIR` and `--relative-base=DIR` (value inline or as the next argument), including GNU's rule that an anchor outside the base drops both options and prints absolute names, and `.` for a name that is the anchor itself. `-e`/`-m` and `-L`/`-P` are last-one-wins, short flags bundle (`-se`, `-zm`), `--` ends options, a lone `-` is an operand.

Diagnostics match GNU: `No such file or directory`, `Not a directory` for a path descending through a regular file (including a regular file named with a trailing slash), `Too many levels of symbolic links`, `realpath: '': No such file or directory` for the empty name, `realpath: missing operand`, and `realpath: option '--relative-to' requires an argument`. Unknown options use the repository's `unknownOption` wording.

## Bounds

Symlink expansion is capped at the existing `MAX_SYMLINK_DEPTH` and every component visit is metered through `FileTraversalBudget`, so a link farm cannot spin. Output goes through `BoundedStringBuilder` against `min(maxStringLength, maxOutputSize)`.

## Tests

- `realpath.basic.test.ts`, `realpath.symlinks.test.ts`, `realpath.options.test.ts` — 70 unit tests.
- `realpath.comparison.test.ts` + fixtures — 26 cases against real GNU `realpath`, all passing on the first recording. Cases print names relative to the test directory, since the absolute answer necessarily differs between the real temporary directory and the VFS. Recorded with GNU coreutils on `PATH` (BSD `realpath` only understands `-q`) and locked so a macOS re-record cannot replace them.

## Validation

`pnpm typecheck`, `pnpm lint:fix`, `pnpm lint:banned`, `pnpm knip`, `pnpm test:unit`, `pnpm test:comparison` all pass. Five python3/WASM-bundle test files fail identically on unmodified `main` in this environment and are untouched by this change.