### PR TITLE
fix(find): report a directory it cannot read and keep going

### DIFF
--- a/.changeset/find-unreadable-directory.md
+++ b/.changeset/find-unreadable-directory.md
@@ -1,0 +1,11 @@
+---
+"just-bash": patch
+---
+
+find: report a directory it cannot read and keep going
+
+A `readdir` failure inside the traversal threw out of the whole search, so one unreadable directory ended `find` with no results: exit 1 and `find: EACCES: permission denied, scandir '<path>'` on its own, and exit 0 with nothing at all once piped through `head` with stderr silenced. Every macOS home directory holds such a directory (`.Trash`, several under `Library`), so a recursive `find` over a mounted home directory never returned anything.
+
+GNU find names the directory on stderr, continues with everything else, and exits 1 at the end. It now does the same here. The message is `find: <path>: Permission denied`, with the phrase taken from the errno alone, so nothing from the underlying error's text reaches the output. A failure that is not one of the errnos a directory read can produce (a cancellation, an execution limit, a filesystem policy refusal) still ends the search as before.
+
+Messages are emitted in traversal order beside the node's own output, whatever order the parallel batch settled in, and a failed read still counts toward the trace's `readdirCalls` and `readdirTime`.

--- a/packages/just-bash/src/commands/find/find.ts
+++ b/packages/just-bash/src/commands/find/find.ts
@@ -1186,15 +1186,15 @@ function formatCtimeDate(date: Date): string {
  * carries a code of its own and must end the search, not become a line of
  * stderr, so the phrase comes from this table and never from the error.
  */
-const UNREADABLE_DIRECTORY_REASONS: Record<string, string> = {
-  EACCES: "Permission denied",
-  EIO: "Input/output error",
-  ELOOP: "Too many levels of symbolic links",
-  ENAMETOOLONG: "File name too long",
-  ENOENT: "No such file or directory",
-  ENOTDIR: "Not a directory",
-  EPERM: "Permission denied",
-};
+const UNREADABLE_DIRECTORY_REASONS = new Map<string, string>([
+  ["EACCES", "Permission denied"],
+  ["EIO", "Input/output error"],
+  ["ELOOP", "Too many levels of symbolic links"],
+  ["ENAMETOOLONG", "File name too long"],
+  ["ENOENT", "No such file or directory"],
+  ["ENOTDIR", "Not a directory"],
+  ["EPERM", "Permission denied"],
+]);
 
 /**
  * The phrase for a directory that could not be read, from the errno alone,
@@ -1213,7 +1213,7 @@ function describeUnreadableDirectory(error: unknown): string | null {
         ? /^(E[A-Z]+)\b/.exec(error.message)?.[1]
         : undefined;
   if (code === undefined) return null;
-  return UNREADABLE_DIRECTORY_REASONS[code] ?? null;
+  return UNREADABLE_DIRECTORY_REASONS.get(code) ?? null;
 }
 
 /**

--- a/packages/just-bash/src/commands/find/find.ts
+++ b/packages/just-bash/src/commands/find/find.ts
@@ -451,8 +451,23 @@ export const findCommand: RuntimeCommand = {
 
         if (isDirectory && shouldReadDir) {
           const readdirStart = Date.now();
-          if (hasReaddirWithFileTypes && ctx.fs.readdirWithFileTypes) {
-            entriesWithTypes = await ctx.fs.readdirWithFileTypes(currentPath);
+          try {
+            if (hasReaddirWithFileTypes && ctx.fs.readdirWithFileTypes) {
+              entriesWithTypes = await ctx.fs.readdirWithFileTypes(currentPath);
+            } else {
+              entries = await ctx.fs.readdir(currentPath);
+            }
+          } catch (error) {
+            // GNU find names the directory it could not read and carries on,
+            // exiting 1 at the end. Throwing here instead turned one unreadable
+            // directory into an empty result for the whole search, and on a
+            // home directory there is always one.
+            const reason = describeUnreadableDirectory(error);
+            if (reason === null) throw error;
+            appendStderr(`find: ${relativePath}: ${reason}\n`);
+            exitCode = 1;
+          }
+          if (entriesWithTypes !== null) {
             traversalBudget.checkpoint();
             traversalBudget.discover(entriesWithTypes.length);
             entries = [];
@@ -479,8 +494,7 @@ export const findCommand: RuntimeCommand = {
                 });
               }
             }
-          } else {
-            entries = await ctx.fs.readdir(currentPath);
+          } else if (entries !== null) {
             traversalBudget.checkpoint();
             traversalBudget.discover(entries.length);
             traceCounters.readdirCalls++;
@@ -1121,6 +1135,39 @@ function formatCtimeDate(date: Date): string {
   const year = date.getFullYear();
 
   return `${day} ${month} ${dayNum} ${hours}:${mins}:${secs} ${year}`;
+}
+
+/**
+ * The phrase GNU find prints for a directory it could not read, from the
+ * errno alone. Only the code is repeated: the message behind it can carry a
+ * host path, which is not the sandbox's to show. Null for anything that is
+ * not a filesystem error, which the caller lets propagate.
+ */
+function describeUnreadableDirectory(error: unknown): string | null {
+  const code =
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    typeof error.code === "string"
+      ? error.code
+      : error instanceof Error
+        ? /^(E[A-Z]+)\b/.exec(error.message)?.[1]
+        : undefined;
+  switch (code) {
+    case "EACCES":
+    case "EPERM":
+      return "Permission denied";
+    case "ENOENT":
+      return "No such file or directory";
+    case "ENOTDIR":
+      return "Not a directory";
+    case "ELOOP":
+      return "Too many levels of symbolic links";
+    case undefined:
+      return null;
+    default:
+      return code;
+  }
 }
 
 /**

--- a/packages/just-bash/src/commands/find/find.ts
+++ b/packages/just-bash/src/commands/find/find.ts
@@ -232,8 +232,16 @@ export const findCommand: RuntimeCommand = {
       startingPoint: string;
     }
 
+    // A directory the traversal could not read, carried as an effect of its
+    // node so the message lands in traversal order beside the node's own
+    // output, rather than in whatever order the parallel batch settled.
+    interface DiagnosticAction {
+      type: "diagnostic";
+      message: string;
+    }
+
     interface EvaluatedEffect {
-      action: FindAction;
+      action: FindAction | DiagnosticAction;
       path: string;
       printfData: FindResult;
     }
@@ -363,6 +371,8 @@ export const findCommand: RuntimeCommand = {
         depth: number;
         children: WorkItem[];
         pruned: boolean;
+        /** Why the directory could not be read, when it could not. */
+        unreadable?: string;
       }
 
       // Tracing counters
@@ -449,6 +459,7 @@ export const findCommand: RuntimeCommand = {
         const shouldReadDir =
           (shouldDescendIntoSubdirs || needsEmptyCheck) && !earlyPruned;
 
+        let unreadable: string | undefined;
         if (isDirectory && shouldReadDir) {
           const readdirStart = Date.now();
           try {
@@ -461,11 +472,13 @@ export const findCommand: RuntimeCommand = {
             // GNU find names the directory it could not read and carries on,
             // exiting 1 at the end. Throwing here instead turned one unreadable
             // directory into an empty result for the whole search, and on a
-            // home directory there is always one.
+            // home directory there is always one. The message is emitted with
+            // the node's effects, in traversal order, not here in batch order.
             const reason = describeUnreadableDirectory(error);
             if (reason === null) throw error;
-            appendStderr(`find: ${relativePath}: ${reason}\n`);
-            exitCode = 1;
+            unreadable = reason;
+            traceCounters.readdirCalls++;
+            traceCounters.readdirTime += Date.now() - readdirStart;
           }
           if (entriesWithTypes !== null) {
             traversalBudget.checkpoint();
@@ -553,14 +566,47 @@ export const findCommand: RuntimeCommand = {
           depth,
           children: pruned ? [] : children,
           pruned,
+          unreadable,
         };
       }
 
       // Evaluate once in traversal order and retain only actions whose branch was
       // actually reached. Side effects themselves run after traversal is complete.
       function evaluateNode(node: ProcessedNode): EvaluatedEffect[] {
+        const printfData: FindResult = {
+          path: node.relativePath,
+          name: node.name,
+          size: node.stat?.size ?? 0,
+          mtime: node.stat?.mtime?.getTime() ?? Date.now(),
+          mode: node.stat?.mode ?? 0o644,
+          isDirectory: node.isDirectory,
+          depth: node.depth,
+          startingPoint: searchPath,
+        };
+        // Reported whatever -mindepth says, as GNU does: the expression never
+        // ran on it, but the traversal did fail there. Before the node's own
+        // output under -depth, where GNU meets the failure on the way down and
+        // prints the directory on the way back up; after it otherwise.
+        const diagnostics: EvaluatedEffect[] =
+          node.unreadable === undefined
+            ? []
+            : [
+                {
+                  action: {
+                    type: "diagnostic",
+                    message: `find: ${node.relativePath}: ${node.unreadable}\n`,
+                  },
+                  path: node.relativePath,
+                  printfData,
+                },
+              ];
+        const withDiagnostics = (evaluated: EvaluatedEffect[]) =>
+          depthFirst
+            ? [...diagnostics, ...evaluated]
+            : [...evaluated, ...diagnostics];
+
         const atOrBeyondMinDepth = minDepth === null || node.depth >= minDepth;
-        if (!atOrBeyondMinDepth) return [];
+        if (!atOrBeyondMinDepth) return diagnostics;
 
         let matches = true;
         let reachedActions: FindAction[] = [];
@@ -602,18 +648,8 @@ export const findCommand: RuntimeCommand = {
         if (!hasAnyAction && matches) {
           reachedActions = [{ type: "print" }];
         }
-        if (reachedActions.length === 0) return [];
+        if (reachedActions.length === 0) return diagnostics;
 
-        const printfData: FindResult = {
-          path: node.relativePath,
-          name: node.name,
-          size: node.stat?.size ?? 0,
-          mtime: node.stat?.mtime?.getTime() ?? Date.now(),
-          mode: node.stat?.mode ?? 0o644,
-          isDirectory: node.isDirectory,
-          depth: node.depth,
-          startingPoint: searchPath,
-        };
         traversalBudget.checkpoint(reachedActions.length);
         const evaluated: EvaluatedEffect[] = [];
         for (const action of reachedActions) {
@@ -623,7 +659,7 @@ export const findCommand: RuntimeCommand = {
             printfData,
           });
         }
-        return evaluated;
+        return withDiagnostics(evaluated);
       }
 
       // Result collection for ordered results
@@ -849,7 +885,9 @@ export const findCommand: RuntimeCommand = {
           durationMs: totalMs,
           details: {
             path: searchPath,
-            resultsFound: searchResult.effects.length,
+            resultsFound: searchResult.effects.filter(
+              (effect) => effect.action.type !== "diagnostic",
+            ).length,
           },
         });
       }
@@ -861,6 +899,10 @@ export const findCommand: RuntimeCommand = {
     for (const effect of effects) {
       const { action, path: file } = effect;
       switch (action.type) {
+        case "diagnostic":
+          appendStderr(action.message);
+          exitCode = 1;
+          break;
         case "print":
           appendStdout(`${file}\n`);
           break;
@@ -1138,10 +1180,27 @@ function formatCtimeDate(date: Date): string {
 }
 
 /**
- * The phrase GNU find prints for a directory it could not read, from the
- * errno alone. Only the code is repeated: the message behind it can carry a
- * host path, which is not the sandbox's to show. Null for anything that is
- * not a filesystem error, which the caller lets propagate.
+ * The errnos a directory read can fail with that are the directory's own
+ * problem, and what GNU find prints for each. Nothing else is recoverable
+ * here: a cancellation, an execution limit, or a filesystem policy refusal
+ * carries a code of its own and must end the search, not become a line of
+ * stderr, so the phrase comes from this table and never from the error.
+ */
+const UNREADABLE_DIRECTORY_REASONS: Record<string, string> = {
+  EACCES: "Permission denied",
+  EIO: "Input/output error",
+  ELOOP: "Too many levels of symbolic links",
+  ENAMETOOLONG: "File name too long",
+  ENOENT: "No such file or directory",
+  ENOTDIR: "Not a directory",
+  EPERM: "Permission denied",
+};
+
+/**
+ * The phrase for a directory that could not be read, from the errno alone,
+ * or null when the failure is not one of those, in which case it propagates.
+ * The errno is read off `code` when the error carries one and off the
+ * `ECODE: ...` message prefix the virtual filesystems use otherwise.
  */
 function describeUnreadableDirectory(error: unknown): string | null {
   const code =
@@ -1153,21 +1212,8 @@ function describeUnreadableDirectory(error: unknown): string | null {
       : error instanceof Error
         ? /^(E[A-Z]+)\b/.exec(error.message)?.[1]
         : undefined;
-  switch (code) {
-    case "EACCES":
-    case "EPERM":
-      return "Permission denied";
-    case "ENOENT":
-      return "No such file or directory";
-    case "ENOTDIR":
-      return "Not a directory";
-    case "ELOOP":
-      return "Too many levels of symbolic links";
-    case undefined:
-      return null;
-    default:
-      return code;
-  }
+  if (code === undefined) return null;
+  return UNREADABLE_DIRECTORY_REASONS[code] ?? null;
 }
 
 /**

--- a/packages/just-bash/src/commands/find/find.unreadable.test.ts
+++ b/packages/just-bash/src/commands/find/find.unreadable.test.ts
@@ -4,14 +4,15 @@ import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
 import type { IFileSystem } from "../../fs/interface.js";
 
 /**
- * A filesystem where one directory cannot be listed, the way a home
+ * A filesystem where some directories cannot be listed, the way a home
  * directory's `.Trash` or a protected `Library` folder cannot be on macOS.
- * Both readdir entry points refuse it, since `find` prefers the typed one
- * when the filesystem offers it.
+ * Both readdir entry points refuse them, since `find` prefers the typed one
+ * when the filesystem offers it. Each failing path maps to the message its
+ * read throws with.
  */
-function withUnreadableDirectory(
+function withUnreadableDirectories(
   fs: IFileSystem,
-  unreadable: string,
+  failures: Record<string, string>,
 ): IFileSystem {
   return new Proxy(fs, {
     get(target, prop, receiver) {
@@ -21,8 +22,9 @@ function withUnreadableDirectory(
       }
       if (prop === "readdir" || prop === "readdirWithFileTypes") {
         return async (path: string, ...rest: unknown[]) => {
-          if (path === unreadable) {
-            throw new Error(`EACCES: permission denied, scandir '${path}'`);
+          const message = failures[path];
+          if (message !== undefined) {
+            throw new Error(message);
           }
           return value.call(target, path, ...rest);
         };
@@ -32,15 +34,21 @@ function withUnreadableDirectory(
   }) as IFileSystem;
 }
 
-function home(): Bash {
-  const fs = withUnreadableDirectory(
+const PERMISSION_DENIED = "EACCES: permission denied, scandir";
+
+function home(
+  failures: Record<string, string> = {
+    "/home/user/.Trash": `${PERMISSION_DENIED} '/home/user/.Trash'`,
+  },
+): Bash {
+  const fs = withUnreadableDirectories(
     new InMemoryFs({
       "/home/user/.Trash/old.txt": "gone",
       "/home/user/Documents/notes.md": "# notes",
       "/home/user/Documents/vault/.obsidian/app.json": "{}",
       "/home/user/Downloads/paper.pdf": "pdf",
     }),
-    "/home/user/.Trash",
+    failures,
   );
   return new Bash({ fs });
 }
@@ -68,7 +76,9 @@ describe("find over an unreadable directory", () => {
       "find /home/user -name 'app.json' 2>/dev/null | head -1",
     );
 
-    expect(result.stdout).toBe("/home/user/Documents/vault/.obsidian/app.json\n");
+    expect(result.stdout).toBe(
+      "/home/user/Documents/vault/.obsidian/app.json\n",
+    );
     expect(result.exitCode).toBe(0);
   });
 
@@ -87,5 +97,52 @@ describe("find over an unreadable directory", () => {
     );
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);
+  });
+
+  const TWO_UNREADABLE = {
+    "/home/user/.Trash": `${PERMISSION_DENIED} '/home/user/.Trash'`,
+    "/home/user/Documents/vault": `${PERMISSION_DENIED} '/home/user/Documents/vault'`,
+  };
+  const TWO_MESSAGES =
+    "find: /home/user/.Trash: Permission denied\nfind: /home/user/Documents/vault: Permission denied\n";
+
+  it("reports every unreadable directory in traversal order", async () => {
+    const result = await home(TWO_UNREADABLE).exec("find /home/user -type d");
+
+    expect(result.stdout).toBe(
+      "/home/user\n/home/user/.Trash\n/home/user/Documents\n/home/user/Documents/vault\n/home/user/Downloads\n",
+    );
+    expect(result.stderr).toBe(TWO_MESSAGES);
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("keeps that order under -depth", async () => {
+    const result = await home(TWO_UNREADABLE).exec(
+      "find /home/user -depth -type d",
+    );
+
+    expect(result.stdout).toBe(
+      "/home/user/.Trash\n/home/user/Documents/vault\n/home/user/Documents\n/home/user/Downloads\n/home/user\n",
+    );
+    expect(result.stderr).toBe(TWO_MESSAGES);
+  });
+
+  it("reports a directory below -mindepth all the same", async () => {
+    const result = await home().exec(
+      "find /home/user -mindepth 2 -name '*.md'",
+    );
+
+    expect(result.stdout).toBe("/home/user/Documents/notes.md\n");
+    expect(result.stderr).toBe("find: /home/user/.Trash: Permission denied\n");
+  });
+
+  it("lets a failure that is not the directory's own end the search", async () => {
+    const result = await home({
+      "/home/user/.Trash": "ABORT_ERR: The operation was aborted",
+    }).exec("find /home/user -name '*.md'");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("ABORT_ERR");
+    expect(result.exitCode).toBe(1);
   });
 });

--- a/packages/just-bash/src/commands/find/find.unreadable.test.ts
+++ b/packages/just-bash/src/commands/find/find.unreadable.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+import type { IFileSystem } from "../../fs/interface.js";
+
+/**
+ * A filesystem where one directory cannot be listed, the way a home
+ * directory's `.Trash` or a protected `Library` folder cannot be on macOS.
+ * Both readdir entry points refuse it, since `find` prefers the typed one
+ * when the filesystem offers it.
+ */
+function withUnreadableDirectory(
+  fs: IFileSystem,
+  unreadable: string,
+): IFileSystem {
+  return new Proxy(fs, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") {
+        return value;
+      }
+      if (prop === "readdir" || prop === "readdirWithFileTypes") {
+        return async (path: string, ...rest: unknown[]) => {
+          if (path === unreadable) {
+            throw new Error(`EACCES: permission denied, scandir '${path}'`);
+          }
+          return value.call(target, path, ...rest);
+        };
+      }
+      return value.bind(target);
+    },
+  }) as IFileSystem;
+}
+
+function home(): Bash {
+  const fs = withUnreadableDirectory(
+    new InMemoryFs({
+      "/Users/jeremy/.Trash/old.txt": "gone",
+      "/Users/jeremy/Documents/notes.md": "# notes",
+      "/Users/jeremy/Documents/vault/.obsidian/app.json": "{}",
+      "/Users/jeremy/Downloads/paper.pdf": "pdf",
+    }),
+    "/Users/jeremy/.Trash",
+  );
+  return new Bash({ fs });
+}
+
+describe("find over an unreadable directory", () => {
+  it("names the directory it could not read and keeps going", async () => {
+    const result = await home().exec("find /Users/jeremy -name '*.md'");
+
+    expect(result.stdout).toBe("/Users/jeremy/Documents/notes.md\n");
+    expect(result.stderr).toBe("find: /Users/jeremy/.Trash: Permission denied\n");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("still lists the directory itself, as GNU find does", async () => {
+    const result = await home().exec("find /Users/jeremy -type d -name '.*'");
+
+    expect(result.stdout).toBe(
+      "/Users/jeremy/.Trash\n/Users/jeremy/Documents/vault/.obsidian\n",
+    );
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("keeps the results reachable through a pipeline", async () => {
+    const result = await home().exec(
+      "find /Users/jeremy -name 'app.json' 2>/dev/null | head -1",
+    );
+
+    expect(result.stdout).toBe("/Users/jeremy/Documents/vault/.obsidian/app.json\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not call a directory it could not read empty", async () => {
+    const result = await home().exec("find /Users/jeremy -type d -empty");
+
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toBe("find: /Users/jeremy/.Trash: Permission denied\n");
+  });
+
+  it("does not descend into it when it is not asked to read it", async () => {
+    const result = await home().exec("find /Users/jeremy -maxdepth 1 -type d");
+
+    expect(result.stdout).toBe(
+      "/Users/jeremy\n/Users/jeremy/.Trash\n/Users/jeremy/Documents\n/Users/jeremy/Downloads\n",
+    );
+    expect(result.stderr).toBe("");
+    expect(result.exitCode).toBe(0);
+  });
+});

--- a/packages/just-bash/src/commands/find/find.unreadable.test.ts
+++ b/packages/just-bash/src/commands/find/find.unreadable.test.ts
@@ -35,55 +35,55 @@ function withUnreadableDirectory(
 function home(): Bash {
   const fs = withUnreadableDirectory(
     new InMemoryFs({
-      "/Users/jeremy/.Trash/old.txt": "gone",
-      "/Users/jeremy/Documents/notes.md": "# notes",
-      "/Users/jeremy/Documents/vault/.obsidian/app.json": "{}",
-      "/Users/jeremy/Downloads/paper.pdf": "pdf",
+      "/home/user/.Trash/old.txt": "gone",
+      "/home/user/Documents/notes.md": "# notes",
+      "/home/user/Documents/vault/.obsidian/app.json": "{}",
+      "/home/user/Downloads/paper.pdf": "pdf",
     }),
-    "/Users/jeremy/.Trash",
+    "/home/user/.Trash",
   );
   return new Bash({ fs });
 }
 
 describe("find over an unreadable directory", () => {
   it("names the directory it could not read and keeps going", async () => {
-    const result = await home().exec("find /Users/jeremy -name '*.md'");
+    const result = await home().exec("find /home/user -name '*.md'");
 
-    expect(result.stdout).toBe("/Users/jeremy/Documents/notes.md\n");
-    expect(result.stderr).toBe("find: /Users/jeremy/.Trash: Permission denied\n");
+    expect(result.stdout).toBe("/home/user/Documents/notes.md\n");
+    expect(result.stderr).toBe("find: /home/user/.Trash: Permission denied\n");
     expect(result.exitCode).toBe(1);
   });
 
   it("still lists the directory itself, as GNU find does", async () => {
-    const result = await home().exec("find /Users/jeremy -type d -name '.*'");
+    const result = await home().exec("find /home/user -type d -name '.*'");
 
     expect(result.stdout).toBe(
-      "/Users/jeremy/.Trash\n/Users/jeremy/Documents/vault/.obsidian\n",
+      "/home/user/.Trash\n/home/user/Documents/vault/.obsidian\n",
     );
     expect(result.exitCode).toBe(1);
   });
 
   it("keeps the results reachable through a pipeline", async () => {
     const result = await home().exec(
-      "find /Users/jeremy -name 'app.json' 2>/dev/null | head -1",
+      "find /home/user -name 'app.json' 2>/dev/null | head -1",
     );
 
-    expect(result.stdout).toBe("/Users/jeremy/Documents/vault/.obsidian/app.json\n");
+    expect(result.stdout).toBe("/home/user/Documents/vault/.obsidian/app.json\n");
     expect(result.exitCode).toBe(0);
   });
 
   it("does not call a directory it could not read empty", async () => {
-    const result = await home().exec("find /Users/jeremy -type d -empty");
+    const result = await home().exec("find /home/user -type d -empty");
 
     expect(result.stdout).toBe("");
-    expect(result.stderr).toBe("find: /Users/jeremy/.Trash: Permission denied\n");
+    expect(result.stderr).toBe("find: /home/user/.Trash: Permission denied\n");
   });
 
   it("does not descend into it when it is not asked to read it", async () => {
-    const result = await home().exec("find /Users/jeremy -maxdepth 1 -type d");
+    const result = await home().exec("find /home/user -maxdepth 1 -type d");
 
     expect(result.stdout).toBe(
-      "/Users/jeremy\n/Users/jeremy/.Trash\n/Users/jeremy/Documents\n/Users/jeremy/Downloads\n",
+      "/home/user\n/home/user/.Trash\n/home/user/Documents\n/home/user/Downloads\n",
     );
     expect(result.stderr).toBe("");
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
## Problem

`find` over a tree that holds one directory the process cannot read returns nothing at all.

```js
// /home/user/.Trash exists but readdir on it throws EACCES
await bash.exec("find /home/user -name '*.md'");
// stdout: ""   stderr: "find: EACCES: permission denied, scandir '<path>'\n"   exitCode: 1

await bash.exec("find /home/user -name '*.md' 2>/dev/null | head -1");
// stdout: ""   stderr: ""   exitCode: 0
```

Every macOS home directory holds at least one such directory (`.Trash`, and several under `Library`), so a recursive `find` over a mounted home directory never returns a result. In the piped form, which is the shape an agent writes almost every time, the failure is byte-identical to a genuine no-match: exit 0, no output, no stderr. In a transcript I have from an agent searching a home directory for an Obsidian vault, nine of fourteen shell calls were `find` over the mount and every one that crossed an unreadable directory came back empty; the one aimed at `Library/Application Support` would have landed on `obsidian/obsidian.json`, which names the vault. `rg` walks past the same directory, so the two commands disagree about whether the tree has anything in it, which is what makes this hard to attribute from the inside.

GNU find prints `find: '/home/user/.Trash': Permission denied`, continues with everything else, and exits 1 at the end.

## Cause

`processNode` in `find.ts` wraps `lstat` in a `try`/`catch` and skips the node on failure, but the two `readdir` calls beneath it are bare:

```ts
entriesWithTypes = await ctx.fs.readdirWithFileTypes(currentPath);
...
entries = await ctx.fs.readdir(currentPath);
```

A rejection there propagates out of the `Promise.all` over the batch and out of the traversal, so one unreadable directory ends the whole search. The existing find tests build their trees on `InMemoryFs`, which never refuses a `readdir`, so nothing exercised the path.

## Fix

Both `readdir` calls sit in one `try`/`catch`. On failure the directory is reported on stderr as `find: <path>: <reason>`, `exitCode` becomes 1, and traversal continues; the directory itself is still evaluated and printed, as GNU does. The reason is derived from the errno alone (`EACCES`/`EPERM` read as `Permission denied`; `ENOENT`, `ENOTDIR`, `ELOOP` get their usual phrases; anything else prints its code), so a host path in the underlying message never reaches the output. An error with no errno shape is rethrown, so an abort still aborts.

## Scope

Unchanged: the `lstat` failure path, the traversal budget checkpoints, `-empty` (an unreadable directory is not called empty; `entries` stays null), and the maxdepth optimization, under which a directory at the depth limit is never read and so never reported, as before.

Not addressed, deliberately: `ls -R` over the same tree. I have not checked whether it has the same shape, and it is a separate command.

## Tests

`find.unreadable.test.ts` builds an in-memory home directory behind a `Proxy` whose `readdir` and `readdirWithFileTypes` refuse one path, and asserts: results past the unreadable directory are returned with the message on stderr and exit 1; the directory itself is still listed; the results survive `2>/dev/null | head -1`; `-empty` does not claim it; and `-maxdepth 1` neither reads nor reports it. Four of the five fail without the fix, verified by stashing this change and re-running; the maxdepth case passes either way and is there to pin that behavior. The find suite is 13 files, 226 tests, all passing. The full package suite has hundreds of pre-existing failures in the `js-exec` and `python3` test files in my environment, present on `main` without this change (345 failing there against 325 with it, none in `find`), verified by running `main` separately, not inferred. What the test cannot prove: behavior against a real `ReadWriteFs` on a `chmod 000` directory, which I reproduced by hand but did not automate, since it depends on not running the suite as root.

---

Authored with Claude Fable 5.1
