### PR TITLE
fix(python): report an oversize file as EFBIG and a read-only mount as EROFS

### DIFF
--- a/.changeset/python3-hostfs-errnos.md
+++ b/.changeset/python3-hostfs-errnos.md
@@ -1,0 +1,7 @@
+---
+"just-bash": patch
+---
+
+python3: report a file over the size limit as EFBIG, and a read-only mount as EROFS
+
+The worker's errno table had `EFBIG` as 27, which is `EINTR` under Emscripten's numbering (`EFBIG` is 22). CPython retries an `open()` that fails with `EINTR`, and each retry leaked the stream Emscripten had already allocated for the failed open, so reading a file over `maxStringLength` looped until the descriptor table was exhausted and the script died of `OSError: [Errno 33] No file descriptors available`, taking any later stdlib import with it. A read the bridge refused as too large for its buffer surfaced as `ENOENT`, and a write into a read-only mount as `EIO`; both now carry their own errno, so Python reports `File too large` and `Read-only file system`. `ENODATA` is corrected to 116 alongside.

--- a/packages/just-bash/src/commands/python3/python3.files.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.files.test.ts
@@ -1,5 +1,11 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { Bash } from "../../Bash.js";
+import { InMemoryFs } from "../../fs/in-memory-fs/in-memory-fs.js";
+import { MountableFs } from "../../fs/mountable-fs/mountable-fs.js";
+import { OverlayFs } from "../../fs/overlay-fs/overlay-fs.js";
 
 // Note: These tests use CPython Emscripten which loads ~9MB WASM on first run.
 // The first test will be slow, subsequent tests reuse the worker.
@@ -157,6 +163,51 @@ EOF`);
       expect(result.stderr).toBe("");
       expect(result.stdout).toBe("42\n");
       expect(result.exitCode).toBe(0);
+    });
+  });
+
+  describe("errors from the host filesystem", () => {
+    it("reports a file over the size limit as EFBIG, once", async () => {
+      const env = new Bash({
+        python: true,
+        executionLimits: { maxStringLength: 128 },
+      });
+      await env.fs.writeFile("/tmp/big.bin", "x".repeat(256));
+      const result = await env.exec(
+        `python3 -c "print(len(open('/tmp/big.bin').read()))"`,
+      );
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toContain(
+        "OSError: [Errno 22] File too large: '/host/tmp/big.bin'",
+      );
+      expect(result.stderr).not.toContain("No file descriptors available");
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("reports a write into a read-only mount as EROFS", async () => {
+      const root = mkdtempSync(join(tmpdir(), "python3-readonly-"));
+      writeFileSync(join(root, "note.txt"), "hello\n");
+      const fs = new MountableFs({ base: new InMemoryFs() });
+      fs.mount(
+        "/mnt/ro",
+        new OverlayFs({ mountPoint: "/", readOnly: true, root }),
+      );
+      const env = new Bash({ cwd: "/", fs, python: true });
+
+      const read = await env.exec(
+        `python3 -c "print(open('/mnt/ro/note.txt').read(), end='')"`,
+      );
+      expect(read.stdout).toBe("hello\n");
+      expect(read.exitCode).toBe(0);
+
+      const write = await env.exec(
+        `python3 -c "f = open('/mnt/ro/new.txt', 'w'); f.write('x'); f.close()"`,
+      );
+      expect(write.stderr).toContain(
+        "OSError: [Errno 69] Read-only file system: '/host/mnt/ro/new.txt'",
+      );
+      expect(write.exitCode).toBe(1);
+      expect(await fs.exists("/mnt/ro/new.txt")).toBe(false);
     });
   });
 

--- a/packages/just-bash/src/commands/python3/python3.files.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.files.test.ts
@@ -184,6 +184,23 @@ EOF`);
       expect(result.exitCode).toBe(1);
     });
 
+    it("refuses to append to a file the bridge cannot carry rather than replace it", async () => {
+      // Over the bridge buffer rather than over maxStringLength, so the read
+      // fails inside the bridge and open() has to classify the failure
+      // before its create fallback: append mode opens with O_CREAT.
+      const env = new Bash({ python: true });
+      const original = "x".repeat(9 * 1024 * 1024);
+      await env.fs.writeFile("/tmp/big.log", original);
+      const result = await env.exec(
+        `python3 -c "f = open('/tmp/big.log', 'a'); f.write('tail'); f.close()"`,
+      );
+      expect(result.stderr).toContain(
+        "OSError: [Errno 22] File too large: '/host/tmp/big.log'",
+      );
+      expect(result.exitCode).toBe(1);
+      expect(await env.fs.readFile("/tmp/big.log")).toBe(original);
+    });
+
     it("reports a write into a read-only mount as EROFS", async () => {
       const root = mkdtempSync(join(tmpdir(), "python3-readonly-"));
       writeFileSync(join(root, "note.txt"), "hello\n");

--- a/packages/just-bash/src/commands/python3/python3.security.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.security.test.ts
@@ -119,7 +119,7 @@ describe("python3 security", () => {
       );
 
       expect(result.stdout).toBe("");
-      expect(result.stderr).toContain("[Errno 27]");
+      expect(result.stderr).toContain("OSError: [Errno 22] File too large");
       expect(result.exitCode).toBe(1);
       const bytes = await env.fs.readFileBuffer("/tmp/truncated.bin");
       expect(bytes.byteLength).toBeLessThanOrEqual(128);

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -557,17 +557,19 @@ function createHOSTFS(
             content = backend.readFile(path);
           }
         } catch (e) {
+          // The bridge refuses a file its buffer cannot carry; that is a
+          // size limit, not a missing file, and it is checked before the
+          // create fallback: an append opens with O_CREAT, and treating the
+          // failed read as an empty file would write only the appended bytes
+          // back over the whole file on close.
+          const message = e instanceof Error ? e.message : String(e);
+          if (/too large/i.test(message)) {
+            throw new FS.ErrnoError(ERRNO_CODES.EFBIG);
+          }
           if (isCreate && isWrite) {
             content = new Uint8Array(0);
           } else {
-            // The bridge refuses a file its buffer cannot carry; that is a
-            // size limit, not a missing file.
-            const message = e instanceof Error ? e.message : String(e);
-            throw new FS.ErrnoError(
-              /too large/i.test(message)
-                ? ERRNO_CODES.EFBIG
-                : ERRNO_CODES.ENOENT,
-            );
+            throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
           }
         }
 

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -329,7 +329,7 @@ function createHOSTFS(
       ENOTDIR: 54,
       EISDIR: 31,
       EINVAL: 28,
-      EFBIG: 27,
+      EFBIG: 22,
       EMFILE: 33,
       ENOSPC: 51,
       ESPIPE: 70,
@@ -337,7 +337,7 @@ function createHOSTFS(
       ENOTEMPTY: 55,
       ENOSYS: 52,
       ENOTSUP: 138,
-      ENODATA: 42,
+      ENODATA: 116,
     },
   );
 
@@ -368,8 +368,12 @@ function createHOSTFS(
         code = ERRNO_CODES.ENOTDIR;
       } else if (msg.includes("already exists")) {
         code = ERRNO_CODES.EEXIST;
+      } else if (msg.includes("read-only") || msg.includes("erofs")) {
+        code = ERRNO_CODES.EROFS;
       } else if (msg.includes("permission")) {
         code = ERRNO_CODES.EACCES;
+      } else if (msg.includes("too large")) {
+        code = ERRNO_CODES.EFBIG;
       } else if (msg.includes("not empty")) {
         code = ERRNO_CODES.ENOTEMPTY;
       }
@@ -552,11 +556,18 @@ function createHOSTFS(
           } else {
             content = backend.readFile(path);
           }
-        } catch (_e) {
+        } catch (e) {
           if (isCreate && isWrite) {
             content = new Uint8Array(0);
           } else {
-            throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+            // The bridge refuses a file its buffer cannot carry; that is a
+            // size limit, not a missing file.
+            const message = e instanceof Error ? e.message : String(e);
+            throw new FS.ErrnoError(
+              /too large/i.test(message)
+                ? ERRNO_CODES.EFBIG
+                : ERRNO_CODES.ENOENT,
+            );
           }
         }
 


### PR DESCRIPTION
## Problem

```js
const bash = new Bash({ python: true, executionLimits: { maxStringLength: 128 } });
await bash.fs.writeFile("/tmp/big.bin", "x".repeat(256));
await bash.exec(`python3 -c "open('/tmp/big.bin').read()"`);
// OSError: [Errno 33] No file descriptors available: '/host/tmp/big.bin'
// OSError: [Errno 33] No file descriptors available: '/lib/python313.zip'
```

Any file over `maxStringLength` (8 MB by default through the bridge buffer) does this, after a noticeable pause, and the second line is the stdlib zip: the interpreter cannot import `traceback` to print the first error. Two smaller ones: a file the bridge refuses as too large for its buffer is reported as `FileNotFoundError` for a file that exists, and a write into a read-only mount is `OSError: [Errno 29] I/O error` rather than the `EROFS` the mount actually raised.

## Cause

The errno table in `createHOSTFS` has

```ts
EFBIG: 27,
```

Under Emscripten's numbering 27 is `EINTR`; `EFBIG` is 22 (`import errno; errno.EFBIG` in the vendored build says so, and `os.strerror(22)` is `File too large`). CPython retries an `open()` that fails with `EINTR` (PEP 475), and Emscripten's `FS.open` has already allocated the stream when `stream_ops.open` throws, so every retry leaks a descriptor until the table is exhausted and the retry fails with the real `EMFILE`, 33. `ENODATA: 42` is wrong the same way (116).

The two mappings: `stream_ops.open` catches every `backend.readFile` failure as `ENOENT`, so the bridge's `Result too large: N > 8388608` reads as a missing file; and `tryFSOperation` has no branch for `read-only`/`erofs`, so the mount's `EROFS: read-only file system, ...` falls through to `EIO`.

`python3.security.test.ts` asserted `[Errno 27]` for the truncate case, which is how the wrong number stayed in place: the test was checking the message the bug produced.

## Fix

`EFBIG` is 22 and `ENODATA` 116; `tryFSOperation` maps `read-only`/`erofs` to `EROFS` and `too large` to `EFBIG`; `stream_ops.open` throws `EFBIG` rather than `ENOENT` when the read failed as too large.

## Scope

Unchanged: `maxFileSize` and where it is enforced; a missing file is still `ENOENT`.

Not addressed, deliberately: the 8 MB per-operation bridge buffer (`Size.DATA_BUFFER`), which is what makes a 9 MB file unreadable at any `maxStringLength`. Chunked reads across the bridge would lift it; that is a protocol change and a separate PR if you want it.

## Tests

`python3.files.test.ts`: a 256-byte file under `maxStringLength: 128` raises `OSError: [Errno 22] File too large` once, with no `No file descriptors available`; a write into an `OverlayFs({ readOnly: true })` mount raises `[Errno 69] Read-only file system` and creates nothing, while a read of the same mount works. `python3.security.test.ts`: the truncate assertion now names `[Errno 22] File too large`. Both new tests fail before the change with the output quoted above.

Suite: 240 passed, 2 skipped across the 16 files.

---

Authored with Claude Opus 5
