### PR TITLE
fix(python): name the interpreter python3 rather than the worker's host path

### DIFF
--- a/.changeset/python3-pin-program-name.md
+++ b/.changeset/python3-pin-program-name.md
@@ -1,0 +1,7 @@
+---
+"just-bash": patch
+---
+
+python3: name the interpreter `python3` rather than the worker's host path
+
+Emscripten's Node glue takes the program name from `process.argv[1]`, which in a worker thread is `worker.js`'s absolute path on the host. CPython received it as `argv[0]` and as the `_` environment variable, so `sys.executable` and `os.environ['_']` disclosed the host install path to the guest, and the path's length shaped the initial heap: at some lengths (200 characters, which a pnpm store path with a patch hash lands on) `Py_FinalizeEx` aborted with `gilstate_tss_clear: failed to clear current tstate` after the program had run, and every `python3` invocation exited 1 with the right output. The module is now created with `thisProgram: "python3"`, so the guest sees `python3` and `sys.executable` is empty, as CPython reports for a program it cannot locate.

--- a/packages/just-bash/src/commands/python3/python3.env.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.env.test.ts
@@ -27,6 +27,24 @@ python3 -c "import os; print(os.environ['VAR1'], os.environ['VAR2'], os.environ[
       expect(result.exitCode).toBe(0);
     });
 
+    it("names the interpreter python3, not the worker's host path", async () => {
+      // Emscripten reads the program name off process.argv[1], which in a
+      // worker thread is worker.js's absolute path on the host. CPython
+      // exposes it as sys.executable and as the `_` variable, and its
+      // length decides the initial heap layout, which at some lengths makes
+      // Py_FinalizeEx abort after the program has run.
+      const env = new Bash({ python: true });
+      const result = await env.exec(
+        `python3 -c "import os, sys; print(os.environ.get('_')); print(repr(sys.executable))"`,
+      );
+      expect(result.stderr).toBe("");
+      // sys.executable is empty because no file named python3 exists on the
+      // guest's PATH, which is what CPython reports for a program it cannot
+      // locate; what matters is that neither carries a host path.
+      expect(result.stdout).toBe("python3\n''\n");
+      expect(result.exitCode).toBe(0);
+    });
+
     it("should handle env vars with spaces", async () => {
       const env = new Bash({ python: true });
       const result = await env.exec(`

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -1366,6 +1366,15 @@ async function runPython(input: WorkerInput): Promise<WorkerOutput> {
 
     Module = await createPythonModule({
       noInitialRun: true,
+      // Emscripten's Node glue otherwise takes the program name from
+      // process.argv[1], which in a worker is this file's absolute host path.
+      // CPython gets it as argv[0] and as the `_` environment variable, so
+      // it leaked into the guest (`sys.executable`, `os.environ['_']`), and
+      // its length shifts the initial heap layout: at some lengths (200
+      // characters, a pnpm store path) Py_FinalizeEx aborts with
+      // "gilstate_tss_clear: failed to clear current tstate" after the
+      // program has run, and every invocation exits 1.
+      thisProgram: "python3",
       preRun: [onPreRun],
       print: onPrint,
       printErr: onPrintErr,


### PR DESCRIPTION
## Problem

```js
const bash = new Bash({ python: true });
await bash.exec(`python3 -c "import os, sys; print(os.environ['_']); print(sys.executable)"`);
// /Users/me/app/node_modules/just-bash/dist/bundle/chunks/worker.js
// /Users/me/app/node_modules/just-bash/dist/bundle/chunks/worker.js
```

The guest sees the host's absolute install path, which is the one class of string the rest of the worker goes to some length to keep out (`sanitizeHostErrorMessage`, the protocol-abuse tests).

The second consequence is the one that sent me here. In a pnpm workspace with a patched `just-bash`, the worker lives at `node_modules/.pnpm/just-bash@3.4.1_patch_hash=<64 hex>/node_modules/just-bash/dist/bundle/chunks/worker.js`, 200 characters, and every `python3` invocation exited 1 with correct stdout:

```plaintext
$ python3 -c "print('hi')"
hi
Fatal Python error: gilstate_tss_clear: failed to clear current tstate (TSS)
Python runtime state: finalizing (tstate=0x00289198)

Aborted()
python3: Security violation: webassembly
```

An agent reads that as its script failing. The `Security violation` line is a consequence: Emscripten's `abort()` builds a `WebAssembly.RuntimeError`, and the worker defense blocks the `WebAssembly` global after CPython loads, so the abort's own error is what gets reported.

## Cause

Emscripten's Node glue sets `thisProgram = process.argv[1]`, and in a `worker_threads` worker that is the worker script's own path. It reaches CPython twice: `callMain` prepends it as `argv[0]`, and `getEnvStrings()` sets `_` to it. Nothing in `worker.ts` overrides it.

The length of that string shapes the initial heap, and at some lengths `Py_FinalizeEx` aborts in `gilstate_tss_clear`, meaning `pthread_setspecific` returned `EINVAL`, which under Emscripten's pthread stub means the key was no longer marked in use. Copying the identical `worker.js` to paths of different lengths, same script, same machine:

| worker path length | outcome |
| --- | --- |
| 60 to 190 | exit 0 |
| 194 to 220 | abort at finalization, exit 1 |
| 240 to 289 | exit 0 |

Holding the path fixed and setting `thisProgram` directly reproduces it: 7, 16, 50, 100, 150 characters pass; 200 aborts. The script does not matter (`pass` aborts too) and what the script allocates does not matter; only the early heap does. The underlying fault is in the CPython/Emscripten build, not in this repo, but this repo is where the install path becomes the program name.

The existing tests cannot see it because a checkout's `src/commands/python3/worker.js` path is short (82 characters here), as is a plain `npm install`'s.

## Fix

`thisProgram: "python3"` in the `createPythonModule` config. The guest sees `python3` for `_`, and `sys.executable` becomes `''`, which is what CPython reports for a program name it cannot locate on `PATH`.

## Scope

Unchanged: `sys.argv`, which the setup code already sets from `scriptPath` and the script args.

Not addressed, deliberately: the finalization abort itself, which is a CPython-on-Emscripten bug this pin only stops one input from triggering. I did not find any other input that lands in the window; the environment strings are otherwise fixed by the glue.

## Tests

`python3.env.test.ts`: `os.environ['_']` is `python3` and `sys.executable` is `''`. Fails before the change with the worker's host path in both. It proves the path no longer reaches the guest; it cannot prove the abort is gone, since that depends on the checkout's path length, which is what the table above is for.

Suite: 239 passed, 2 skipped across the 16 python3 and python-scripting files.

---

Authored with Claude Opus 5
