### PR TITLE
fix(diff): default to POSIX normal format

### DIFF
--- a/.changeset/diff-normal-format-default.md
+++ b/.changeset/diff-normal-format-default.md
@@ -1,0 +1,19 @@
+---
+"just-bash": minor
+---
+
+`diff` now defaults to POSIX normal format (`2c2` / `<` / `---` / `>`) instead of unified, matching GNU diffutils and POSIX. **This changes the default output and will break anything parsing the previous unified-by-default output** — pass `-u` to keep unified.
+
+Previously `-u` was parsed and discarded, `createTwoFilesPatch` was the only output path, and every invocation was prefixed with jsdiff's 67-character `===...===` banner, which is not valid output in any GNU format. Normal format was unreachable by any flag, so `diff a b | grep '^<'` — the canonical "lines only in A" idiom — silently matched nothing and exited cleanly on files that differ.
+
+- `-u` / `--unified` now selects unified format, and `--normal` selects the default explicitly.
+- New `-c` / `--context` for context format (`*** ` / `--- ` / `***************` / `! `).
+- New `--version`.
+- The `===` banner is gone from every format. The `-u` / `-c` file headers carry no timestamp, so output is reproducible; GNU puts each file's mtime there.
+- Filenames in `-u` / `-c` headers are quoted and escaped as GNU does, so a filename containing a newline can no longer forge header or `@@` lines in the emitted patch.
+- Two output styles at once (for example `diff -u -c`) is now an error, as in GNU: `diff: conflicting output style options`, exit 2.
+- `\ No newline at end of file` is reported in all three formats.
+
+`-q`, `-s`, `-i`, `-` for stdin, and the exit codes are unchanged.
+
+Hunk selection is unchanged: where several equally minimal edit scripts exist, just-bash may group ambiguous changes differently than GNU. The output is always a correct, equally minimal patch, but the `NcN` line numbers can differ on such inputs.

--- a/packages/just-bash/src/commands/diff/diff.gnu-context.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.gnu-context.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Context format, selected with -c.
+ *
+ * Every expected string in this file was produced by running GNU diffutils
+ * 3.12 on the same two inputs and freezing its output verbatim,
+ * with only the two header lines replaced (GNU stamps them with the files'
+ * mtimes; just-bash omits the timestamp so its output is reproducible).
+ */
+describe("diff context format (-c) vs GNU diffutils 3.12", () => {
+  describe("context format (-c)", () => {
+    it("matches GNU for a single changed line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n  a\n! b\n  c\n--- 1,3 ----\n  a\n! X\n  c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure insertion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nNEW\nl2\nl3\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n--- 1,4 ----\n  l1\n+ NEW\n  l2\n  l3\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the end", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\nb\nc\nd\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,2 ****\n--- 1,4 ----\n  a\n  b\n+ c\n+ d\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "b\nc\n", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,2 ****\n--- 1,3 ----\n+ a\n  b\n  c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure deletion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nl3\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n  l1\n- l2\n  l3\n--- 1,2 ----\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a deletion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "b\nc\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n- a\n  b\n  c\n--- 1,2 ----\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a multi-line deletion", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\nd\n", "/b.txt": "a\nd\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,4 ****\n  a\n- b\n- c\n  d\n--- 1,2 ----\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two hunks far enough apart to stay separate", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB1\n",
+        },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,4 ****\n! A\n  m0\n  m1\n  m2\n--- 1,4 ----\n! A1\n  m0\n  m1\n  m2\n***************\n*** 6,9 ****\n  m4\n  m5\n  m6\n! B\n--- 6,9 ----\n  m4\n  m5\n  m6\n! B1\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two changes close enough for GNU to merge them", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nB1\n",
+        },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,8 ****\n! A\n  m0\n  m1\n  m2\n  m3\n  m4\n  m5\n! B\n--- 1,8 ----\n! A1\n  m0\n  m1\n  m2\n  m3\n  m4\n  m5\n! B1\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion and a deletion in one hunk", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "k1\nDEL\nk2\nk3\nk4\n",
+          "/b.txt": "k1\nk2\nk3\nADD\nk4\n",
+        },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,5 ****\n  k1\n- DEL\n  k2\n  k3\n  k4\n--- 1,5 ----\n  k1\n  k2\n  k3\n+ ADD\n  k4\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an empty file against a non-empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "", "/b.txt": "a\nb\n" } });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 0 ****\n--- 1,2 ----\n+ a\n+ b\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a non-empty file against an empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "a\nb\n", "/b.txt": "" } });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,2 ****\n- a\n- b\n--- 0 ----\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for neither file ending in a newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n  a\n! b\n  c\n\\ No newline at end of file\n--- 1,3 ----\n  a\n! X\n  c\n\\ No newline at end of file\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the second file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n  a\n! b\n! c\n--- 1,3 ----\n  a\n! X\n! c\n\\ No newline at end of file\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the first file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n  a\n  b\n! c\n\\ No newline at end of file\n--- 1,3 ----\n  a\n  b\n! c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a blank line as context", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "x\n\ny\n", "/b.txt": "X\n\ny\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,3 ****\n! x\n  \n  y\n--- 1,3 ----\n! X\n  \n  y\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a line changed to a blank line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\n\n" },
+      });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,2 ****\n  a\n! b\n--- 1,2 ----\n  a\n! \n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/diff/diff.gnu-normal.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.gnu-normal.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * POSIX normal format is what diff emits with no format flag.
+ *
+ * Every expected string in this file was produced by running GNU diffutils
+ * 3.12 on the same two inputs and freezing its output verbatim.
+ */
+describe("diff normal format vs GNU diffutils 3.12", () => {
+  describe("normal format", () => {
+    it("matches GNU for a single changed line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2c2\n< b\n---\n> X\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure insertion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nNEW\nl2\nl3\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1a2\n> NEW\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the end", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\nb\nc\nd\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2a3,4\n> c\n> d\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "b\nc\n", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("0a1\n> a\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure deletion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nl3\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2d1\n< l2\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a deletion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "b\nc\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1d0\n< a\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a multi-line deletion", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\nd\n", "/b.txt": "a\nd\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2,3d1\n< b\n< c\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two hunks far enough apart to stay separate", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB1\n",
+        },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1c1\n< A\n---\n> A1\n9c9\n< B\n---\n> B1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two changes close enough for GNU to merge them", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nB1\n",
+        },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1c1\n< A\n---\n> A1\n8c8\n< B\n---\n> B1\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion and a deletion in one hunk", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "k1\nDEL\nk2\nk3\nk4\n",
+          "/b.txt": "k1\nk2\nk3\nADD\nk4\n",
+        },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2d1\n< DEL\n4a4\n> ADD\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an empty file against a non-empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "", "/b.txt": "a\nb\n" } });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("0a1,2\n> a\n> b\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a non-empty file against an empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "a\nb\n", "/b.txt": "" } });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1,2d0\n< a\n< b\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for neither file ending in a newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2c2\n< b\n---\n> X\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the second file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "2,3c2,3\n< b\n< c\n---\n> X\n> c\n\\ No newline at end of file\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the first file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "3c3\n< c\n\\ No newline at end of file\n---\n> c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a blank line as context", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "x\n\ny\n", "/b.txt": "X\n\ny\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1c1\n< x\n---\n> X\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a line changed to a blank line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\n\n" },
+      });
+      const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("2c2\n< b\n---\n> \n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/diff/diff.gnu-unified.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.gnu-unified.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Unified format, selected with -u.
+ *
+ * Every expected string in this file was produced by running GNU diffutils
+ * 3.12 on the same two inputs and freezing its output verbatim,
+ * with only the two header lines replaced (GNU stamps them with the files'
+ * mtimes; just-bash omits the timestamp so its output is reproducible).
+ */
+describe("diff unified format (-u) vs GNU diffutils 3.12", () => {
+  describe("unified format (-u)", () => {
+    it("matches GNU for a single changed line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,3 @@\n a\n-b\n+X\n c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure insertion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nNEW\nl2\nl3\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,4 @@\n l1\n+NEW\n l2\n l3\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the end", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\nb\nc\nd\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,2 +1,4 @@\n a\n b\n+c\n+d\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "b\nc\n", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,2 +1,3 @@\n+a\n b\n c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a pure deletion in the middle", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "l1\nl2\nl3\n", "/b.txt": "l1\nl3\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,2 @@\n l1\n-l2\n l3\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a deletion at the start", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "b\nc\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,2 @@\n-a\n b\n c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a multi-line deletion", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\nd\n", "/b.txt": "a\nd\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,4 +1,2 @@\n a\n-b\n-c\n d\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two hunks far enough apart to stay separate", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nm6\nB1\n",
+        },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,4 +1,4 @@\n-A\n+A1\n m0\n m1\n m2\n@@ -6,4 +6,4 @@\n m4\n m5\n m6\n-B\n+B1\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for two changes close enough for GNU to merge them", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "A\nm0\nm1\nm2\nm3\nm4\nm5\nB\n",
+          "/b.txt": "A1\nm0\nm1\nm2\nm3\nm4\nm5\nB1\n",
+        },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,8 +1,8 @@\n-A\n+A1\n m0\n m1\n m2\n m3\n m4\n m5\n-B\n+B1\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an insertion and a deletion in one hunk", async () => {
+      const env = new Bash({
+        files: {
+          "/a.txt": "k1\nDEL\nk2\nk3\nk4\n",
+          "/b.txt": "k1\nk2\nk3\nADD\nk4\n",
+        },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,5 +1,5 @@\n k1\n-DEL\n k2\n k3\n+ADD\n k4\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for an empty file against a non-empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "", "/b.txt": "a\nb\n" } });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -0,0 +1,2 @@\n+a\n+b\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a non-empty file against an empty one", async () => {
+      const env = new Bash({ files: { "/a.txt": "a\nb\n", "/b.txt": "" } });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,2 +0,0 @@\n-a\n-b\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for neither file ending in a newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,3 @@\n a\n-b\n+X\n c\n\\ No newline at end of file\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the second file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc\n", "/b.txt": "a\nX\nc" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,3 @@\n a\n-b\n-c\n+X\n+c\n\\ No newline at end of file\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for only the first file missing its final newline", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\nc", "/b.txt": "a\nb\nc\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,3 @@\n a\n b\n-c\n\\ No newline at end of file\n+c\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a blank line as context", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "x\n\ny\n", "/b.txt": "X\n\ny\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,3 +1,3 @@\n-x\n+X\n \n y\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("matches GNU for a line changed to a blank line", async () => {
+      const env = new Bash({
+        files: { "/a.txt": "a\nb\n", "/b.txt": "a\n\n" },
+      });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,2 +1,2 @@\n a\n-b\n+\n",
+      );
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(1);
+    });
+  });
+});

--- a/packages/just-bash/src/commands/diff/diff.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.test.ts
@@ -27,7 +27,7 @@ describe("diff", () => {
       expect(result.exitCode).toBe(1);
     });
 
-    it("should show unified diff output by default", async () => {
+    it("should show normal diff output by default", async () => {
       const env = new Bash({
         files: {
           "/a.txt": "hello\n",
@@ -35,10 +35,8 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /a.txt /b.txt");
-      expect(result.stdout).toContain("---");
-      expect(result.stdout).toContain("+++");
-      expect(result.stdout).toContain("-hello");
-      expect(result.stdout).toContain("+world");
+      expect(result.stdout).toBe("1c1\n< hello\n---\n> world\n");
+      expect(result.stderr).toBe("");
       expect(result.exitCode).toBe(1);
     });
 
@@ -50,7 +48,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /a.txt /b.txt");
-      expect(result.stdout).toContain("+line2");
+      expect(result.stdout).toBe("1a2\n> line2\n");
       expect(result.exitCode).toBe(1);
     });
 
@@ -62,7 +60,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /a.txt /b.txt");
-      expect(result.stdout).toContain("-line2");
+      expect(result.stdout).toBe("2d1\n< line2\n");
       expect(result.exitCode).toBe(1);
     });
   });
@@ -154,6 +152,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /a.txt /b.txt");
+      expect(result.stdout).toBe("1c1\n< Hello\n---\n> hello\n");
       expect(result.exitCode).toBe(1);
     });
   });
@@ -166,8 +165,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec('echo "from stdin" | diff - /b.txt');
-      expect(result.stdout).toContain("-from stdin");
-      expect(result.stdout).toContain("+from file");
+      expect(result.stdout).toBe("1c1\n< from stdin\n---\n> from file\n");
       expect(result.exitCode).toBe(1);
     });
 
@@ -178,8 +176,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec('echo "from stdin" | diff /a.txt -');
-      expect(result.stdout).toContain("-from file");
-      expect(result.stdout).toContain("+from stdin");
+      expect(result.stdout).toBe("1c1\n< from file\n---\n> from stdin\n");
       expect(result.exitCode).toBe(1);
     });
   });
@@ -248,20 +245,21 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /a.txt /b.txt");
-      expect(result.stdout).toContain("-line2");
-      expect(result.stdout).toContain("+modified");
+      expect(result.stdout).toBe("2c2\n< line2\n---\n> modified\n");
       expect(result.exitCode).toBe(1);
     });
 
-    it("should show context around changes", async () => {
+    it("should show context around changes with -u", async () => {
       const env = new Bash({
         files: {
           "/a.txt": "1\n2\n3\n4\n5\n",
           "/b.txt": "1\n2\nX\n4\n5\n",
         },
       });
-      const result = await env.exec("diff /a.txt /b.txt");
-      expect(result.stdout).toContain("@@");
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1,5 +1,5 @@\n 1\n 2\n-3\n+X\n 4\n 5\n",
+      );
       expect(result.exitCode).toBe(1);
     });
   });
@@ -275,7 +273,7 @@ describe("diff", () => {
         },
       });
       const result = await env.exec("diff /empty.txt /content.txt");
-      expect(result.stdout).toContain("+has content");
+      expect(result.stdout).toBe("0a1\n> has content\n");
       expect(result.exitCode).toBe(1);
     });
 
@@ -289,6 +287,121 @@ describe("diff", () => {
       const result = await env.exec("diff /a.txt /b.txt");
       expect(result.stdout).toBe("");
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("output style selection", () => {
+    const files = { "/a.txt": "1\n2\n3\n4\n5\n", "/b.txt": "1\n2\nX\n4\n5\n" };
+
+    it("should select normal format with --normal", async () => {
+      const env = new Bash({ files });
+      const result = await env.exec("diff --normal /a.txt /b.txt");
+      expect(result.stdout).toBe("3c3\n< 3\n---\n> X\n");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should select context format with -c", async () => {
+      const env = new Bash({ files });
+      const result = await env.exec("diff -c /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "*** /a.txt\n--- /b.txt\n***************\n*** 1,5 ****\n" +
+          "  1\n  2\n! 3\n  4\n  5\n--- 1,5 ----\n  1\n  2\n! X\n  4\n  5\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should select context format with --context", async () => {
+      const env = new Bash({ files });
+      const short = await env.exec("diff -c /a.txt /b.txt");
+      const long = await env.exec("diff --context /a.txt /b.txt");
+      expect(long.stdout).toBe(short.stdout);
+      expect(long.exitCode).toBe(1);
+    });
+
+    it("should not emit the jsdiff === banner in any style", async () => {
+      const env = new Bash({ files });
+      for (const flag of ["", "-u", "-c", "--normal"]) {
+        const result = await env.exec(`diff ${flag} /a.txt /b.txt`);
+        expect(result.stdout).not.toContain("=====");
+      }
+    });
+
+    it("should reject conflicting output styles", async () => {
+      const env = new Bash({ files });
+      const result = await env.exec("diff -u -c /a.txt /b.txt");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        "diff: conflicting output style options\n" +
+          "diff: Try 'diff --help' for more information.\n",
+      );
+      expect(result.exitCode).toBe(2);
+    });
+  });
+
+  describe("version", () => {
+    it("should print the program name and exit 0 with --version", async () => {
+      const env = new Bash();
+      const result = await env.exec("diff --version");
+      expect(result.stdout).toBe("diff (just-bash)\n");
+      expect(result.stderr).toBe("");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("filename quoting in -u/-c headers", () => {
+    it("should leave an ordinary filename bare", async () => {
+      const env = new Bash({ files: { "/a.txt": "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff -u /a.txt /b.txt");
+      expect(result.stdout).toBe(
+        "--- /a.txt\n+++ /b.txt\n@@ -1 +1 @@\n-a\n+b\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should quote a filename containing a space", async () => {
+      const env = new Bash({ files: { "/has space": "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff -u '/has space' /b.txt");
+      expect(result.stdout).toBe(
+        '--- "/has space"\n+++ /b.txt\n@@ -1 +1 @@\n-a\n+b\n',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should escape a newline so it cannot forge patch lines", async () => {
+      const env = new Bash({ files: { "/ev\nil": "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff -u \"$(printf '/ev\\nil')\" /b.txt");
+      expect(result.stdout).toBe(
+        '--- "/ev\\nil"\n+++ /b.txt\n@@ -1 +1 @@\n-a\n+b\n',
+      );
+      // A raw newline here would have forged two extra lines in the patch.
+      expect(result.stdout.split("\n")).toHaveLength(6);
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should escape a double quote, and quote in -c headers too", async () => {
+      const env = new Bash({ files: { '/a"b c': "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff -c '/a\"b c' /b.txt");
+      expect(result.stdout).toBe(
+        '*** "/a\\"b c"\n--- /b.txt\n***************\n' +
+          "*** 1 ****\n! a\n--- 1 ----\n! b\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should leave non-ASCII filenames bare", async () => {
+      const env = new Bash({ files: { "/ünïcøde": "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff -u /ünïcøde /b.txt");
+      expect(result.stdout).toBe(
+        "--- /ünïcøde\n+++ /b.txt\n@@ -1 +1 @@\n-a\n+b\n",
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("should not print filenames at all in normal format", async () => {
+      const env = new Bash({ files: { "/has space": "a\n", "/b.txt": "b\n" } });
+      const result = await env.exec("diff '/has space' /b.txt");
+      expect(result.stdout).toBe("1c1\n< a\n---\n> b\n");
+      expect(result.exitCode).toBe(1);
     });
   });
 });

--- a/packages/just-bash/src/commands/diff/diff.ts
+++ b/packages/just-bash/src/commands/diff/diff.ts
@@ -2,7 +2,6 @@
  * diff - Compare files line by line
  */
 
-import * as Diff from "diff";
 import { decodeBytesToUtf8 } from "../../encoding.js";
 import type {
   ExecResult,
@@ -11,22 +10,35 @@ import type {
 } from "../../types.js";
 import { parseArgs } from "../../utils/args.js";
 import { hasHelpFlag, showHelp } from "../help.js";
+import {
+  computeChanges,
+  DEFAULT_CONTEXT,
+  formatContext,
+  formatNormal,
+  formatUnified,
+  splitLines,
+} from "./format.js";
 
 const diffHelp = {
   name: "diff",
   summary: "compare files line by line",
   usage: "diff [OPTION]... FILE1 FILE2",
   options: [
-    "-u, --unified     output unified diff format (default)",
+    "    --normal      output a normal diff (default)",
+    "-u, --unified     output a unified diff",
+    "-c, --context     output a context diff",
     "-q, --brief       report only whether files differ",
     "-s, --report-identical-files  report when files are the same",
     "-i, --ignore-case  ignore case differences",
+    "    --version     output version information and exit",
     "    --help        display this help and exit",
   ],
 };
 
 const argDefs = {
+  normal: { long: "normal", type: "boolean" as const },
   unified: { short: "u", long: "unified", type: "boolean" as const },
+  context: { short: "c", long: "context", type: "boolean" as const },
   brief: { short: "q", long: "brief", type: "boolean" as const },
   reportSame: {
     short: "s",
@@ -34,6 +46,7 @@ const argDefs = {
     type: "boolean" as const,
   },
   ignoreCase: { short: "i", long: "ignore-case", type: "boolean" as const },
+  version: { long: "version", type: "boolean" as const },
 };
 
 export const diffCommand: RuntimeCommand = {
@@ -48,13 +61,30 @@ export const diffCommand: RuntimeCommand = {
     const parsed = parseArgs("diff", args, argDefs);
     if (!parsed.ok) return parsed.error;
 
-    const brief = parsed.result.flags.brief;
-    const reportSame = parsed.result.flags.reportSame;
-    const ignoreCase = parsed.result.flags.ignoreCase;
-    const files = parsed.result.positional;
+    const flags = parsed.result.flags;
+    if (flags.version) {
+      // No version number: this command ships inside just-bash and has no
+      // release cadence of its own, and a hard-coded package version would go
+      // stale on the very next release.
+      return { stdout: "diff (just-bash)\n", stderr: "", exitCode: 0 };
+    }
 
-    // Note: unified flag is accepted but is the default behavior
-    void parsed.result.flags.unified;
+    const styleCount =
+      Number(flags.normal) + Number(flags.unified) + Number(flags.context);
+    if (styleCount > 1) {
+      return {
+        stdout: "",
+        stderr:
+          "diff: conflicting output style options\n" +
+          "diff: Try 'diff --help' for more information.\n",
+        exitCode: 2,
+      };
+    }
+
+    const brief = flags.brief;
+    const reportSame = flags.reportSame;
+    const ignoreCase = flags.ignoreCase;
+    const files = parsed.result.positional;
 
     if (files.length < 2) {
       return { stdout: "", stderr: "diff: missing operand\n", exitCode: 2 };
@@ -91,6 +121,8 @@ export const diffCommand: RuntimeCommand = {
       };
     }
 
+    // Cheap whole-content equality first: -q and identical files never need
+    // the line-by-line diff.
     let t1 = c1,
       t2 = c2;
     if (ignoreCase) {
@@ -118,9 +150,33 @@ export const diffCommand: RuntimeCommand = {
       };
     }
 
-    const output = Diff.createTwoFilesPatch(f1, f2, c1, c2, "", "", {
-      context: 3,
-    });
+    const oldFile = splitLines(c1);
+    const newFile = splitLines(c2);
+    const changes = computeChanges(oldFile, newFile, ignoreCase);
+
+    let output: string;
+    if (flags.unified) {
+      output = formatUnified(
+        f1,
+        f2,
+        oldFile,
+        newFile,
+        changes,
+        DEFAULT_CONTEXT,
+      );
+    } else if (flags.context) {
+      output = formatContext(
+        f1,
+        f2,
+        oldFile,
+        newFile,
+        changes,
+        DEFAULT_CONTEXT,
+      );
+    } else {
+      output = formatNormal(oldFile, newFile, changes);
+    }
+
     // diff emits text; the pipeline handles encoding.
     return {
       stdout: output,
@@ -135,7 +191,9 @@ import type { CommandFuzzInfo } from "../fuzz-flags-types.js";
 export const flagsForFuzzing: CommandFuzzInfo = {
   name: "diff",
   flags: [
+    { flag: "--normal", type: "boolean" },
     { flag: "-u", type: "boolean" },
+    { flag: "-c", type: "boolean" },
     { flag: "-q", type: "boolean" },
     { flag: "-s", type: "boolean" },
     { flag: "-i", type: "boolean" },

--- a/packages/just-bash/src/commands/diff/diff.utf8-stdin.test.ts
+++ b/packages/just-bash/src/commands/diff/diff.utf8-stdin.test.ts
@@ -12,7 +12,6 @@ describe("diff reads UTF-8 from stdin", () => {
     const result = await env.exec("cat /a.txt | diff - /b.txt");
     // diff exits 1 when files differ.
     expect(result.exitCode).toBe(1);
-    expect(result.stdout).toContain("한글");
-    expect(result.stdout).toContain("different");
+    expect(result.stdout).toBe("1c1\n< 한글\n---\n> different\n");
   });
 });

--- a/packages/just-bash/src/commands/diff/format.ts
+++ b/packages/just-bash/src/commands/diff/format.ts
@@ -1,0 +1,348 @@
+/**
+ * Output formatters for diff.
+ *
+ * The three formats GNU diff can produce: POSIX normal format (the default),
+ * unified format (-u) and context format (-c). Layout was derived by running
+ * GNU diffutils 3.12 and matching the bytes it emits.
+ *
+ * Two intentional deviations from GNU:
+ *
+ * - The -u/-c file header carries no timestamp. GNU appends a tab and the
+ *   file's mtime; inside a virtual filesystem that is often synthetic or
+ *   absent, and it would make output non-reproducible. Patch consumers ignore
+ *   the field.
+ * - When several minimal edit scripts exist for the same pair of files, which
+ *   one comes out is arbitrary, and this picks a different one than GNU on
+ *   some inputs. Hunks are still minimal and the formats are exact; only the
+ *   grouping of ambiguous changes can differ.
+ */
+
+import * as Diff from "diff";
+
+const NO_NEWLINE = "\\ No newline at end of file\n";
+
+/** Number of context lines GNU shows around a change for -u and -c. */
+export const DEFAULT_CONTEXT = 3;
+
+export interface FileLines {
+  /** Lines with their trailing newline stripped. */
+  lines: string[];
+  /** True when the last line is not newline-terminated. */
+  noEol: boolean;
+}
+
+/**
+ * A run of adjacent deleted and/or inserted lines. Starts are 0-based indices
+ * into the corresponding `FileLines.lines`.
+ */
+export interface Change {
+  oldStart: number;
+  oldCount: number;
+  newStart: number;
+  newCount: number;
+}
+
+/** Splits file content into lines, remembering a missing final newline. */
+export function splitLines(content: string): FileLines {
+  if (content === "") return { lines: [], noEol: false };
+  const noEol = !content.endsWith("\n");
+  const lines = content.split("\n");
+  // A newline-terminated file ends with an empty trailing element.
+  if (!noEol) lines.pop();
+  return { lines, noEol };
+}
+
+/**
+ * Builds the comparison tokens for a file. Every line keeps its newline so a
+ * final line without one never compares equal to the same text with one —
+ * that is what makes GNU report `\ No newline at end of file` as a difference.
+ */
+function tokenize(file: FileLines, ignoreCase: boolean): string[] {
+  const last = file.lines.length - 1;
+  return file.lines.map((line, i) => {
+    const token = i === last && file.noEol ? line : `${line}\n`;
+    return ignoreCase ? token.toLowerCase() : token;
+  });
+}
+
+/** Computes the runs of deleted and/or inserted lines between two files. */
+export function computeChanges(
+  oldFile: FileLines,
+  newFile: FileLines,
+  ignoreCase: boolean,
+): Change[] {
+  const parts = Diff.diffArrays(
+    tokenize(oldFile, ignoreCase),
+    tokenize(newFile, ignoreCase),
+  );
+
+  const changes: Change[] = [];
+  let oldIdx = 0;
+  let newIdx = 0;
+  let i = 0;
+  while (i < parts.length) {
+    const part = parts[i];
+    if (!part.added && !part.removed) {
+      oldIdx += part.count ?? part.value.length;
+      newIdx += part.count ?? part.value.length;
+      i++;
+      continue;
+    }
+    const change: Change = {
+      oldStart: oldIdx,
+      oldCount: 0,
+      newStart: newIdx,
+      newCount: 0,
+    };
+    // Deletions and insertions that touch arrive as separate adjacent parts;
+    // one hunk covers the whole run.
+    while (i < parts.length && (parts[i].added || parts[i].removed)) {
+      const count = parts[i].count ?? parts[i].value.length;
+      if (parts[i].removed) {
+        change.oldCount += count;
+        oldIdx += count;
+      } else {
+        change.newCount += count;
+        newIdx += count;
+      }
+      i++;
+    }
+    changes.push(change);
+  }
+  return changes;
+}
+
+/**
+ * Quotes a filename for a -u/-c header the way GNU diff does.
+ *
+ * Without this a filename containing a newline would forge extra header or
+ * `@@` lines in the emitted patch, which a downstream `patch` would act on.
+ * Rule taken from GNU diffutils 3.12 in a UTF-8 locale: quote when the name
+ * holds whitespace, a double quote or a control character; leave non-ASCII
+ * alone. A lone backslash does not trigger quoting but is escaped once some
+ * other character has.
+ */
+function quoteFilename(name: string): string {
+  if (!/[\s"\u0000-\u001f\u007f]/.test(name)) return name;
+  let out = '"';
+  for (const ch of name) {
+    if (ch === '"' || ch === "\\") out += `\\${ch}`;
+    else if (ch === "\t") out += "\\t";
+    else if (ch === "\n") out += "\\n";
+    else if (ch === "\r") out += "\\r";
+    else if (ch < "\u0020" || ch === "\u007f") {
+      out += `\\${ch.charCodeAt(0).toString(8).padStart(3, "0")}`;
+    } else out += ch;
+  }
+  return `${out}"`;
+}
+
+/** Appends one line plus, when it is a final line without newline, the marker. */
+function pushLine(
+  out: string[],
+  file: FileLines,
+  index: number,
+  prefix: string,
+): void {
+  out.push(`${prefix}${file.lines[index]}\n`);
+  if (file.noEol && index === file.lines.length - 1) out.push(NO_NEWLINE);
+}
+
+/** `N` for one line, `N,M` for a run, and the preceding line for an empty run. */
+function normalRange(start: number, count: number): string {
+  if (count === 0) return String(start);
+  if (count === 1) return String(start + 1);
+  return `${start + 1},${start + count}`;
+}
+
+/** POSIX normal format: `2c2` / `< old` / `---` / `> new`. */
+export function formatNormal(
+  oldFile: FileLines,
+  newFile: FileLines,
+  changes: Change[],
+): string {
+  const out: string[] = [];
+  for (const change of changes) {
+    const op = change.oldCount === 0 ? "a" : change.newCount === 0 ? "d" : "c";
+    out.push(
+      `${normalRange(change.oldStart, change.oldCount)}${op}${normalRange(
+        change.newStart,
+        change.newCount,
+      )}\n`,
+    );
+    for (let i = 0; i < change.oldCount; i++) {
+      pushLine(out, oldFile, change.oldStart + i, "< ");
+    }
+    if (op === "c") out.push("---\n");
+    for (let i = 0; i < change.newCount; i++) {
+      pushLine(out, newFile, change.newStart + i, "> ");
+    }
+  }
+  return out.join("");
+}
+
+/**
+ * Groups changes into hunks. GNU merges two changes into one hunk when at most
+ * `2 * context` unchanged lines separate them.
+ */
+function groupIntoHunks(changes: Change[], context: number): Change[][] {
+  const hunks: Change[][] = [];
+  let current: Change[] = [];
+  for (const change of changes) {
+    const prev = current[current.length - 1];
+    if (
+      prev &&
+      change.oldStart - (prev.oldStart + prev.oldCount) > 2 * context
+    ) {
+      hunks.push(current);
+      current = [];
+    }
+    current.push(change);
+  }
+  if (current.length > 0) hunks.push(current);
+  return hunks;
+}
+
+interface HunkBounds {
+  oldFrom: number;
+  oldTo: number;
+  newFrom: number;
+  newTo: number;
+}
+
+/** Half-open [from, to) line ranges covered by a hunk, context included. */
+function hunkBounds(
+  hunk: Change[],
+  oldFile: FileLines,
+  newFile: FileLines,
+  context: number,
+): HunkBounds {
+  const first = hunk[0];
+  const last = hunk[hunk.length - 1];
+  return {
+    oldFrom: Math.max(0, first.oldStart - context),
+    oldTo: Math.min(
+      oldFile.lines.length,
+      last.oldStart + last.oldCount + context,
+    ),
+    newFrom: Math.max(0, first.newStart - context),
+    newTo: Math.min(
+      newFile.lines.length,
+      last.newStart + last.newCount + context,
+    ),
+  };
+}
+
+/** `@@` range: `N,0` when empty, bare `N` for one line, else `N,count`. */
+function unifiedRange(from: number, to: number): string {
+  const count = to - from;
+  if (count === 0) return `${from},0`;
+  if (count === 1) return String(from + 1);
+  return `${from + 1},${count}`;
+}
+
+/** Unified format (-u): `--- old`, `+++ new`, `@@` hunks. */
+export function formatUnified(
+  oldName: string,
+  newName: string,
+  oldFile: FileLines,
+  newFile: FileLines,
+  changes: Change[],
+  context: number,
+): string {
+  const out: string[] = [
+    `--- ${quoteFilename(oldName)}\n`,
+    `+++ ${quoteFilename(newName)}\n`,
+  ];
+  for (const hunk of groupIntoHunks(changes, context)) {
+    const b = hunkBounds(hunk, oldFile, newFile, context);
+    out.push(
+      `@@ -${unifiedRange(b.oldFrom, b.oldTo)} +${unifiedRange(
+        b.newFrom,
+        b.newTo,
+      )} @@\n`,
+    );
+    let oldIdx = b.oldFrom;
+    for (const change of hunk) {
+      // Unchanged lines are printed from the old file, matching GNU under -i.
+      for (; oldIdx < change.oldStart; oldIdx++)
+        pushLine(out, oldFile, oldIdx, " ");
+      for (let i = 0; i < change.oldCount; i++) {
+        pushLine(out, oldFile, change.oldStart + i, "-");
+      }
+      for (let i = 0; i < change.newCount; i++) {
+        pushLine(out, newFile, change.newStart + i, "+");
+      }
+      oldIdx = change.oldStart + change.oldCount;
+    }
+    for (; oldIdx < b.oldTo; oldIdx++) pushLine(out, oldFile, oldIdx, " ");
+  }
+  return out.join("");
+}
+
+/** `*** N,M ****` range: start,end inclusive, bare `N` for one line. */
+function contextRange(from: number, to: number): string {
+  const count = to - from;
+  if (count === 0) return String(from);
+  if (count === 1) return String(from + 1);
+  return `${from + 1},${to}`;
+}
+
+/**
+ * Emits one side of a context-format hunk. GNU omits the body entirely when
+ * this side has no changed lines, leaving just the range header.
+ */
+function pushContextSide(
+  out: string[],
+  file: FileLines,
+  hunk: Change[],
+  from: number,
+  to: number,
+  isOldSide: boolean,
+): void {
+  const hasChanges = hunk.some(
+    (c) => (isOldSide ? c.oldCount : c.newCount) > 0,
+  );
+  if (!hasChanges) return;
+
+  let idx = from;
+  for (const change of hunk) {
+    const start = isOldSide ? change.oldStart : change.newStart;
+    const count = isOldSide ? change.oldCount : change.newCount;
+    for (; idx < start; idx++) pushLine(out, file, idx, "  ");
+    // A run touching both files is a change (`!`); otherwise it is one-sided.
+    const marker =
+      change.oldCount > 0 && change.newCount > 0
+        ? "! "
+        : isOldSide
+          ? "- "
+          : "+ ";
+    for (let i = 0; i < count; i++) pushLine(out, file, start + i, marker);
+    idx = start + count;
+  }
+  for (; idx < to; idx++) pushLine(out, file, idx, "  ");
+}
+
+/** Context format (-c): `*** old`, `--- new`, `***************` hunks. */
+export function formatContext(
+  oldName: string,
+  newName: string,
+  oldFile: FileLines,
+  newFile: FileLines,
+  changes: Change[],
+  context: number,
+): string {
+  const out: string[] = [
+    `*** ${quoteFilename(oldName)}\n`,
+    `--- ${quoteFilename(newName)}\n`,
+  ];
+  for (const hunk of groupIntoHunks(changes, context)) {
+    const b = hunkBounds(hunk, oldFile, newFile, context);
+    out.push("***************\n");
+    out.push(`*** ${contextRange(b.oldFrom, b.oldTo)} ****\n`);
+    pushContextSide(out, oldFile, hunk, b.oldFrom, b.oldTo, true);
+    out.push(`--- ${contextRange(b.newFrom, b.newTo)} ----\n`);
+    pushContextSide(out, newFile, hunk, b.newFrom, b.newTo, false);
+  }
+  return out.join("");
+}


### PR DESCRIPTION
Fixes #412.

## The bug

`diff` with no flags emitted **unified** format. Three defects fell out of that:

1. **Normal format was unreachable.** `-u` was parsed and then discarded (`void parsed.result.flags.unified`), and `createTwoFilesPatch` was the only non-brief output path — so no flag produced `<` / `>`.
2. **`-c` and `--version` did not exist.**
3. **A 67-character `===…===` banner** led every invocation — a `createTwoFilesPatch` artifact that is not valid output in any GNU format.

The practical impact was a *silent* false negative: `diff a b | grep '^<'`, the canonical "lines only in A" idiom, matched nothing and exited cleanly on files that differ.

This takes option 1 from the issue.

## What changed

- **Normal format is the default** (`NcN` / `NaN` / `NdN`, `<`, `---`, `>`), matching GNU and POSIX. `--normal` selects it explicitly.
- **`-u` / `--unified` now selects unified format** instead of being thrown away.
- **New `-c` / `--context`** for context format (`*** ` / `--- ` / `***************` / `! `), including GNU's rule that a hunk's old or new block body is omitted when that side has no changes.
- **New `--version`**, exit 0.
- **The `===` banner is gone** from every format; `-u` / `-c` headers are built directly rather than post-processed.
- **Filenames in `-u` / `-c` headers are quoted and escaped as GNU does** — see the security note below.
- **Two output styles at once is an error**, as in GNU: `diff: conflicting output style options`, exit 2.
- `\ No newline at end of file` is reported in all three formats, on the correct side, in the right position.
- `flagsForFuzzing` and the `--help` options block are updated; help no longer claims unified is the default.

Unchanged and covered by existing tests: `-q`, `-s`, `-i`, `-` for stdin, missing operand → 2, unreadable file → 2, identical files → empty stdout and exit 0.

`package.json` and the lockfile are untouched.

## How the formats were derived

The three formatters were written by running GNU diffutils 3.12 and matching the bytes it emits — no GNU source was used for them. The new tests freeze that output verbatim for: a single changed line, insertions at the middle/start/end, deletions at the middle/start, a multi-line deletion, two hunks far enough apart to stay separate, two changes close enough to merge into one, an insertion and deletion sharing a hunk, empty vs non-empty in both directions, all three trailing-newline combinations, a blank context line, and a line changed to a blank line.

## Two deliberate deviations from GNU

**1. No timestamp in the `-u` / `-c` header.** GNU emits `--- d1\t2026-09-07 16:45:17.720325084 +0200`; this emits `--- d1`. Inside a virtual filesystem the mtime is often synthetic or absent (stdin has none), and a timestamp would make output non-reproducible for callers and for this repo's fixture-based comparison tests. Patch consumers ignore the field. Happy to emit mtimes instead if you'd rather have exact header parity.

**2. Hunk grouping can differ on ambiguous input.** Several equally minimal edit scripts usually exist for the same pair of files, and which one you get depends on the implementation. Edit-script selection still comes from the `diff` package, so on some inputs the `NcN` line numbers group differently than GNU's. Measured over 199 mutated source-file pairs:

- **149 / 199** unified diffs are byte-identical to GNU
- **199 / 199** apply cleanly under GNU `patch` and reproduce the target file exactly
- **0** differ from GNU in edit count — every diff is equally minimal

So the output is always a correct, minimal patch; only the grouping of ambiguous changes can differ. This is unchanged from the current behaviour on `main`, and it is called out in the changeset.

## On the automated review

Thanks — the GPL finding was correct and serious, and I've dealt with it.

**GPL (🔴 blocker) — fixed by rewriting the branch.** The first push contained `myers.ts`, a line-by-line port of diffutils' `compareseq`, `diag`, `shift_boundaries` and `discard_confusing_lines`, plus a port of the `find_identical_ends` trim in `format.ts`. It preserved structure, identifiers and comments, so it was plainly a derivative of GPLv3 code and could not ship in an Apache-2.0 package. That was my mistake. The branch has been **force-pushed as a single clean commit** so the GPL-derived code is not in this PR's history at all, not merely removed by a follow-up. Edit-script selection is back on the `diff` package (BSD-3-Clause), which stays a dependency. The formatters and their tests are unaffected — they came from observed output, and GNU is explicit that a program's output is not covered by the GPL. The cost is deviation 2 above.

**`--version` staleness (🔴) — fixed.** It now prints `diff (just-bash)` with no number. A hard-coded `3.4.2` would have been wrong the moment this minor changeset published 3.5.0, and this command has no release cadence of its own. Build-time injection is possible (everything shipped as runnable JS is esbuild-bundled), but it means threading a `--define` through five build scripts plus a from-source fallback, which felt disproportionate for one string — happy to do it if you'd prefer a real version.

**Filename injection (🟡) — fixed.** Good catch. `-u` / `-c` headers now quote and escape filenames, so a name containing a newline can no longer forge header or `@@` lines in the patch stream. The rule was taken from GNU's observed behaviour in a UTF-8 locale: quote when the name contains whitespace, a `"` or a control character; escape `\`, `"`, `\t`, `\n`, `\r` and `\NNN`; leave non-ASCII bare (GNU only octal-escapes it in the C locale). 21/21 differential cases match GNU, including tab, CR, `\x01`, quotes, backslashes and multi-byte names. Normal format prints no filenames at all, so it has no such surface. Note that `-q` / `-s` still print filenames unquoted; GNU shell-quotes them there (`Files 'with space' and plain differ`), but that is pre-existing behaviour the issue explicitly asked me not to change, so I left it — happy to fix separately.

**`-q` conflict (🟡) — not applied, the finding looks incorrect.** GNU does not treat `-q` as a conflicting output style. Against diffutils 3.12:

```
$ diff -q -u a b   → Files a and b differ    (exit 1)
$ diff -u -q a b   → Files a and b differ    (exit 1)
$ diff -q -c a b   → Files a and b differ    (exit 1)
$ diff -q --normal a b → Files a and b differ (exit 1)
```

Only two *format* styles together conflict (`diff -u -c` → exit 2), which is what the code implements. Happy to be shown otherwise.

## Testing

`pnpm typecheck`, `pnpm lint` (incl. banned-patterns), `pnpm knip` and `pnpm build` are clean. `pnpm test:run --exclude src/spec-tests` passes 11,689 tests; the 6 failures are CPython-WASM sandbox tests that fail identically on a clean `origin/main` worktree here, so they are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
