### PR TITLE
fix(expansion): don't trip nounset on a whole-word quoted ${var:-default}

### DIFF
--- a/.changeset/nounset-quoted-default-expansion.md
+++ b/.changeset/nounset-quoted-default-expansion.md
@@ -1,0 +1,16 @@
+---
+"just-bash": patch
+---
+
+Fix `set -u` reporting "unbound variable" for `"${var:-default}"` and friends when the expansion is the entire double-quoted word.
+
+`echo "${U:-d}"` aborted the script while `echo "${U:-d}b"` and `echo "a${U:-d}"` were fine, because a word that is exactly one double-quoted part holding exactly one `${var<op>word}` is routed through `handleArrayDefaultValue()`, which read the variable with nounset still armed. Every operator that is supposed to suppress nounset was affected: `:-`, `-`, `:=`, `=`, `:+` and `+`.
+
+This broke the idiomatic guard for scripts that run both inside and outside CI:
+
+```bash
+set -euo pipefail
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then render >> "$GITHUB_STEP_SUMMARY"; fi
+```
+
+`"${#var}"` and a bare `"${var}"` still report an unbound variable under `set -u`, as in GNU bash.

--- a/packages/just-bash/src/comparison-tests/fixtures/nounset-quoted-default.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/nounset-quoted-default.comparison.fixtures.json
@@ -17,8 +17,9 @@
     "command": "set -u; unset JB_NOUNSET_J; echo \"${JB_NOUNSET_J}\"; echo reached",
     "files": {},
     "stdout": "",
-    "stderr": "/bin/bash: JB_NOUNSET_J: unbound variable\n",
-    "exitCode": 127
+    "stderr": "/bin/bash: line 1: JB_NOUNSET_J: unbound variable\n",
+    "exitCode": 127,
+    "locked": true
   },
   "42bf6bb9eaecafe8": {
     "command": "set -euo pipefail\nunset GITHUB_STEP_SUMMARY\nif [ -n \"${GITHUB_STEP_SUMMARY:-}\" ]; then echo \"writing to $GITHUB_STEP_SUMMARY\"; else echo \"no step summary\"; fi\nGITHUB_STEP_SUMMARY=summary.md\nif [ -n \"${GITHUB_STEP_SUMMARY:-}\" ]; then echo \"report\" >> \"$GITHUB_STEP_SUMMARY\"; fi\ncat summary.md",
@@ -66,8 +67,9 @@
     "command": "set -u; unset JB_NOUNSET_I; echo \"${#JB_NOUNSET_I}\"; echo reached",
     "files": {},
     "stdout": "",
-    "stderr": "/bin/bash: JB_NOUNSET_I: unbound variable\n",
-    "exitCode": 127
+    "stderr": "/bin/bash: line 1: JB_NOUNSET_I: unbound variable\n",
+    "exitCode": 127,
+    "locked": true
   },
   "c1e67d7cfd1e8f6f": {
     "command": "set -u; unset JB_NOUNSET_E; echo \"[${JB_NOUNSET_E:+alt}]\"",

--- a/packages/just-bash/src/comparison-tests/fixtures/nounset-quoted-default.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/nounset-quoted-default.comparison.fixtures.json
@@ -1,0 +1,79 @@
+{
+  "0527bcbdf93ecea6": {
+    "command": "set -u; unset JB_NOUNSET_F; echo \"[${JB_NOUNSET_F+alt}]\"",
+    "files": {},
+    "stdout": "[]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "21803fe924c962d8": {
+    "command": "set -u; unset JB_NOUNSET_D; echo \"${JB_NOUNSET_D=assigned}\"; echo \"$JB_NOUNSET_D\"",
+    "files": {},
+    "stdout": "assigned\nassigned\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2f981e30be51fdc9": {
+    "command": "set -u; unset JB_NOUNSET_J; echo \"${JB_NOUNSET_J}\"; echo reached",
+    "files": {},
+    "stdout": "",
+    "stderr": "/bin/bash: JB_NOUNSET_J: unbound variable\n",
+    "exitCode": 127
+  },
+  "42bf6bb9eaecafe8": {
+    "command": "set -euo pipefail\nunset GITHUB_STEP_SUMMARY\nif [ -n \"${GITHUB_STEP_SUMMARY:-}\" ]; then echo \"writing to $GITHUB_STEP_SUMMARY\"; else echo \"no step summary\"; fi\nGITHUB_STEP_SUMMARY=summary.md\nif [ -n \"${GITHUB_STEP_SUMMARY:-}\" ]; then echo \"report\" >> \"$GITHUB_STEP_SUMMARY\"; fi\ncat summary.md",
+    "files": {},
+    "stdout": "no step summary\nreport\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5f5535bb94da437c": {
+    "command": "set -u; unset JB_NOUNSET_C; echo \"${JB_NOUNSET_C:=assigned}\"; echo \"$JB_NOUNSET_C\"",
+    "files": {},
+    "stdout": "assigned\nassigned\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "62c4ed942dfeee5a": {
+    "command": "set -u; JB_NOUNSET_G=value; JB_NOUNSET_H=; echo \"${JB_NOUNSET_G:-fallback}\"; echo \"[${JB_NOUNSET_H:-fallback}]\"; echo \"[${JB_NOUNSET_H-fallback}]\"",
+    "files": {},
+    "stdout": "value\n[fallback]\n[]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "81e8cd70967cddeb": {
+    "command": "set -u; unset JB_NOUNSET_ARR; echo \"${JB_NOUNSET_ARR[@]:-fallback}\"; echo \"[${JB_NOUNSET_ARR[@]:+alt}]\"",
+    "files": {},
+    "stdout": "fallback\n[]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ae1a1d7f33660417": {
+    "command": "set -u; unset JB_NOUNSET_A; echo \"${JB_NOUNSET_A:-fallback}\"",
+    "files": {},
+    "stdout": "fallback\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "aeea8559e831ba3b": {
+    "command": "set -u; unset JB_NOUNSET_B; echo \"${JB_NOUNSET_B-fallback}\"; echo \"[${JB_NOUNSET_B-}]\"",
+    "files": {},
+    "stdout": "fallback\n[]\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b6615d717e9e57ba": {
+    "command": "set -u; unset JB_NOUNSET_I; echo \"${#JB_NOUNSET_I}\"; echo reached",
+    "files": {},
+    "stdout": "",
+    "stderr": "/bin/bash: JB_NOUNSET_I: unbound variable\n",
+    "exitCode": 127
+  },
+  "c1e67d7cfd1e8f6f": {
+    "command": "set -u; unset JB_NOUNSET_E; echo \"[${JB_NOUNSET_E:+alt}]\"",
+    "files": {},
+    "stdout": "[]\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/nounset-quoted-default.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/nounset-quoted-default.comparison.test.ts
@@ -103,10 +103,13 @@ describe("nounset with a whole-word quoted default - GNU Bash Comparison", () =>
   });
 
   // `${#var}` and a bare `${var}` must still abort the script: no operator
-  // suppresses nounset there. Exit codes are excluded because bash -c reports
-  // an expansion error as 127 while just-bash reports 1 -- an unrelated
-  // pre-existing difference. src/interpreter/expansion/nounset-quoted-default.test.ts
-  // pins just-bash's own status and message.
+  // suppresses nounset there, so nothing is printed and `echo reached` never
+  // runs. Exit codes are excluded because bash -c reports an expansion error
+  // as 127 while just-bash reports 1 -- an unrelated pre-existing difference;
+  // src/interpreter/expansion/nounset-quoted-default.test.ts pins just-bash's
+  // own status and message exactly. Both fixtures are locked to their Linux
+  // (bash 5) diagnostic, which inserts "line 1: " where macOS bash 3.2 does
+  // not; the recorded stderr is never compared, only kept from drifting.
   const stdoutOnly = { compareExitCode: false };
 
   it("still reports an unbound variable for a whole-word quoted ${#var}", async () => {

--- a/packages/just-bash/src/comparison-tests/nounset-quoted-default.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/nounset-quoted-default.comparison.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Under `set -u`, a word that is exactly one double-quoted part holding exactly
+ * one `${var<op>word}` took a dedicated array-expansion path that probed the
+ * variable with nounset still armed. Adjacent literal text ("${U:-d}b") took the
+ * general path and already behaved, which made the failure look arbitrary.
+ */
+describe("nounset with a whole-word quoted default - GNU Bash Comparison", () => {
+  let testDirectory: string;
+
+  beforeEach(async () => {
+    testDirectory = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDirectory);
+  });
+
+  it("uses the default for a whole-word quoted ${var:-word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_A; echo "${JB_NOUNSET_A:-fallback}"',
+    );
+  });
+
+  it("uses the default for a whole-word quoted ${var-word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_B; echo "${JB_NOUNSET_B-fallback}"; echo "[${JB_NOUNSET_B-}]"',
+    );
+  });
+
+  it("assigns and expands a whole-word quoted ${var:=word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_C; echo "${JB_NOUNSET_C:=assigned}"; echo "$JB_NOUNSET_C"',
+    );
+  });
+
+  it("assigns and expands a whole-word quoted ${var=word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_D; echo "${JB_NOUNSET_D=assigned}"; echo "$JB_NOUNSET_D"',
+    );
+  });
+
+  it("yields nothing for a whole-word quoted ${var:+word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_E; echo "[${JB_NOUNSET_E:+alt}]"',
+    );
+  });
+
+  it("yields nothing for a whole-word quoted ${var+word}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_F; echo "[${JB_NOUNSET_F+alt}]"',
+    );
+  });
+
+  it("keeps honouring set values and the empty/unset distinction", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; JB_NOUNSET_G=value; JB_NOUNSET_H=; echo "${JB_NOUNSET_G:-fallback}"; echo "[${JB_NOUNSET_H:-fallback}]"; echo "[${JB_NOUNSET_H-fallback}]"',
+    );
+  });
+
+  it("runs the GitHub Actions summary guard both ways", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      [
+        "set -euo pipefail",
+        "unset GITHUB_STEP_SUMMARY",
+        'if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then echo "writing to $GITHUB_STEP_SUMMARY"; else echo "no step summary"; fi',
+        "GITHUB_STEP_SUMMARY=summary.md",
+        'if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then echo "report" >> "$GITHUB_STEP_SUMMARY"; fi',
+        "cat summary.md",
+      ].join("\n"),
+    );
+  });
+
+  // `${#var}` and a bare `${var}` must still abort the script: no operator
+  // suppresses nounset there. Exit codes are excluded because bash -c reports
+  // an expansion error as 127 while just-bash reports 1 -- an unrelated
+  // pre-existing difference. src/interpreter/expansion/nounset-quoted-default.test.ts
+  // pins just-bash's own status and message.
+  const stdoutOnly = { compareExitCode: false };
+
+  it("still reports an unbound variable for a whole-word quoted ${#var}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_I; echo "${#JB_NOUNSET_I}"; echo reached',
+      stdoutOnly,
+    );
+  });
+
+  it("still reports an unbound variable for a whole-word quoted ${var}", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_J; echo "${JB_NOUNSET_J}"; echo reached',
+      stdoutOnly,
+    );
+  });
+
+  it("uses the default for a whole-word quoted array default", async () => {
+    const env = await setupFiles(testDirectory, {});
+    await compareOutputs(
+      env,
+      testDirectory,
+      'set -u; unset JB_NOUNSET_ARR; echo "${JB_NOUNSET_ARR[@]:-fallback}"; echo "[${JB_NOUNSET_ARR[@]:+alt}]"',
+    );
+  });
+});

--- a/packages/just-bash/src/interpreter/expansion/array-prefix-suffix.ts
+++ b/packages/just-bash/src/interpreter/expansion/array-prefix-suffix.ts
@@ -121,7 +121,9 @@ export async function handleArrayDefaultValue(
     // Outer parameter is a scalar variable
     const varName = paramPart.parameter;
     const isSet = await isVariableSet(ctx, varName);
-    const varValue = await getVariable(ctx, varName);
+    // ${var:-word}, ${var:=word} and ${var:+word} all handle unset variables
+    // themselves, so nounset must not fire while probing the current value.
+    const varValue = await getVariable(ctx, varName, false);
     const isEmpty = varValue === "";
     const checkEmpty = op.checkEmpty ?? false;
 

--- a/packages/just-bash/src/interpreter/expansion/nounset-quoted-default.test.ts
+++ b/packages/just-bash/src/interpreter/expansion/nounset-quoted-default.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../../Bash.js";
+
+/**
+ * Regression tests for nounset firing on a word that is exactly one
+ * double-quoted part holding exactly one `${var<op>word}`. That shape is routed
+ * through handleArrayDefaultValue(), which used to read the variable with
+ * nounset still armed; anything with adjacent literal text took the general
+ * path and behaved correctly.
+ */
+describe("nounset with a whole-word quoted parameter expansion", () => {
+  it("does not fire for ${var:-word} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec('set -u\necho "${JB_UNSET:-fallback}"');
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("fallback\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not fire for ${var-word} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      'set -u\necho "${JB_UNSET-fallback}"\necho "[${JB_UNSET-}]"',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("fallback\n[]\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not fire for ${var:=word} and assigns the default", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      'set -u\necho "${JB_UNSET:=assigned}"\necho "$JB_UNSET"',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("assigned\nassigned\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not fire for ${var=word} and assigns the default", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      'set -u\necho "${JB_UNSET=assigned}"\necho "$JB_UNSET"',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("assigned\nassigned\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not fire for ${var:+word} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec('set -u\necho "[${JB_UNSET:+alt}]"');
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("[]\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("does not fire for ${var+word} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec('set -u\necho "[${JB_UNSET+alt}]"');
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("[]\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still expands a set variable through the same shape", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      'set -u\nJB_SET=value\nJB_EMPTY=\necho "${JB_SET:-fallback}"\necho "[${JB_EMPTY:-fallback}]"\necho "[${JB_EMPTY-fallback}]"\necho "[${JB_SET:+alt}]"',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("value\n[fallback]\n[]\n[alt]\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('runs the `[ -n "${VAR:-}" ]` guard under set -euo pipefail', async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      [
+        "set -euo pipefail",
+        'if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then echo "writing to $GITHUB_STEP_SUMMARY"; else echo "no step summary"; fi',
+        "GITHUB_STEP_SUMMARY=/tmp/summary.md",
+        'if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then echo "report" >> "$GITHUB_STEP_SUMMARY"; fi',
+        "cat /tmp/summary.md",
+      ].join("\n"),
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("no step summary\nreport\n");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("still fires for ${#var} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec('set -u\necho "${#JB_UNSET}"\necho reached');
+    expect(result.stderr).toBe("bash: JB_UNSET: unbound variable\n");
+    expect(result.stdout).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("still fires for a bare ${var} as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec('set -u\necho "${JB_UNSET}"\necho reached');
+    expect(result.stderr).toBe("bash: JB_UNSET: unbound variable\n");
+    expect(result.stdout).toBe("");
+    expect(result.exitCode).toBe(1);
+  });
+
+  it("does not fire for an unset array default as a whole double-quoted word", async () => {
+    const env = new Bash();
+    const result = await env.exec(
+      'set -u\necho "${JB_ARR[@]:-fallback}"\necho "[${JB_ARR[@]:+alt}]"',
+    );
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toBe("fallback\n[]\n");
+    expect(result.exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
## The bug

Under `set -u`, a word that is **exactly one double-quoted part containing exactly one `${var<op>word}`** reports "unbound variable", even though the operator is supposed to suppress nounset. Adjacent literal text takes a different code path and already worked, which made the failure look arbitrary:

```bash
set -u; echo "${U:-d}"    # before: bash: U: unbound variable   GNU bash: d
set -u; echo "${U:-d}b"   # db     (already correct)
set -u; echo "a${U:-d}"   # ad     (already correct)
```

Every operator that suppresses nounset was affected: `:-`, `-`, `:=`, `=`, `:+`, `+`.

The practical impact is that the idiomatic "works inside and outside GitHub Actions" guard could not run at all:

```bash
set -euo pipefail
if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then render >> "$GITHUB_STEP_SUMMARY"; fi
```

## Root cause

That exact AST shape (`wordParts.length === 1` && `DoubleQuoted` && `dqPart.parts.length === 1` && `DefaultValue`/`UseAlternative`/`AssignDefault`) is claimed by `handleArrayDefaultValue()` in `packages/just-bash/src/interpreter/expansion/array-prefix-suffix.ts`, reached from `word-glob-expansion.ts:276`. Its scalar branch probed the current value with `getVariable(ctx, varName)` at `array-prefix-suffix.ts:124`, and `getVariable`'s `checkNounset` parameter defaults to `true` (`expansion/variable.ts:119-124`), so nounset fired before the operator ever got a chance to supply the default.

The general path already gets this right — `expansion.ts:1000-1009` computes `skipNounset` for `DefaultValue`/`AssignDefault`/`UseAlternative`/`ErrorIfUnset` and passes `!skipNounset`. This change makes the scalar branch agree by passing `false`.

## Scope of the fix

One line plus a comment. Checked and deliberately left alone:

- The **array branch** (`arrayMatch`) of the same function reads through `getArrayElements()` / `ctx.state.env.get()`, neither of which consults nounset — verified `"${arr[@]:-d}"` and `"${arr[@]:+d}"` were already correct, and there is a regression test for them.
- `isVariableSet()` does not check nounset either, so it needed no change.
- `"${#U}"` and a bare `"${U}"` **still** report an unbound variable under `set -u`, matching GNU bash. There are explicit tests pinning that.

Behaviour changes only for the previously-throwing case: for a set variable, `checkNounset` has no effect on the returned value.

## Verification

Every operator now matches system bash byte for byte via `pnpm dev:exec --real-bash`:

```
$ printf 'set -u\necho "[${U:-d}]"\necho "[${U-d}]"\necho "[${U:+d}]"\necho "[${U+d}]"\necho "[${A:=d1}][$A]"\necho "[${B=d2}][$B]"\n' | pnpm dev:exec --real-bash
just-bash:  "[d]\n[d]\n[]\n[]\n[d1][d1]\n[d2][d2]\n"
real bash:  "[d]\n[d]\n[]\n[]\n[d1][d1]\n[d2][d2]\n"
```

## Tests

- `src/comparison-tests/nounset-quoted-default.comparison.test.ts` (+ recorded fixtures) — all six operators as whole double-quoted words, the set/empty/unset distinction, the array default, the `[ -n "${VAR:-}" ]` guard end to end, and the two shapes that must still error.
- `src/interpreter/expansion/nounset-quoted-default.test.ts` — the same matrix asserting full stdout **and** stderr plus exit status, including `bash: JB_UNSET: unbound variable\n` / exit 1 for `"${#JB_UNSET}"` and `"${JB_UNSET}"`.

The two must-still-error comparison cases pass `compareExitCode: false`: `bash -c` reports an expansion error as **127** while just-bash reports **1**. That is a pre-existing, unrelated divergence I did not touch; the unit tests pin just-bash's own status and message, and the comparison still asserts stdout parity (nothing printed, `echo reached` never runs).

Reverting just the changed line makes 5 tests in each new file fail, and restoring it makes them pass.

## Validation

`pnpm typecheck`, `pnpm lint` (incl. banned-patterns + workflow security), and `pnpm knip` are clean. `pnpm test:run` is 15632 passed / 6 failed — the 6 failures are pre-existing and environmental (Python WASM 5s timeouts and real-DNS lookups in `src/security/**` and `src/network/allow-list/dns-rebinding-integration.test.ts`); they reproduce identically with this change reverted.

## Credit

Reported downstream as ai-ecoverse/slicc#2978, filed there as "`set -u` expands variables in a non-taken `if` branch". That diagnosis was wrong — untaken branches are never evaluated — but the report is what surfaced this, and the guard in it is the real-world script that could not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
