### PR TITLE
fix(fs): finish a cross-mount copy around an entry it cannot copy, then report them

### DIFF
--- a/.changeset/cross-mount-copy-reports-failed-entries.md
+++ b/.changeset/cross-mount-copy-reports-failed-entries.md
@@ -1,0 +1,9 @@
+---
+"just-bash": patch
+---
+
+MountableFs: copy every other entry across mounts when one cannot be copied, then report the failures together
+
+A recursive `cp` from one mount into another walks the tree entry by entry, and one entry the destination refuses ended the whole walk: everything after it was left uncopied, and the error named only that entry. The ordinary case is a symlink, since `ReadWriteFs` and `OverlayFs` refuse to create one unless `allowSymlinks` is set, so a tree holding a single link (a checked-out repository, a `node_modules`) failed on it with `EPERM: operation not permitted, symlink ...` and nothing to show for the rest.
+
+The walk now continues past an entry it cannot copy, and once the tree is done throws one error naming the entries it could not copy, capped at ten, the way GNU `cp` reports each failed entry and exits 1 at the end. `cp -R` through `MountableFs` therefore leaves a usable copy with the links missing, and the error says which ones. A copy within one mount is that mount's own and is unchanged.

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -373,7 +373,7 @@ describe("MountableFs", () => {
       await expect(
         fs.cp("/mnt/a/dir", "/mnt/b/dir", { recursive: true }),
       ).rejects.toThrow(
-        "copied all but 2 entries: EPERM: operation not permitted, symlink '/dir/link'; EPERM: operation not permitted, symlink '/dir/sub/up'",
+        "copied all but 2 entries: /mnt/a/dir/link: EPERM: operation not permitted, symlink '/dir/link'; /mnt/a/dir/sub/up: EPERM: operation not permitted, symlink '/dir/sub/up'",
       );
 
       expect(await mount2.readFile("/dir/a.txt")).toBe("a");
@@ -402,10 +402,34 @@ describe("MountableFs", () => {
       await expect(
         fs.cp("/mnt/a/dir", "/mnt/b/dir", { recursive: true }),
       ).rejects.toThrow(
-        /^copied all but 12 entries: (EPERM: operation not permitted, symlink '\/dir\/link-\d\d'; ){9}EPERM: operation not permitted, symlink '\/dir\/link-09'; and 2 more$/,
+        /^copied all but 12 entries: (\/mnt\/a\/dir\/link-\d\d: EPERM: operation not permitted, symlink '\/dir\/link-\d\d'; ){9}\/mnt\/a\/dir\/link-09: EPERM: operation not permitted, symlink '\/dir\/link-09'; and 2 more$/,
       );
 
       expect(await mount2.readFile("/dir/a.txt")).toBe("a");
+    });
+
+    it("should report a directory it could not enter as one entry with its contents", async () => {
+      const mount1 = new InMemoryFs();
+      await mount1.mkdir("/dir");
+      await mount1.writeFile("/dir/a.txt", "a");
+      await mount1.mkdir("/dir/sub");
+      await mount1.writeFile("/dir/sub/b.txt", "b");
+      await mount1.writeFile("/dir/sub/c.txt", "c");
+
+      // A file already sits where the subdirectory has to go.
+      const mount2 = new InMemoryFs({ "/dir/sub": "in the way" });
+      const fs = new MountableFs();
+      fs.mount("/mnt/a", mount1);
+      fs.mount("/mnt/b", mount2);
+
+      await expect(
+        fs.cp("/mnt/a/dir", "/mnt/b/dir", { recursive: true }),
+      ).rejects.toThrow(
+        /^copied all but 1 entry: \/mnt\/a\/dir\/sub and everything in it: EEXIST/,
+      );
+
+      expect(await mount2.readFile("/dir/a.txt")).toBe("a");
+      expect(await mount2.readFile("/dir/sub")).toBe("in the way");
     });
   });
 

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.test.ts
@@ -2,6 +2,13 @@ import { describe, expect, it } from "vitest";
 import { InMemoryFs } from "../in-memory-fs/in-memory-fs.js";
 import { MountableFs } from "./mountable-fs.js";
 
+/** A destination with the symlink policy ReadWriteFs and OverlayFs default to. */
+class NoSymlinkFs extends InMemoryFs {
+  override async symlink(_target: string, linkPath: string): Promise<void> {
+    throw new Error(`EPERM: operation not permitted, symlink '${linkPath}'`);
+  }
+}
+
 describe("MountableFs", () => {
   describe("mount/unmount operations", () => {
     it("should mount a filesystem at a path", () => {
@@ -343,6 +350,62 @@ describe("MountableFs", () => {
 
       const content = await mounted.readFile("/dest.txt");
       expect(content).toBe("content");
+    });
+
+    // ReadWriteFs and OverlayFs refuse to create a symlink unless allowSymlinks
+    // is set, which is the default; a tree with one link in it must still copy
+    // everything around the link.
+    it("should copy every other entry when the destination refuses one, then report it", async () => {
+      const mount1 = new InMemoryFs();
+      await mount1.mkdir("/dir");
+      await mount1.writeFile("/dir/a.txt", "a");
+      await mount1.symlink("/dir/a.txt", "/dir/link");
+      await mount1.mkdir("/dir/sub");
+      await mount1.writeFile("/dir/sub/b.txt", "b");
+      await mount1.symlink("../a.txt", "/dir/sub/up");
+      await mount1.writeFile("/dir/z.txt", "z");
+
+      const mount2 = new NoSymlinkFs();
+      const fs = new MountableFs();
+      fs.mount("/mnt/a", mount1);
+      fs.mount("/mnt/b", mount2);
+
+      await expect(
+        fs.cp("/mnt/a/dir", "/mnt/b/dir", { recursive: true }),
+      ).rejects.toThrow(
+        "copied all but 2 entries: EPERM: operation not permitted, symlink '/dir/link'; EPERM: operation not permitted, symlink '/dir/sub/up'",
+      );
+
+      expect(await mount2.readFile("/dir/a.txt")).toBe("a");
+      expect(await mount2.readFile("/dir/sub/b.txt")).toBe("b");
+      expect(await mount2.readFile("/dir/z.txt")).toBe("z");
+      expect(await mount2.exists("/dir/link")).toBe(false);
+      expect(await mount2.exists("/dir/sub/up")).toBe(false);
+    });
+
+    it("should name a bounded number of the entries it could not copy", async () => {
+      const mount1 = new InMemoryFs();
+      await mount1.mkdir("/dir");
+      await mount1.writeFile("/dir/a.txt", "a");
+      for (let i = 0; i < 12; i++) {
+        await mount1.symlink(
+          "/dir/a.txt",
+          `/dir/link-${String(i).padStart(2, "0")}`,
+        );
+      }
+
+      const mount2 = new NoSymlinkFs();
+      const fs = new MountableFs();
+      fs.mount("/mnt/a", mount1);
+      fs.mount("/mnt/b", mount2);
+
+      await expect(
+        fs.cp("/mnt/a/dir", "/mnt/b/dir", { recursive: true }),
+      ).rejects.toThrow(
+        /^copied all but 12 entries: (EPERM: operation not permitted, symlink '\/dir\/link-\d\d'; ){9}EPERM: operation not permitted, symlink '\/dir\/link-09'; and 2 more$/,
+      );
+
+      expect(await mount2.readFile("/dir/a.txt")).toBe("a");
     });
   });
 

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -21,11 +21,18 @@ import {
 } from "../path-utils.js";
 
 /**
- * How many entries a failed cross-mount copy names in its error. A tree with
- * thousands of symlinks the destination refuses (a node_modules) is still one
- * error, not one the size of the tree.
+ * How many entries a failed cross-mount copy names in its error. Only these
+ * are kept while the walk runs; the rest are counted, so a tree with thousands
+ * of symlinks the destination refuses (a node_modules) costs one error rather
+ * than one the size of the tree, in memory as well as in the message.
  */
 const CROSS_MOUNT_COPY_FAILURES_REPORTED = 10;
+
+/** What a cross-mount copy could not copy: how many entries, and the first few. */
+interface CrossMountCopyFailures {
+  count: number;
+  named: string[];
+}
 
 /**
  * Configuration for a mount point
@@ -643,20 +650,22 @@ export class MountableFs implements IFileSystem {
    * (a symlink the destination refuses to create, a file it refuses to write)
    * does not end the walk: every other entry is still copied, and the failures
    * are thrown together once the tree is done, the way GNU cp reports each
-   * entry it could not copy and exits 1 at the end.
+   * entry it could not copy and exits 1 at the end. A directory that fails
+   * before its children are reached is one entry whose contents are missing
+   * with it, and is reported as such.
    */
   private async crossMountCopy(
     src: string,
     dest: string,
     options?: CpOptions,
   ): Promise<void> {
-    const failures: string[] = [];
-    await this.crossMountCopyEntry(src, dest, options, failures);
-    if (failures.length > 0) {
-      const reported = failures.slice(0, CROSS_MOUNT_COPY_FAILURES_REPORTED);
-      const unreported = failures.length - reported.length;
+    const failures: CrossMountCopyFailures = { count: 0, named: [] };
+    const srcStat = await this.lstat(src);
+    await this.crossMountCopyEntry(src, dest, srcStat, options, failures);
+    if (failures.count > 0) {
+      const unnamed = failures.count - failures.named.length;
       throw new Error(
-        `copied all but ${failures.length} ${failures.length === 1 ? "entry" : "entries"}: ${reported.join("; ")}${unreported > 0 ? `; and ${unreported} more` : ""}`,
+        `copied all but ${failures.count} ${failures.count === 1 ? "entry" : "entries"}: ${failures.named.join("; ")}${unnamed > 0 ? `; and ${unnamed} more` : ""}`,
       );
     }
   }
@@ -664,11 +673,10 @@ export class MountableFs implements IFileSystem {
   private async crossMountCopyEntry(
     src: string,
     dest: string,
+    srcStat: FsStat,
     options: CpOptions | undefined,
-    failures: string[],
+    failures: CrossMountCopyFailures,
   ): Promise<void> {
-    const srcStat = await this.lstat(src);
-
     if (srcStat.isFile) {
       const content = await this.readFileBuffer(src);
       await this.writeFile(dest, content);
@@ -682,15 +690,26 @@ export class MountableFs implements IFileSystem {
       for (const child of children) {
         const srcChild = joinPath(src, child);
         const destChild = joinPath(dest, child);
+        let childStat: FsStat | undefined;
         try {
+          childStat = await this.lstat(srcChild);
           await this.crossMountCopyEntry(
             srcChild,
             destChild,
+            childStat,
             options,
             failures,
           );
         } catch (error) {
-          failures.push(error instanceof Error ? error.message : String(error));
+          const message =
+            error instanceof Error ? error.message : String(error);
+          const entry = childStat?.isDirectory
+            ? `${srcChild} and everything in it`
+            : srcChild;
+          failures.count++;
+          if (failures.named.length < CROSS_MOUNT_COPY_FAILURES_REPORTED) {
+            failures.named.push(`${entry}: ${message}`);
+          }
         }
       }
     } else if (srcStat.isSymbolicLink) {

--- a/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
+++ b/packages/just-bash/src/fs/mountable-fs/mountable-fs.ts
@@ -21,6 +21,13 @@ import {
 } from "../path-utils.js";
 
 /**
+ * How many entries a failed cross-mount copy names in its error. A tree with
+ * thousands of symlinks the destination refuses (a node_modules) is still one
+ * error, not one the size of the tree.
+ */
+const CROSS_MOUNT_COPY_FAILURES_REPORTED = 10;
+
+/**
  * Configuration for a mount point
  */
 export interface MountConfig {
@@ -631,11 +638,34 @@ export class MountableFs implements IFileSystem {
 
   /**
    * Perform a cross-mount copy operation.
+   *
+   * A directory is copied entry by entry, and an entry that cannot be copied
+   * (a symlink the destination refuses to create, a file it refuses to write)
+   * does not end the walk: every other entry is still copied, and the failures
+   * are thrown together once the tree is done, the way GNU cp reports each
+   * entry it could not copy and exits 1 at the end.
    */
   private async crossMountCopy(
     src: string,
     dest: string,
     options?: CpOptions,
+  ): Promise<void> {
+    const failures: string[] = [];
+    await this.crossMountCopyEntry(src, dest, options, failures);
+    if (failures.length > 0) {
+      const reported = failures.slice(0, CROSS_MOUNT_COPY_FAILURES_REPORTED);
+      const unreported = failures.length - reported.length;
+      throw new Error(
+        `copied all but ${failures.length} ${failures.length === 1 ? "entry" : "entries"}: ${reported.join("; ")}${unreported > 0 ? `; and ${unreported} more` : ""}`,
+      );
+    }
+  }
+
+  private async crossMountCopyEntry(
+    src: string,
+    dest: string,
+    options: CpOptions | undefined,
+    failures: string[],
   ): Promise<void> {
     const srcStat = await this.lstat(src);
 
@@ -652,7 +682,16 @@ export class MountableFs implements IFileSystem {
       for (const child of children) {
         const srcChild = joinPath(src, child);
         const destChild = joinPath(dest, child);
-        await this.crossMountCopy(srcChild, destChild, options);
+        try {
+          await this.crossMountCopyEntry(
+            srcChild,
+            destChild,
+            options,
+            failures,
+          );
+        } catch (error) {
+          failures.push(error instanceof Error ? error.message : String(error));
+        }
       }
     } else if (srcStat.isSymbolicLink) {
       const target = await this.readlink(src);


### PR DESCRIPTION
## Problem

```ts
import { Bash, MountableFs, OverlayFs, ReadWriteFs } from "just-bash";

// docs/ holds a.txt, link.txt -> a.txt, and z.txt
const fs = new MountableFs();
fs.mount("/mnt/docs", new OverlayFs({ root: "/path/to/docs", readOnly: true }));
fs.mount("/work", new ReadWriteFs({ root: "/path/to/work" }));
const bash = new Bash({ fs, cwd: "/work" });

const { stderr, exitCode } = await bash.exec("cp -R /mnt/docs copy");
// stderr:   cp: cannot copy '/mnt/docs': EPERM: operation not permitted, symlink '/work/copy/link.txt'
// exitCode: 1
// copy/ holds a.txt and nothing else; z.txt was never reached
```

A recursive copy from one mount into another ends at the first entry the destination refuses, and everything after it is left uncopied. The ordinary case is a symlink: `ReadWriteFs` and `OverlayFs` refuse to create one unless `allowSymlinks` is set, so any tree with a link in it (a checked-out repository, a `node_modules`) fails this way. For an agent this reads as the folder being off limits rather than one entry being skipped, and it is easy to misattribute to the host: the errno is the one macOS raises when it denies an app a folder.

## Cause

`crossMountCopy` recurses per child with no handling between entries:

```ts
for (const child of children) {
  const srcChild = joinPath(src, child);
  const destChild = joinPath(dest, child);
  await this.crossMountCopy(srcChild, destChild, options);
}
```

The first rejected promise unwinds the whole walk. The existing cross-mount tests copy between two `InMemoryFs`, which create symlinks, so no entry ever fails in them.

## Fix

The walk continues past an entry it cannot copy and, once the tree is done, throws one error naming the entries it could not copy (capped at ten, then `and N more`), the way GNU `cp` reports each failed entry and exits 1 at the end. The `cp` command needs no change: it prints the error as `cp: cannot copy '<src>': copied all but 2 entries: ...` and exits 1.

## Scope

Unchanged: a copy within one mount is delegated to that filesystem's own `cp` as before. A failure on the source operand itself (unreadable, missing) still throws directly. A cross-mount `mv` that could not copy everything leaves the source in place, as it did when the copy aborted.

Not addressed, deliberately: a symlink policy for `cp` (`-L`, `--no-dereference`), which is a command-level feature rather than this bug; a structured error type carrying the failures, which nothing consumes yet; per-entry lines on stderr, since the filesystem layer has no stderr and the command prints one line per source operand.

## Tests

Two cases in `mountable-fs.test.ts`, using an `InMemoryFs` subclass whose `symlink()` throws `EPERM` (the policy `ReadWriteFs` and `OverlayFs` default to). The first asserts the files before, beside, and after two links (one nested) all arrive, the links do not, and the message names both in traversal order. The second asserts twelve refused links report ten and `and 2 more`. They do not exercise a real `ReadWriteFs` destination or the `cp` command's rendering; both are covered in the consumer suite this was found in, not here.

`vitest run src/fs/ src/commands/cp/ src/commands/mv/`: 33 files, 1197 passed, 1 skipped (pre-existing). `tsc --noEmit` in my checkout reports errors in `src/commands/js-exec/run-runtime.ts` only, a `run` module not installed here; pre-existing and untouched by this change.

---

Authored with Claude Opus 5
