### PR TITLE
test(curl): new tests to cover request data from stdin

### DIFF
--- a/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
+++ b/packages/just-bash/src/commands/curl/tests/data-at-file.test.ts
@@ -217,6 +217,53 @@ describe("curl @file interpretation", () => {
     });
   });
 
+  describe("data from stdin with @-", () => {
+    it.fails("-d @- reads stdin and strips CR and LF", async () => {
+      const env = createEnv();
+      const result = await env.exec("curl -d @- https://api.example.com/test", {
+        stdin: "first=1\n&second=2\r\n",
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.method).toBe("POST");
+      expect(lastRequest?.options.body).toBe("first=1&second=2");
+    });
+
+    it.fails("--data-binary @- reads stdin verbatim", async () => {
+      const env = createEnv();
+      const result = await env.exec(
+        "curl --data-binary @- https://api.example.com/test",
+        { stdin: "first line\nsecond line\r\n" },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.method).toBe("POST");
+      expect(lastRequest?.options.body).toBe("first line\nsecond line\r\n");
+    });
+
+    it.fails("--data-urlencode @- URL-encodes stdin", async () => {
+      const env = createEnv();
+      const result = await env.exec(
+        "curl --data-urlencode @- https://api.example.com/test",
+        { stdin: "hello world & friends" },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("hello+world+%26+friends");
+    });
+
+    it.fails("--data-urlencode name@- prefixes URL-encoded stdin", async () => {
+      const env = createEnv();
+      const result = await env.exec(
+        "curl --data-urlencode note@- https://api.example.com/test",
+        { stdin: "hello world & friends" },
+      );
+
+      expect(result.exitCode).toBe(0);
+      expect(lastRequest?.options.body).toBe("note=hello+world+%26+friends");
+    });
+  });
+
   describe("mixed inline + file payloads", () => {
     it("merges -d @file with a trailing --data-urlencode inline", async () => {
       const env = createEnv({ "/payload.txt": "from=file" });

--- a/packages/just-bash/src/comparison-tests/curl-data.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/curl-data.comparison.test.ts
@@ -106,6 +106,21 @@ describe("curl data options - real curl comparison", () => {
     expect(result).toMatchObject({ stdout: real, stderr: "", exitCode: 0 });
   });
 
+  it.fails("matches -d @- reading request data from stdin", async () => {
+    const stdin = "a=1\n&b=2\r\n";
+    await writeFile(join(realCurlCwd, "stdin.txt"), stdin);
+    const { stdout: real } = await execFileAsync(
+      "sh",
+      ["-c", 'curl -sS -d @- "$1" < stdin.txt', "sh", `${baseUrl}/echo`],
+      { cwd: realCurlCwd, encoding: "utf8" },
+    );
+    const result = await createEnv().exec(`curl -sS -d @- '${baseUrl}/echo'`, {
+      stdin,
+    });
+
+    expect(result).toMatchObject({ stdout: real, stderr: "", exitCode: 0 });
+  });
+
   it("matches -G combined with an explicit request method", async () => {
     const real = await runRealCurl([
       "-X",


### PR DESCRIPTION
Real curl treats `@-` as “read request data from stdin” for data options, but curl via just-bash currently treats `-` as a literal filename and fails with:

`curl: (1) ENOENT: no such file or directory, open '/home/user/-'`

This can be especially opaque with `curl -s` or when a later pipeline stage masks curl's exit status.

The PR only contributes (failing) tests that repro the behavior. If these look worthy to add, I can follow-up with the implementation.
