### PR TITLE
fix(arithmetic): run nested command substitution in the current shell state

### DIFF
--- a/.changeset/arith-command-substitution-state.md
+++ b/.changeset/arith-command-substitution-state.md
@@ -1,0 +1,5 @@
+---
+"just-bash": patch
+---
+
+Run a command substitution nested inside `$(( ))`, `(( ))` or an array subscript against the current shell state instead of a detached shell seeded from the initial environment. `X=abc; echo $(( $(echo "$X" | wc -c) ))` returned `1` (GNU bash: `4`) because `$X` was unset inside the substitution — exported variables, functions, the working directory and `local`s were all invisible too. The substitution's output is now spliced into the expression and parsed as arithmetic the way bash does, so `$(( $(echo "1 + 2") ))` is `3` and unparsable output raises an arithmetic syntax error rather than silently evaluating to `0`.

--- a/packages/just-bash/src/comparison-tests/README.md
+++ b/packages/just-bash/src/comparison-tests/README.md
@@ -120,6 +120,11 @@ When recording:
 Currently locked fixtures:
 - `ls -R` - Uses Linux-style output with ".:" header
 - `cat -n` with multiple files - Uses continuous line numbering (Linux behavior)
+- Arithmetic syntax errors in `arithmetic-command-substitution-isolation` - Holds
+  the Linux `stderr`. bash words this message differently per version ("syntax
+  error" vs "arithmetic syntax error") and numbers the line differently, so
+  re-recording on macOS would otherwise drift. Only `stdout` and the exit code
+  are compared, so the recorded `stderr` is documentation.
 
 ## API Reference
 

--- a/packages/just-bash/src/comparison-tests/arithmetic-command-substitution-isolation.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/arithmetic-command-substitution-isolation.comparison.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * Two properties of a command substitution inside `$(( ))` that the state-sharing
+ * fix has to preserve: it is still a subshell (its mutations are discarded), and
+ * its output is still *data* (bash re-parses it as arithmetic but does not run
+ * expansions on it, so a `$(...)` reached that way is a syntax error).
+ *
+ * The array-subscript case is the documented exception - bash does expand a
+ * subscript reached through data. See spec-tests bugs.test.sh, which records
+ * that as bash behaviour.
+ */
+describe("arithmetic command substitution isolation - GNU Bash Comparison", () => {
+  let testDirectory: string;
+
+  beforeEach(async () => {
+    testDirectory = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDirectory);
+  });
+
+  describe("subshell isolation is preserved", () => {
+    it("discards assignments made inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'K=1\necho $(( $(K=99; echo 2) ))\necho "K=$K"',
+      );
+    });
+
+    it("discards a cd made inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest "$PWD" = "$before" && echo same',
+      );
+    });
+
+    it("discards a function defined inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "echo $(( $(f() { :; }; echo 1) ))\ntype f >/dev/null 2>&1 && echo leaked || echo isolated",
+      );
+    });
+
+    it("discards a shell option set inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'echo $(( $(set -u; echo 1) ))\necho "[$UNSET_VAR] status=$?"',
+      );
+    });
+
+    it("discards a shopt set inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "echo $(( $(shopt -s nullglob; echo 1) ))\nshopt -q nullglob && echo leaked || echo isolated",
+      );
+    });
+
+    it("discards a variable attribute set inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'echo $(( $(declare -i N; echo 1) ))\nN="2+3"\necho "N=$N"',
+      );
+    });
+  });
+
+  describe("substitution output is data, not script", () => {
+    it("rejects a substitution reached through variable indirection", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'a=\'$(echo 1)\'\nb=a\necho "[$(( b ))]"\necho "status=$?"',
+      );
+    });
+
+    it("rejects a substitution present in the substitution output", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'v=\'$(echo 1)\'\necho "[$(( $(echo v) ))]"\necho "status=$?"',
+      );
+    });
+
+    it("still expands a substitution in an array subscript from data", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "a=(0 1 2)\nb=(3 4 5)\nsub='a[$(echo 2)]'\necho \"${b[sub]}\"",
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/comparison-tests/arithmetic-command-substitution.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/arithmetic-command-substitution.comparison.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, it } from "vitest";
+import {
+  cleanupTestDir,
+  compareOutputs,
+  createTestDir,
+  setupFiles,
+} from "./fixture-runner.js";
+
+/**
+ * A `$(...)` / backtick substitution nested inside `$(( ))` or `(( ))` runs in
+ * the current shell state, so it sees everything the script has assigned. It
+ * used to run in a detached shell seeded from the initial environment, which
+ * silently produced a plausible wrong number.
+ *
+ * Reported downstream as ai-ecoverse/slicc#2978.
+ */
+describe("arithmetic command substitution - GNU Bash Comparison", () => {
+  let testDirectory: string;
+
+  beforeEach(async () => {
+    testDirectory = await createTestDir();
+  });
+
+  afterEach(async () => {
+    await cleanupTestDir(testDirectory);
+  });
+
+  describe("variable visibility", () => {
+    it("sees a plain variable assigned by the script", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=abc\necho $(( $(echo "$X" | wc -c) ))',
+      );
+    });
+
+    it("does not fall back to a default for a variable that is set", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "X=abc\necho $(( $(echo ${X:-DEFAULT} | wc -c) ))",
+      );
+    });
+
+    it("sees an exported variable", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'export EE=zz\necho $(( $(echo "${EE:-none}" | wc -c) ))',
+      );
+    });
+
+    it("sees a function defined by the script", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "f() { echo 5; }\necho $(( $(f) + 1 ))",
+      );
+    });
+
+    it("sees a variable assigned inside a function body", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'g() { local L=wxyz; echo $(( $(echo "$L" | wc -c) )); }\ng',
+      );
+    });
+
+    it("sees the script's working directory", async () => {
+      const env = await setupFiles(testDirectory, { "sub/marker.txt": "m\n" });
+      await compareOutputs(
+        env,
+        testDirectory,
+        "cd sub\necho $(( $(ls | wc -l) ))",
+      );
+    });
+  });
+
+  describe("every arithmetic entry point agrees", () => {
+    it("evaluates the backtick form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=abc\necho $(( `echo "$X" | wc -c` ))',
+      );
+    });
+
+    it("evaluates the (( )) command form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=abc\n(( n = $(echo "$X" | wc -c) ))\necho $n',
+      );
+    });
+
+    it("evaluates the let form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=abc\nlet "m = $(echo "$X" | wc -c)"\necho $m',
+      );
+    });
+
+    it("evaluates the assignment form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=abc\na=$(( $(echo "$X" | wc -c) ))\necho $a',
+      );
+    });
+
+    it("evaluates an array subscript", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'arr=(zero one two three)\nX=ab\necho ${arr[$(echo "$X" | wc -c)]}',
+      );
+    });
+  });
+
+  describe("quoting is preserved", () => {
+    it("keeps repeated spaces inside a quoted substitution argument", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'Q="a  b"\necho $(( $(printf %s "$Q" | wc -c) ))',
+      );
+    });
+
+    it("does not re-expand variable data as shell syntax in the backtick form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "Q='$(echo PWNED)'\necho $(( `printf %s \"$Q\" | wc -c` ))",
+      );
+    });
+
+    it("does not re-expand variable data as shell syntax in the $() form", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "Q='$(echo PWNED)'\necho $(( $(printf %s \"$Q\" | wc -c) ))",
+      );
+    });
+  });
+
+  describe("nesting", () => {
+    it("evaluates a substitution nested in a substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'X=7\necho $(( $(echo $(echo "$X")) ))',
+      );
+    });
+
+    it("evaluates arithmetic nested inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        "X=4\necho $(( $(echo $(( X * 2 ))) + 1 ))",
+      );
+    });
+  });
+
+  describe("substitution output is spliced as arithmetic, not parseInt'd", () => {
+    it("evaluates an operator expression in the output", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo "1 + 2") ))');
+    });
+
+    it("trims surrounding whitespace", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo " 7 ") ))');
+    });
+
+    it("reads a bare word in the output as a variable name", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, "v=9\necho $(( $(echo v) ))");
+    });
+
+    it("honours hex notation in the output", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo "0x10") ))');
+    });
+
+    it("honours octal notation in the output", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo "010") ))');
+    });
+  });
+
+  describe("empty and failing substitutions", () => {
+    it("treats empty output as 0 when it is the whole expression", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo "") ))');
+    });
+
+    it("treats a silent successful command as 0", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, "echo $(( $(true) ))");
+    });
+
+    it("treats a failing command with no output as 0", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, "echo $(( $(false) ))");
+    });
+
+    it("adds an empty operand as 0", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(env, testDirectory, 'echo $(( $(echo "") + 1 ))');
+    });
+  });
+
+  describe("subshell isolation is preserved", () => {
+    it("discards assignments made inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'K=1\necho $(( $(K=99; echo 2) ))\necho "K=$K"',
+      );
+    });
+
+    it("discards a cd made inside the substitution", async () => {
+      const env = await setupFiles(testDirectory, {});
+      await compareOutputs(
+        env,
+        testDirectory,
+        'mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest "$PWD" = "$before" && echo same',
+      );
+    });
+  });
+});

--- a/packages/just-bash/src/comparison-tests/arithmetic-command-substitution.comparison.test.ts
+++ b/packages/just-bash/src/comparison-tests/arithmetic-command-substitution.comparison.test.ts
@@ -225,24 +225,4 @@ describe("arithmetic command substitution - GNU Bash Comparison", () => {
       await compareOutputs(env, testDirectory, 'echo $(( $(echo "") + 1 ))');
     });
   });
-
-  describe("subshell isolation is preserved", () => {
-    it("discards assignments made inside the substitution", async () => {
-      const env = await setupFiles(testDirectory, {});
-      await compareOutputs(
-        env,
-        testDirectory,
-        'K=1\necho $(( $(K=99; echo 2) ))\necho "K=$K"',
-      );
-    });
-
-    it("discards a cd made inside the substitution", async () => {
-      const env = await setupFiles(testDirectory, {});
-      await compareOutputs(
-        env,
-        testDirectory,
-        'mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest "$PWD" = "$before" && echo same',
-      );
-    });
-  });
 });

--- a/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution-isolation.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution-isolation.comparison.fixtures.json
@@ -1,0 +1,65 @@
+{
+  "0ae82e11e577eb29": {
+    "command": "echo $(( $(declare -i N; echo 1) ))\nN=\"2+3\"\necho \"N=$N\"",
+    "files": {},
+    "stdout": "1\nN=2+3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1843ab1af033bb8b": {
+    "command": "a='$(echo 1)'\nb=a\necho \"[$(( b ))]\"\necho \"status=$?\"",
+    "files": {},
+    "stdout": "status=1\n",
+    "stderr": "/bin/bash: line 2: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
+    "exitCode": 0
+  },
+  "1a57bbd4c7f457cc": {
+    "command": "echo $(( $(f() { :; }; echo 1) ))\ntype f >/dev/null 2>&1 && echo leaked || echo isolated",
+    "files": {},
+    "stdout": "1\nisolated\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "5677456ee8f77709": {
+    "command": "echo $(( $(shopt -s nullglob; echo 1) ))\nshopt -q nullglob && echo leaked || echo isolated",
+    "files": {},
+    "stdout": "1\nisolated\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "89cceb23635d8e76": {
+    "command": "a=(0 1 2)\nb=(3 4 5)\nsub='a[$(echo 2)]'\necho \"${b[sub]}\"",
+    "files": {},
+    "stdout": "5\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "920a845fe32b9f93": {
+    "command": "echo $(( $(set -u; echo 1) ))\necho \"[$UNSET_VAR] status=$?\"",
+    "files": {},
+    "stdout": "1\n[] status=0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "9a38a22a1db5ae67": {
+    "command": "v='$(echo 1)'\necho \"[$(( $(echo v) ))]\"\necho \"status=$?\"",
+    "files": {},
+    "stdout": "status=1\n",
+    "stderr": "/bin/bash: line 1: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
+    "exitCode": 0
+  },
+  "b9c0490e3bae3f1a": {
+    "command": "K=1\necho $(( $(K=99; echo 2) ))\necho \"K=$K\"",
+    "files": {},
+    "stdout": "2\nK=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "cb7c9d5c48feb69b": {
+    "command": "mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest \"$PWD\" = \"$before\" && echo same",
+    "files": {},
+    "stdout": "1\nsame\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution-isolation.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution-isolation.comparison.fixtures.json
@@ -10,8 +10,9 @@
     "command": "a='$(echo 1)'\nb=a\necho \"[$(( b ))]\"\necho \"status=$?\"",
     "files": {},
     "stdout": "status=1\n",
-    "stderr": "/bin/bash: line 2: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
-    "exitCode": 0
+    "stderr": "/bin/bash: line 3: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
+    "exitCode": 0,
+    "locked": true
   },
   "1a57bbd4c7f457cc": {
     "command": "echo $(( $(f() { :; }; echo 1) ))\ntype f >/dev/null 2>&1 && echo leaked || echo isolated",
@@ -45,8 +46,9 @@
     "command": "v='$(echo 1)'\necho \"[$(( $(echo v) ))]\"\necho \"status=$?\"",
     "files": {},
     "stdout": "status=1\n",
-    "stderr": "/bin/bash: line 1: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
-    "exitCode": 0
+    "stderr": "/bin/bash: line 2: $(echo 1): syntax error: operand expected (error token is \"$(echo 1)\")\n",
+    "exitCode": 0,
+    "locked": true
   },
   "b9c0490e3bae3f1a": {
     "command": "K=1\necho $(( $(K=99; echo 2) ))\necho \"K=$K\"",

--- a/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution.comparison.fixtures.json
@@ -120,13 +120,6 @@
     "stderr": "",
     "exitCode": 0
   },
-  "b9c0490e3bae3f1a": {
-    "command": "K=1\necho $(( $(K=99; echo 2) ))\necho \"K=$K\"",
-    "files": {},
-    "stdout": "2\nK=1\n",
-    "stderr": "",
-    "exitCode": 0
-  },
   "c618528595daa9f5": {
     "command": "echo $(( $(echo \"\") ))",
     "files": {},
@@ -138,13 +131,6 @@
     "command": "Q='$(echo PWNED)'\necho $(( `printf %s \"$Q\" | wc -c` ))",
     "files": {},
     "stdout": "13\n",
-    "stderr": "",
-    "exitCode": 0
-  },
-  "cb7c9d5c48feb69b": {
-    "command": "mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest \"$PWD\" = \"$before\" && echo same",
-    "files": {},
-    "stdout": "1\nsame\n",
     "stderr": "",
     "exitCode": 0
   },

--- a/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution.comparison.fixtures.json
+++ b/packages/just-bash/src/comparison-tests/fixtures/arithmetic-command-substitution.comparison.fixtures.json
@@ -1,0 +1,193 @@
+{
+  "045a1220a99d6400": {
+    "command": "X=7\necho $(( $(echo $(echo \"$X\")) ))",
+    "files": {},
+    "stdout": "7\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "05c8841038cc7cb4": {
+    "command": "f() { echo 5; }\necho $(( $(f) + 1 ))",
+    "files": {},
+    "stdout": "6\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "083ca7d65289dc03": {
+    "command": "echo $(( $(echo \"010\") ))",
+    "files": {},
+    "stdout": "8\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "153e1edadfb2b0b2": {
+    "command": "echo $(( $(echo \"0x10\") ))",
+    "files": {},
+    "stdout": "16\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "1e4c32174235a551": {
+    "command": "echo $(( $(false) ))",
+    "files": {},
+    "stdout": "0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "21dcff3003bf519a": {
+    "command": "echo $(( $(true) ))",
+    "files": {},
+    "stdout": "0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "2c6e07d9b683d770": {
+    "command": "cd sub\necho $(( $(ls | wc -l) ))",
+    "files": {
+      "sub/marker.txt": "m\n"
+    },
+    "stdout": "1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "3d371c35f71f1005": {
+    "command": "X=abc\necho $(( `echo \"$X\" | wc -c` ))",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "60d75ced627a9459": {
+    "command": "X=abc\necho $(( $(echo ${X:-DEFAULT} | wc -c) ))",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "62249baae84457a5": {
+    "command": "echo $(( $(echo \"1 + 2\") ))",
+    "files": {},
+    "stdout": "3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "72e43d3d879a2e3c": {
+    "command": "X=abc\necho $(( $(echo \"$X\" | wc -c) ))",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "74bcb8a7540b6a76": {
+    "command": "X=abc\n(( n = $(echo \"$X\" | wc -c) ))\necho $n",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "7a691ed9a0226924": {
+    "command": "X=abc\na=$(( $(echo \"$X\" | wc -c) ))\necho $a",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "83b6b41d85947d7f": {
+    "command": "X=abc\nlet \"m = $(echo \"$X\" | wc -c)\"\necho $m",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "8bbb5e68ae54a5c1": {
+    "command": "arr=(zero one two three)\nX=ab\necho ${arr[$(echo \"$X\" | wc -c)]}",
+    "files": {},
+    "stdout": "three\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "93a387a9ff573830": {
+    "command": "Q='$(echo PWNED)'\necho $(( $(printf %s \"$Q\" | wc -c) ))",
+    "files": {},
+    "stdout": "13\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "9a7e5e4050471bc9": {
+    "command": "X=4\necho $(( $(echo $(( X * 2 ))) + 1 ))",
+    "files": {},
+    "stdout": "9\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "b9c0490e3bae3f1a": {
+    "command": "K=1\necho $(( $(K=99; echo 2) ))\necho \"K=$K\"",
+    "files": {},
+    "stdout": "2\nK=1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "c618528595daa9f5": {
+    "command": "echo $(( $(echo \"\") ))",
+    "files": {},
+    "stdout": "0\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ca686f7b8c632eca": {
+    "command": "Q='$(echo PWNED)'\necho $(( `printf %s \"$Q\" | wc -c` ))",
+    "files": {},
+    "stdout": "13\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "cb7c9d5c48feb69b": {
+    "command": "mkdir -p deep\nbefore=$PWD\necho $(( $(cd deep; echo 1) ))\ntest \"$PWD\" = \"$before\" && echo same",
+    "files": {},
+    "stdout": "1\nsame\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "dedea5d885bc8d18": {
+    "command": "export EE=zz\necho $(( $(echo \"${EE:-none}\" | wc -c) ))",
+    "files": {},
+    "stdout": "3\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "e413edcb0baad66d": {
+    "command": "echo $(( $(echo \"\") + 1 ))",
+    "files": {},
+    "stdout": "1\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ea432561a95cd340": {
+    "command": "Q=\"a  b\"\necho $(( $(printf %s \"$Q\" | wc -c) ))",
+    "files": {},
+    "stdout": "4\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "ee757186e4260856": {
+    "command": "v=9\necho $(( $(echo v) ))",
+    "files": {},
+    "stdout": "9\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f4a862c7f331b266": {
+    "command": "echo $(( $(echo \" 7 \") ))",
+    "files": {},
+    "stdout": "7\n",
+    "stderr": "",
+    "exitCode": 0
+  },
+  "f7ec7f3577f7198f": {
+    "command": "g() { local L=wxyz; echo $(( $(echo \"$L\" | wc -c) )); }\ng",
+    "files": {},
+    "stdout": "5\n",
+    "stderr": "",
+    "exitCode": 0
+  }
+}

--- a/packages/just-bash/src/interpreter/arithmetic-command-substitution.test.ts
+++ b/packages/just-bash/src/interpreter/arithmetic-command-substitution.test.ts
@@ -71,8 +71,55 @@ describe("command substitution inside arithmetic", () => {
     expect(result.exitCode).toBe(0);
     expect(result.stdout).toBe("status=1\n");
     expect(result.stderr).toBe(
-      'bash: syntax error: operand expected (error token is "$(f)")\n',
+      'bash: $(f): syntax error: operand expected (error token is "$(f)")\n',
     );
+  });
+
+  it("does not reach command execution through variable indirection", async () => {
+    const bash = new Bash();
+
+    // GNU bash: `$(echo PWNED): syntax error: operand expected`. The command
+    // must not run just because its text reached arithmetic as *data*.
+    const result = await bash.exec(
+      'a=\'$(echo PWNED >&2; echo 1)\'\nb=a\necho "[$(( b ))]"\necho "status=$?"',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("status=1\n");
+    expect(result.stderr).toBe(
+      'bash: $(echo PWNED >&2; echo 1): syntax error: operand expected (error token is "$(echo PWNED >&2; echo 1)")\n',
+    );
+  });
+
+  it("still expands a command substitution in an array subscript from data", async () => {
+    const bash = new Bash();
+
+    // bash *does* expand subscripts reached through data, unlike bare operands
+    // (spec-tests bugs.test.sh records this as bash behaviour).
+    const result = await bash.exec(
+      "a=(0 1 2)\nb=(3 4 5)\nsub='a[$(echo 2)]'\necho \"${b[sub]}\"",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("5\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("discards shell state mutated inside the substitution", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      "echo $(( $(f() { :; }; set -u; cd /tmp; echo 1) ))\n" +
+        "type f 2>&1 | head -1\n" +
+        'echo "unset=[$UNSET_VAR] status=$?"\n' +
+        'test "$PWD" != /tmp && echo cwd-kept',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe(
+      "1\nbash: type: f: not found\nunset=[] status=0\ncwd-kept\n",
+    );
+    expect(result.stderr).toBe("");
   });
 
   it("is bounded by the substitution nesting guard, like a plain one", async () => {

--- a/packages/just-bash/src/interpreter/arithmetic-command-substitution.test.ts
+++ b/packages/just-bash/src/interpreter/arithmetic-command-substitution.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from "vitest";
+import { Bash } from "../Bash.js";
+
+/**
+ * A `$(...)` / backtick substitution nested inside `$(( ))` or `(( ))` used to
+ * run through `ctx.execFn`, a fresh top-level execution seeded from the
+ * instance's base state. It could not see anything the running script had
+ * assigned, and `Number.parseInt(output, 10) || 0` turned the resulting empty
+ * output into a plausible wrong number instead of an error.
+ *
+ * Reported downstream as ai-ecoverse/slicc#2978.
+ */
+describe("command substitution inside arithmetic", () => {
+  it("does not leak the initial environment in place of script state", async () => {
+    const bash = new Bash({ env: { X: "initial-value" } });
+
+    const result = await bash.exec(
+      'X=abc\necho $(( $(echo -n "$X" | wc -c) ))',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("3\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("forwards substitution stderr at expansion time", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      'echo $(( $(echo "boom" >&2; echo 3) + 1 ))',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("4\n");
+    expect(result.stderr).toBe("boom\n");
+  });
+
+  it("treats an exiting substitution the way a plain one does", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec('echo $(( $(exit 7; echo 1) ))\necho "$?"');
+
+    // Matches bash: the exit discards the output, so the operand is empty (0),
+    // and $? reports the `echo` that consumed it rather than the substitution.
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("0\n0\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("does not silently turn unparsable output into 0", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      'echo "[$(( $(echo "hello world") ))]"\necho "status=$?"',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("status=1\n");
+    expect(result.stderr).toBe(
+      'bash: world: syntax error: invalid arithmetic operator (error token is "world")\n',
+    );
+  });
+
+  it("does not re-expand a substitution present in the output", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      'f() { echo "\\$(f)"; }\necho "[$(( $(f) ))]"\necho "status=$?"',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("status=1\n");
+    expect(result.stderr).toBe(
+      'bash: syntax error: operand expected (error token is "$(f)")\n',
+    );
+  });
+
+  it("is bounded by the substitution nesting guard, like a plain one", async () => {
+    const plain = await new Bash().exec('f() { echo "$(f)"; }\nf');
+    const arithmetic = await new Bash().exec(
+      "f() { echo $(( $(f) + 1 )); }\nf",
+    );
+
+    expect(arithmetic.exitCode).toBe(plain.exitCode);
+    expect(arithmetic.stdout).toBe("");
+    expect(arithmetic.stderr).toBe(plain.stderr);
+    expect(arithmetic.stderr).toBe(
+      "bash: Command substitution nesting limit exceeded (50)\n",
+    );
+  });
+
+  it("evaluates deeply nested substitutions", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec("echo $(( $(echo $(echo $(echo 5))) + 1 ))");
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("6\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("keeps quoting intact in the (( )) command form", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      'Q="a  b"\n(( n = $(printf %s "$Q" | wc -c) ))\necho "$n"',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("4\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("does not execute variable data spliced into a backtick substitution", async () => {
+    const bash = new Bash();
+
+    const result = await bash.exec(
+      "Q='$(echo PWNED)'\necho $(( `printf %s \"$Q\" | wc -c` ))",
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("13\n");
+    expect(result.stderr).toBe("");
+  });
+
+  it("sees script state from an array subscript substitution", async () => {
+    const bash = new Bash({ env: { X: "initial-value" } });
+
+    const result = await bash.exec(
+      'arr=(zero one two three)\nX=ab\necho "${arr[$(echo "$X" | wc -c)]}"',
+    );
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toBe("three\n");
+    expect(result.stderr).toBe("");
+  });
+});

--- a/packages/just-bash/src/interpreter/arithmetic.ts
+++ b/packages/just-bash/src/interpreter/arithmetic.ts
@@ -36,10 +36,35 @@ import type { InterpreterContext } from "./types.js";
 interface ArithmeticResolutionContext {
   readonly visited: Set<string>;
   depth: number;
+  /**
+   * True while evaluating an expression parsed out of *data* - a variable's
+   * value or a command substitution's output - rather than out of the script
+   * text. bash re-parses such text as arithmetic but does not run expansions on
+   * it, so a `$(...)` reached this way is a syntax error, not a command.
+   */
+  fromData: boolean;
 }
 
 function createArithmeticResolutionContext(): ArithmeticResolutionContext {
-  return { visited: new Set(), depth: 0 };
+  return { visited: new Set(), depth: 0, fromData: false };
+}
+
+/**
+ * Evaluate an expression that was parsed out of data, with command
+ * substitution disabled for the whole subtree.
+ */
+async function evaluateAsData(
+  ctx: InterpreterContext,
+  expr: ArithExpr,
+  resolution: ArithmeticResolutionContext,
+): Promise<number> {
+  const savedFromData = resolution.fromData;
+  resolution.fromData = true;
+  try {
+    return await evaluateArithmeticInternal(ctx, expr, false, resolution);
+  } finally {
+    resolution.fromData = savedFromData;
+  }
 }
 
 /**
@@ -217,7 +242,7 @@ async function evaluateArithValue(
       "",
     );
   }
-  return await evaluateArithmeticInternal(ctx, expr, false, resolution);
+  return await evaluateAsData(ctx, expr, resolution);
 }
 
 async function evaluateResolvedArithValue(
@@ -304,7 +329,7 @@ async function resolveArithVariable(
     }
 
     // Evaluate the parsed expression
-    return await evaluateArithmeticInternal(ctx, expr, false, resolution);
+    return await evaluateAsData(ctx, expr, resolution);
   } finally {
     resolution.depth--;
     resolution.visited.delete(name);
@@ -417,19 +442,12 @@ async function evaluateSubstitutionOutput(
   const trimmed = output.trim();
   // An empty substitution leaves an empty expression, which bash evaluates as 0.
   if (!trimmed) return 0;
-  // bash does not re-expand the spliced text, so a substitution in the output
-  // is a literal token that the arithmetic parser cannot resolve.
-  if (trimmed.includes("$(") || trimmed.includes("`")) {
-    throw new ArithmeticError(
-      `syntax error: operand expected (error token is "${trimmed}")`,
-    );
-  }
   const parser = new Parser();
   // parseArithmeticExpression validates that the whole output was consumed, so
   // junk like "hello world" raises a syntax error instead of silently
   // truncating to the leading token.
   const { expression } = parseArithmeticExpression(parser, trimmed);
-  return await evaluateArithmeticInternal(ctx, expression, false, resolution);
+  return await evaluateAsData(ctx, expression, resolution);
 }
 
 export async function evaluateArithmetic(
@@ -453,6 +471,30 @@ async function evaluateArithmeticInternal(
 ): Promise<number> {
   const evaluate = (nestedExpr: ArithExpr, expansion = isExpansionContext) =>
     evaluateArithmeticInternal(ctx, nestedExpr, expansion, resolution);
+  /**
+   * Evaluate an array subscript. bash expands a subscript even when the
+   * surrounding expression came from data, so `x='a[$(cmd)]'; $(( x ))` runs
+   * the command (see spec-tests bugs.test.sh "command execution ... not
+   * allowed", which records this as bash behaviour). Only a bare operand
+   * reached through data is a syntax error.
+   */
+  const evaluateSubscript = async (
+    subscript: ArithExpr,
+    expansion = isExpansionContext,
+  ): Promise<number> => {
+    const savedFromData = resolution.fromData;
+    resolution.fromData = false;
+    try {
+      return await evaluateArithmeticInternal(
+        ctx,
+        subscript,
+        expansion,
+        resolution,
+      );
+    } finally {
+      resolution.fromData = savedFromData;
+    }
+  };
 
   switch (expr.type) {
     case "ArithNumber":
@@ -477,13 +519,23 @@ async function evaluateArithmeticInternal(
       // If not a simple number, evaluate as arithmetic expression
       const parser = new Parser();
       const { expr: parsed } = parseArithExpr(parser, trimmed, 0);
-      return await evaluate(parsed);
+      return await evaluateAsData(ctx, parsed, resolution);
     }
 
     case "ArithNested":
       return await evaluate(expr.expression);
 
     case "ArithCommandSubst": {
+      // Reached from a variable's value or a substitution's output rather than
+      // from the script - bash does not expand data, so this is a syntax error.
+      // Guarding here rather than by scanning the text covers indirection
+      // through any number of variables.
+      if (resolution.fromData) {
+        const token = `$(${expr.command})`;
+        throw new ArithmeticError(
+          `${token}: syntax error: operand expected (error token is "${token}")`,
+        );
+      }
       // Run the substitution in the current interpreter state, then splice its
       // output into the arithmetic expression the way bash does.
       const output = await runCommandSubstitutionText(ctx, expr.command);
@@ -556,7 +608,7 @@ async function evaluateArithmeticInternal(
 
       // Case 4: Indexed array - A[expr]
       if (expr.index) {
-        let index = await evaluate(expr.index);
+        let index = await evaluateSubscript(expr.index);
 
         // Handle negative indices - bash counts from max_index + 1
         if (index < 0) {
@@ -703,7 +755,7 @@ async function evaluateArithmeticInternal(
             const expandedKey = await getVariable(ctx, expr.operand.index.name);
             elementKey = expandedKey;
           } else if (expr.operand.index) {
-            const index = await evaluate(expr.operand.index);
+            const index = await evaluateSubscript(expr.operand.index);
             elementKey = String(index);
           } else {
             return operand;
@@ -761,7 +813,7 @@ async function evaluateArithmeticInternal(
               : expr.operand.nameExpr.name;
           }
           if (varName && /^[a-zA-Z_][a-zA-Z0-9_]*$/.test(varName)) {
-            const index = await evaluate(expr.operand.subscript);
+            const index = await evaluateSubscript(expr.operand.subscript);
             const current =
               Number.parseInt(
                 getArrayElement(ctx, varName, index) || "0",
@@ -816,11 +868,11 @@ async function evaluateArithmeticInternal(
           arrayKey = expandedKey || "\\";
         } else if (isAssoc) {
           // For non-variable subscripts on associative arrays, evaluate and convert to string
-          const index = await evaluate(expr.subscript);
+          const index = await evaluateSubscript(expr.subscript);
           arrayKey = String(index);
         } else {
           // For indexed arrays, evaluate the subscript as arithmetic
-          let index = await evaluate(expr.subscript);
+          let index = await evaluateSubscript(expr.subscript);
           // Handle negative indices
           if (index < 0) {
             const elements = getArrayElements(ctx, name);
@@ -902,7 +954,7 @@ async function evaluateArithmeticInternal(
       // Build the env key - include subscript for array assignment
       let envKey = varName;
       if (expr.subscript) {
-        const index = await evaluate(expr.subscript);
+        const index = await evaluateSubscript(expr.subscript);
         envKey = `${varName}_${index}`;
       }
       const current =
@@ -933,7 +985,7 @@ async function evaluateArithmeticInternal(
       if (!varName || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(varName)) {
         return 0; // Invalid variable name
       }
-      const index = await evaluate(expr.subscript);
+      const index = await evaluateSubscript(expr.subscript);
       const envKey = `${varName}_${index}`;
       const value = ctx.state.env.get(envKey);
       if (value !== undefined) {

--- a/packages/just-bash/src/interpreter/arithmetic.ts
+++ b/packages/just-bash/src/interpreter/arithmetic.ts
@@ -23,10 +23,12 @@
 import type { ArithExpr } from "../ast/types.js";
 import {
   parseArithExpr,
+  parseArithmeticExpression,
   parseArithNumber,
 } from "../parser/arithmetic-parser.js";
 import { Parser } from "../parser/parser.js";
 import { ArithmeticError, NounsetError } from "./errors.js";
+import { runCommandSubstitutionText } from "./expansion/command-substitution.js";
 import { getArrayElements, getVariable } from "./expansion.js";
 import { getArrayElement, hasArray, setArrayElement } from "./helpers/array.js";
 import type { InterpreterContext } from "./types.js";
@@ -398,6 +400,38 @@ async function expandBracedContent(
   }
 }
 
+/**
+ * Evaluate the output of an arithmetic command substitution.
+ *
+ * bash splices the output into the arithmetic expression as text and then
+ * parses it, so `$(( $(echo "1 + 2") ))` is 3 and `$(( $(echo v) ))` reads the
+ * variable `v`. Empty output collapses to nothing, which bash evaluates as 0
+ * when it is the whole expression. Parsing failures raise an arithmetic error
+ * rather than silently becoming 0.
+ */
+async function evaluateSubstitutionOutput(
+  ctx: InterpreterContext,
+  output: string,
+  resolution: ArithmeticResolutionContext,
+): Promise<number> {
+  const trimmed = output.trim();
+  // An empty substitution leaves an empty expression, which bash evaluates as 0.
+  if (!trimmed) return 0;
+  // bash does not re-expand the spliced text, so a substitution in the output
+  // is a literal token that the arithmetic parser cannot resolve.
+  if (trimmed.includes("$(") || trimmed.includes("`")) {
+    throw new ArithmeticError(
+      `syntax error: operand expected (error token is "${trimmed}")`,
+    );
+  }
+  const parser = new Parser();
+  // parseArithmeticExpression validates that the whole output was consumed, so
+  // junk like "hello world" raises a syntax error instead of silently
+  // truncating to the leading token.
+  const { expression } = parseArithmeticExpression(parser, trimmed);
+  return await evaluateArithmeticInternal(ctx, expression, false, resolution);
+}
+
 export async function evaluateArithmetic(
   ctx: InterpreterContext,
   expr: ArithExpr,
@@ -450,20 +484,10 @@ async function evaluateArithmeticInternal(
       return await evaluate(expr.expression);
 
     case "ArithCommandSubst": {
-      // Execute the command and parse the result as a number
-      if (ctx.execFn) {
-        const result = await ctx.execFn(expr.command, {
-          signal: ctx.state.signal,
-        });
-        // Command substitution stderr should go to the shell's stderr at expansion time
-        if (result.stderr) {
-          ctx.state.expansionStderr =
-            (ctx.state.expansionStderr || "") + result.stderr;
-        }
-        const output = result.stdout.trim();
-        return Number.parseInt(output, 10) || 0;
-      }
-      return 0;
+      // Run the substitution in the current interpreter state, then splice its
+      // output into the arithmetic expression the way bash does.
+      const output = await runCommandSubstitutionText(ctx, expr.command);
+      return await evaluateSubstitutionOutput(ctx, output, resolution);
     }
 
     case "ArithBracedExpansion": {
@@ -959,15 +983,8 @@ async function evalConcatPartToStringAsync(
       return await getVariable(ctx, expr.name);
     case "ArithBracedExpansion":
       return await expandBracedContent(ctx, expr.content);
-    case "ArithCommandSubst": {
-      if (ctx.execFn) {
-        const result = await ctx.execFn(expr.command, {
-          signal: ctx.state.signal,
-        });
-        return result.stdout.trim();
-      }
-      return "0";
-    }
+    case "ArithCommandSubst":
+      return await runCommandSubstitutionText(ctx, expr.command);
     case "ArithConcat": {
       let result = "";
       for (const part of expr.parts) {

--- a/packages/just-bash/src/interpreter/expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion.ts
@@ -19,12 +19,7 @@ import { parseArithmeticExpression } from "../parser/arithmetic-parser.js";
 import { Parser } from "../parser/parser.js";
 import { GlobExpander } from "../shell/glob.js";
 import { evaluateArithmetic } from "./arithmetic.js";
-import {
-  BadSubstitutionError,
-  ExecutionLimitError,
-  ExitError,
-} from "./errors.js";
-import { cloneArrays } from "./helpers/array.js";
+import { BadSubstitutionError, ExecutionLimitError } from "./errors.js";
 
 /**
  * Check if a string exceeds the maximum allowed length.
@@ -49,7 +44,10 @@ import {
   expandSubscriptForAssocArray,
 } from "./expansion/arith-text-expansion.js";
 import { expandBraceRange } from "./expansion/brace-range.js";
-import { getFileReadShorthand } from "./expansion/command-substitution.js";
+import {
+  getFileReadShorthand,
+  runCommandSubstitution,
+} from "./expansion/command-substitution.js";
 // Import from extracted modules
 import {
   escapeGlobChars,
@@ -787,91 +785,7 @@ async function expandPart(
         }
       }
 
-      // Command substitution runs in a subshell-like context
-      // ExitError should NOT terminate the main script, just this substitution
-      // But ExecutionLimitError MUST propagate to protect against infinite recursion
-      // Check command substitution nesting depth limit
-      const currentDepth = ctx.substitutionDepth ?? 0;
-      const maxDepth = ctx.limits.maxSubstitutionDepth;
-      if (currentDepth >= maxDepth) {
-        throw new ExecutionLimitError(
-          `Command substitution nesting limit exceeded (${maxDepth})`,
-          "substitution_depth",
-        );
-      }
-      // Increment depth for nested substitutions
-      const savedDepth = ctx.substitutionDepth;
-      ctx.substitutionDepth = currentDepth + 1;
-
-      // Command substitutions get a new BASHPID (unlike $$ which stays the same)
-      const savedBashPid = ctx.state.bashPid;
-      ctx.state.bashPid = ctx.state.nextVirtualPid++;
-      // Save environment - command substitutions run in a subshell and should not
-      // modify parent environment (e.g., aliases defined inside $() should not leak)
-      const savedEnv = new Map(ctx.state.env);
-      const savedArrays = cloneArrays(ctx.state.arrays);
-      const savedCwd = ctx.state.cwd;
-      // Suppress verbose mode (set -v) inside command substitutions
-      // bash only prints verbose output for the main script
-      const savedSuppressVerbose = ctx.state.suppressVerbose;
-      ctx.state.suppressVerbose = true;
-      try {
-        const result = await ctx.executeScript(part.body);
-        // Restore environment but preserve exit code
-        const exitCode = result.exitCode;
-        ctx.state.env = savedEnv;
-        ctx.state.arrays = savedArrays;
-        ctx.state.cwd = savedCwd;
-        ctx.state.suppressVerbose = savedSuppressVerbose;
-        // Store the exit code for $?
-        recordSubstitutionExit(ctx.state, exitCode);
-        // Command substitution stderr should go to the shell's stderr at expansion time,
-        // NOT be affected by later redirections on the outer command
-        if (result.stderr) {
-          ctx.state.expansionStderr =
-            (ctx.state.expansionStderr || "") + result.stderr;
-        }
-        ctx.state.bashPid = savedBashPid;
-        ctx.substitutionDepth = savedDepth;
-        const output = result.stdout.replace(/\n+$/, "");
-        // Check string length limit for command substitution output
-        checkStringLength(
-          output,
-          ctx.limits.maxStringLength,
-          "command substitution",
-        );
-        return output;
-      } catch (error) {
-        // Restore environment on error as well
-        ctx.state.env = savedEnv;
-        ctx.state.arrays = savedArrays;
-        ctx.state.cwd = savedCwd;
-        ctx.state.bashPid = savedBashPid;
-        ctx.substitutionDepth = savedDepth;
-        ctx.state.suppressVerbose = savedSuppressVerbose;
-        // ExecutionLimitError must always propagate - these are safety limits
-        if (error instanceof ExecutionLimitError) {
-          throw error;
-        }
-        if (error instanceof ExitError) {
-          // Catch exit in command substitution - return output so far
-          recordSubstitutionExit(ctx.state, error.exitCode);
-          // Also forward stderr from the exit
-          if (error.stderr) {
-            ctx.state.expansionStderr =
-              (ctx.state.expansionStderr || "") + error.stderr;
-          }
-          const exitOutput = error.stdout.replace(/\n+$/, "");
-          // Check string length limit for command substitution output
-          checkStringLength(
-            exitOutput,
-            ctx.limits.maxStringLength,
-            "command substitution",
-          );
-          return exitOutput;
-        }
-        throw error;
-      }
+      return runCommandSubstitution(ctx, part.body);
     }
 
     case "ProcessSubstitution":

--- a/packages/just-bash/src/interpreter/expansion/arith-text-expansion.ts
+++ b/packages/just-bash/src/interpreter/expansion/arith-text-expansion.ts
@@ -7,6 +7,7 @@
  */
 
 import type { InterpreterContext } from "../types.js";
+import { runCommandSubstitutionText } from "./command-substitution.js";
 import { getVariable } from "./variable.js";
 
 /**
@@ -81,6 +82,21 @@ export async function expandDollarVarsInArithText(
         i += 2;
         continue;
       }
+    }
+    // Backtick command substitution - don't expand. Like $(...), the command
+    // runs against the live interpreter state when the arithmetic node is
+    // evaluated, so splicing variable values in here would both lose quoting
+    // and let variable data be re-parsed as shell syntax.
+    if (text[i] === "`") {
+      let j = i + 1;
+      while (j < text.length && text[j] !== "`") {
+        // Skip escaped characters so \` stays inside the span
+        if (text[j] === "\\") j++;
+        j++;
+      }
+      result += text.slice(i, Math.min(j + 1, text.length));
+      i = j + 1;
+      continue;
     }
     // Check for double quotes - expand variables inside but keep the quotes
     // (arithmetic preprocessor will strip them)
@@ -167,20 +183,9 @@ export async function expandSubscriptForAssocArray(
           }
           j++;
         }
-        // Extract and execute the command
+        // Extract and execute the command against the current shell state
         const cmdStr = inner.slice(i + 2, j - 1);
-        if (ctx.execFn) {
-          const cmdResult = await ctx.execFn(cmdStr, {
-            signal: ctx.state.signal,
-          });
-          // Strip trailing newlines like command substitution does
-          result += cmdResult.stdout.replace(/\n+$/, "");
-          // Forward stderr to expansion stderr
-          if (cmdResult.stderr) {
-            ctx.state.expansionStderr =
-              (ctx.state.expansionStderr || "") + cmdResult.stderr;
-          }
-        }
+        result += await runCommandSubstitutionText(ctx, cmdStr);
         i = j;
       } else if (inner[i + 1] === "{") {
         // Check for ${...} - find matching }
@@ -218,16 +223,7 @@ export async function expandSubscriptForAssocArray(
         j++;
       }
       const cmdStr = inner.slice(i + 1, j);
-      if (ctx.execFn) {
-        const cmdResult = await ctx.execFn(cmdStr, {
-          signal: ctx.state.signal,
-        });
-        result += cmdResult.stdout.replace(/\n+$/, "");
-        if (cmdResult.stderr) {
-          ctx.state.expansionStderr =
-            (ctx.state.expansionStderr || "") + cmdResult.stderr;
-        }
-      }
+      result += await runCommandSubstitutionText(ctx, cmdStr);
       i = j + 1;
     } else {
       result += inner[i];

--- a/packages/just-bash/src/interpreter/expansion/command-substitution.ts
+++ b/packages/just-bash/src/interpreter/expansion/command-substitution.ts
@@ -9,6 +9,11 @@ import type {
   SimpleCommandNode,
   WordNode,
 } from "../../ast/types.js";
+import { Parser } from "../../parser/parser.js";
+import { ExecutionLimitError, ExitError } from "../errors.js";
+import { cloneArrays } from "../helpers/array.js";
+import { recordSubstitutionExit } from "../helpers/substitution-status.js";
+import type { InterpreterContext } from "../types.js";
 
 /**
  * Check if a command substitution body matches the $(<file) shorthand pattern.
@@ -63,4 +68,119 @@ export function getFileReadShorthand(
   if (redirect.target.type !== "Word") return null;
 
   return { target: redirect.target };
+}
+
+/**
+ * Execute a command substitution body against the *current* interpreter state.
+ *
+ * Command substitutions are subshell-like: they see everything the running
+ * script has set (including non-exported variables), but their own mutations to
+ * the environment, arrays and cwd are discarded afterwards. Callers must never
+ * route this through `ctx.execFn`, which starts a fresh top-level execution
+ * seeded from the instance's base state and therefore cannot see any variable
+ * assigned by the running script.
+ *
+ * Returns stdout with trailing newlines stripped, exactly like `$(...)`.
+ */
+export async function runCommandSubstitution(
+  ctx: InterpreterContext,
+  body: ScriptNode,
+): Promise<string> {
+  // Command substitution runs in a subshell-like context.
+  // ExitError should NOT terminate the main script, just this substitution.
+  // But ExecutionLimitError MUST propagate to protect against infinite recursion.
+  const currentDepth = ctx.substitutionDepth ?? 0;
+  const maxDepth = ctx.limits.maxSubstitutionDepth;
+  if (currentDepth >= maxDepth) {
+    throw new ExecutionLimitError(
+      `Command substitution nesting limit exceeded (${maxDepth})`,
+      "substitution_depth",
+    );
+  }
+  // Increment depth for nested substitutions
+  const savedDepth = ctx.substitutionDepth;
+  ctx.substitutionDepth = currentDepth + 1;
+
+  // Command substitutions get a new BASHPID (unlike $$ which stays the same)
+  const savedBashPid = ctx.state.bashPid;
+  ctx.state.bashPid = ctx.state.nextVirtualPid++;
+  // Save environment - command substitutions run in a subshell and should not
+  // modify parent environment (e.g., aliases defined inside $() should not leak)
+  const savedEnv = new Map(ctx.state.env);
+  const savedArrays = cloneArrays(ctx.state.arrays);
+  const savedCwd = ctx.state.cwd;
+  // Suppress verbose mode (set -v) inside command substitutions
+  // bash only prints verbose output for the main script
+  const savedSuppressVerbose = ctx.state.suppressVerbose;
+  ctx.state.suppressVerbose = true;
+
+  const restore = (): void => {
+    ctx.state.env = savedEnv;
+    ctx.state.arrays = savedArrays;
+    ctx.state.cwd = savedCwd;
+    ctx.state.bashPid = savedBashPid;
+    ctx.state.suppressVerbose = savedSuppressVerbose;
+    ctx.substitutionDepth = savedDepth;
+  };
+
+  try {
+    const result = await ctx.executeScript(body);
+    // Restore environment but preserve exit code
+    restore();
+    // Store the exit code for $?
+    recordSubstitutionExit(ctx.state, result.exitCode);
+    // Command substitution stderr should go to the shell's stderr at expansion
+    // time, NOT be affected by later redirections on the outer command
+    if (result.stderr) {
+      ctx.state.expansionStderr =
+        (ctx.state.expansionStderr || "") + result.stderr;
+    }
+    return finishSubstitutionOutput(ctx, result.stdout);
+  } catch (error) {
+    // Restore environment on error as well
+    restore();
+    // ExecutionLimitError must always propagate - these are safety limits
+    if (error instanceof ExecutionLimitError) {
+      throw error;
+    }
+    if (error instanceof ExitError) {
+      // Catch exit in command substitution - return output so far
+      recordSubstitutionExit(ctx.state, error.exitCode);
+      // Also forward stderr from the exit
+      if (error.stderr) {
+        ctx.state.expansionStderr =
+          (ctx.state.expansionStderr || "") + error.stderr;
+      }
+      return finishSubstitutionOutput(ctx, error.stdout);
+    }
+    throw error;
+  }
+}
+
+function finishSubstitutionOutput(
+  ctx: InterpreterContext,
+  stdout: string,
+): string {
+  const output = stdout.replace(/\n+$/, "");
+  // Check string length limit for command substitution output
+  if (output.length > ctx.limits.maxStringLength) {
+    throw new ExecutionLimitError(
+      `command substitution: string length limit exceeded (${ctx.limits.maxStringLength} bytes)`,
+      "string_length",
+    );
+  }
+  return output;
+}
+
+/**
+ * Parse and run a command substitution that the parser kept as raw text
+ * (arithmetic `$(...)`/backticks, array subscripts), against the current
+ * interpreter state.
+ */
+export async function runCommandSubstitutionText(
+  ctx: InterpreterContext,
+  command: string,
+): Promise<string> {
+  const parser = new Parser();
+  return await runCommandSubstitution(ctx, parser.parse(command));
 }

--- a/packages/just-bash/src/interpreter/expansion/command-substitution.ts
+++ b/packages/just-bash/src/interpreter/expansion/command-substitution.ts
@@ -11,8 +11,8 @@ import type {
 } from "../../ast/types.js";
 import { Parser } from "../../parser/parser.js";
 import { ExecutionLimitError, ExitError } from "../errors.js";
-import { cloneArrays } from "../helpers/array.js";
 import { recordSubstitutionExit } from "../helpers/substitution-status.js";
+import { beginIsolatedShellState } from "../state-transaction.js";
 import type { InterpreterContext } from "../types.js";
 
 /**
@@ -101,31 +101,28 @@ export async function runCommandSubstitution(
   const savedDepth = ctx.substitutionDepth;
   ctx.substitutionDepth = currentDepth + 1;
 
+  // The substitution reads the live state but must not write back to it: a
+  // `set -u`, a function definition or a `cd` inside $() is discarded the way
+  // bash discards a subshell's. beginIsolatedShellState swaps in copies of
+  // every mutable namespace and returns the rollback.
+  const restoreState = beginIsolatedShellState(ctx.state);
   // Command substitutions get a new BASHPID (unlike $$ which stays the same)
-  const savedBashPid = ctx.state.bashPid;
   ctx.state.bashPid = ctx.state.nextVirtualPid++;
-  // Save environment - command substitutions run in a subshell and should not
-  // modify parent environment (e.g., aliases defined inside $() should not leak)
-  const savedEnv = new Map(ctx.state.env);
-  const savedArrays = cloneArrays(ctx.state.arrays);
-  const savedCwd = ctx.state.cwd;
   // Suppress verbose mode (set -v) inside command substitutions
   // bash only prints verbose output for the main script
   const savedSuppressVerbose = ctx.state.suppressVerbose;
   ctx.state.suppressVerbose = true;
 
   const restore = (): void => {
-    ctx.state.env = savedEnv;
-    ctx.state.arrays = savedArrays;
-    ctx.state.cwd = savedCwd;
-    ctx.state.bashPid = savedBashPid;
+    restoreState();
     ctx.state.suppressVerbose = savedSuppressVerbose;
     ctx.substitutionDepth = savedDepth;
   };
 
   try {
     const result = await ctx.executeScript(body);
-    // Restore environment but preserve exit code
+    // Roll the subshell state back before publishing anything to the parent:
+    // the exit code and stderr below are the only things that cross the boundary.
     restore();
     // Store the exit code for $?
     recordSubstitutionExit(ctx.state, result.exitCode);

--- a/packages/just-bash/src/parser/arithmetic-parser.ts
+++ b/packages/just-bash/src/parser/arithmetic-parser.ts
@@ -40,6 +40,32 @@ function preprocessArithInput(input: string): string {
   let result = "";
   let i = 0;
   while (i < input.length) {
+    // Command substitutions keep their text verbatim: it is parsed and run as a
+    // shell script later, where quoting is significant. Stripping quotes here
+    // would turn $(printf %s "$q") into $(printf %s $q) and word-split the value.
+    // $(( )) is not a command substitution, so it falls through to be preprocessed.
+    if (input[i] === "$" && input[i + 1] === "(" && input[i + 2] !== "(") {
+      let depth = 1;
+      let j = i + 2;
+      while (j < input.length && depth > 0) {
+        if (input[j] === "(") depth++;
+        else if (input[j] === ")") depth--;
+        if (depth > 0) j++;
+      }
+      result += input.slice(i, Math.min(j + 1, input.length));
+      i = j + 1;
+      continue;
+    }
+    if (input[i] === "`") {
+      let j = i + 1;
+      while (j < input.length && input[j] !== "`") {
+        if (input[j] === "\\") j++;
+        j++;
+      }
+      result += input.slice(i, Math.min(j + 1, input.length));
+      i = j + 1;
+      continue;
+    }
     if (input[i] === '"') {
       // Skip opening quote
       i++;


### PR DESCRIPTION
## Fails open to a wrong number

A `$(...)` / backtick command substitution nested inside `$(( ))` or `(( ))` ran in a **detached shell seeded from the initial environment**. It could not see any variable the running script had set — not even exported ones. Because the missing value produced empty output rather than an error, the arithmetic silently evaluated to a plausible wrong number:

```bash
X=abc
echo $(( $(echo "$X" | wc -c) ))           # -> 1    GNU bash: 4
echo $(( $(echo ${X:-DEFAULT} | wc -c) ))  # -> 8    — proves X was unset in there
export EE=zz
echo $(( $(echo "${EE:-none}" | wc -c) ))  # -> 5    — exported vars invisible too
echo $(( $(echo $HOME | wc -c) ))          # -> 11   — the *initial* env WAS visible
```

The shape it was reported as, where `"$X"` vanishing shifted `+%s` into `-d`'s argument slot:

```bash
X=2026-09-08T00:19:09Z
date -d "$X" +%s                  # 1788826749  (correct on its own)
echo $(( $(date -d "$X" +%s) - 60 ))
# before: -60, plus `date: invalid date '+%s'` on stderr
# GNU bash / after: 1788826689
```

## Root cause

`arithmetic.ts:452` (numeric path) and `arithmetic.ts:962` (string path). `ArithCommandSubst` keeps the substitution as raw text and ran it via `ctx.execFn`, the Bash-level `exec` (`Bash.ts:818` → `execInScope`) — a fresh top-level execution seeded from the instance's base state, not the running interpreter's.

Ordinary command substitution does the right thing and is the model followed here: `expansion.ts:755+` executes the parsed body via `ctx.executeScript`, sharing the current state. That is why `$(echo $(echo "$X"))` always worked, and why the `let` form worked (it expands as a word first).

The backtick form *appeared* correct only by accident — `expandDollarVarsInArithText` textually pre-expanded `$var` inside backticks before the detached shell ran, which is its own problem (see below).

## What changed

1. **`runCommandSubstitution`** extracted from `expansion.ts` into `expansion/command-substitution.ts` — the depth guard, env/array/cwd save-restore, `expansionStderr` plumbing, `ExitError` handling and output-length check, unchanged. Both `ArithCommandSubst` sites and the array-subscript sites in `expandSubscriptForAssocArray` (same `ctx.execFn` defect, reachable via `${arr[$(...)]}`) now go through it. `ctx.execFn` no longer appears anywhere in the expansion path.

2. **`Number.parseInt(output, 10) || 0` removed — behaviour change, called out deliberately.** bash splices the substitution's output into the expression as text and parses *that* as arithmetic. `parseInt` was a second fail-open: `$(( $(echo "1 + 2") ))` silently became `2`, and `$(( $(echo "hello world") ))` silently became `0`. The output is now parsed as an arithmetic expression, matching bash:

   | expression | before | after | GNU bash |
   |---|---|---|---|
   | `$(( $(echo "1 + 2") ))` | 2 | **3** | 3 |
   | `$(( $(echo " 7 ") ))` | 7 | 7 | 7 |
   | `v=9; $(( $(echo v) ))` | 0 | **9** | 9 |
   | `$(( $(echo "0x10") ))` | 0 | **16** | 16 |
   | `$(( $(echo "010") ))` | 10 | **8** | 8 |
   | `$(( $(echo "hello world") ))` | 0 | **syntax error, exit 1** | syntax error, exit 1 |
   | `$(( $(echo "") ))` | 0 | 0 | 0 |

   Note the empty case: I checked this against bash 5.3 and 3.2 rather than assuming. bash does **not** error on an empty operand when it is the whole expression — `$(( $(echo "") ))`, `$(( $(true) ))` and `$(( $(echo abc) ))` are all `0`, because the spliced text is empty / an unset variable name. The operand-expected error only fires in operand position (`$(( 1 + $(echo "") ))`), which falls out of the normal parser. So the new failure mode is a genuine syntax error on unparsable output, not a blanket error on emptiness.

   bash also does not re-expand the spliced text, so a `$(...)` in the output is rejected rather than executed — this also stops `f() { echo '$(f)'; }; echo $(( $(f) ))` from recursing forever.

3. **Substitution text is kept verbatim** through `preprocessArithInput` and `expandDollarVarsInArithText`. Both used to rewrite the inside of the substitution, which was harmless when the text went to a detached shell but is not once it is parsed as a real shell script:
   - `preprocessArithInput` stripped double quotes everywhere, turning `$(printf %s "$Q")` into `$(printf %s $Q)` and word-splitting the value. `Q="a  b"` gave 2 instead of 4.
   - `expandDollarVarsInArithText` spliced variable *values* into backtick commands. With `Q='$(echo PWNED)'`, `$(( \`printf %s "$Q" | wc -c\` ))` returned 5 — the length of `PWNED` — because the variable's data was re-parsed and executed as shell syntax. It now returns 13, the length of the literal, matching bash. `$((` still falls through to be preprocessed as before.

### Known limitation, unchanged

Splicing is done at the value level, not the text level, so precedence across the substitution boundary still differs: `$(( $(echo "2 + 3") * 4 ))` is 20 here and 14 in bash. That is the same limitation already documented at the top of `arithmetic.ts` for `$var` expansion; making it exact needs the substitution expanded before the arithmetic is parsed, which is a broader change than this fix.

## Tests

- `src/comparison-tests/arithmetic-command-substitution.comparison.test.ts` — 27 cases recorded against real bash: variable visibility (plain, `${:-}`, exported, function, `local`, cwd), all five entry points (`$(( ))`, `(( ))`, backticks, `let`, `a=$(( ))`, array subscript), quoting preservation, nesting, output splicing, empty/failing substitutions, and subshell isolation. Verified identical on bash 3.2 and 5.3 before recording.
- `src/interpreter/arithmetic-command-substitution.test.ts` — 10 unit tests asserting full stdout *and* stderr for what fixtures don't cover: stderr forwarding at expansion time, the syntax-error paths, the nesting guard, and that a `Bash({ env: { X: ... } })` initial value no longer shadows script state.

## Validation

`pnpm typecheck && pnpm lint && pnpm knip` clean. `pnpm test:run`: **15647 passed**, 98 skipped. The 6 remaining failures are pre-existing CPython-WASM/worker tests (`python3` lazy-load, sys.path, traceback, worker-protocol desync) that fail identically on the base commit on this machine — confirmed by re-running them against unmodified `src/interpreter`.

Scope is this bug only; `expansion/array-prefix-suffix.ts` and `control-flow.ts` are untouched.

Credit to the downstream report ai-ecoverse/slicc#2978 for the reproduction.

## Review follow-up (3d04a6f5)

- **Subshell isolation.** `runCommandSubstitution` now uses the existing `beginIsolatedShellState` transaction instead of hand-rolling a partial rollback, so functions, `set -u`, `shopt`, variable attributes and `previousDir` set inside `$()` are discarded like bash discards a subshell's. The partial rollback was inherited verbatim from the old `expansion.ts` and leaked identically on plain `$()` on `main`; routing arithmetic substitutions onto that path is what made it reachable from `$(( ))`, so this closes the pre-existing leak too.
- **Data-to-code path.** The text scan for `$(` in substitution output was bypassable with one level of variable indirection (`v='$(cmd)'; $(( $(echo v) ))` executed `cmd`). Replaced with provenance tracking on the resolution context: anything parsed out of data — a variable's value, an array element's value, a substitution's output — evaluates with command substitution disabled, at any indirection depth. Array subscripts are the deliberate exception, because bash *does* expand `a[$(cmd)]` reached through data; `spec-tests` `bugs.test.sh` and `array-assign.test.sh` both pin that, and treating it as an error broke them.

Isolation and provenance coverage lives in `arithmetic-command-substitution-isolation.comparison.test.ts` (9 cases recorded against real bash) plus 3 unit tests. Both commits are GPG-signed and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

