### PR TITLE
fix(python): name the program in tracebacks and run it in its own namespace

### DIFF
--- a/.changeset/python3-tracebacks-name-the-script.md
+++ b/.changeset/python3-tracebacks-name-the-script.md
@@ -1,0 +1,7 @@
+---
+"just-bash": patch
+---
+
+python3: name the program in tracebacks and run it in its own namespace
+
+The program was pasted into the worker's wrapper script, so every traceback named `/tmp/_jb_script.py` at a line four hundred past the program's own, for `-c` code and script files alike, and the wrapper's helpers (`json`, `Path`, `_orig_open`, ...) sat in the program's globals. The program is now compiled under its own name (`<string>`, `<stdin>`, or the script path as typed) and run in a fresh `__main__` namespace, the wrapper's own frame is dropped from what is printed, `__file__` and `sys.path[0]` are set for a script file as CPython sets them (so a sibling module imports without a `/host` prefix), and `sys.exit("message")` prints the message before exiting 1.

--- a/packages/just-bash/src/commands/python3/python3.env.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.env.test.ts
@@ -171,6 +171,16 @@ python3 -c "import os; print(os.getcwd())"
       expect(result.exitCode).toBe(1);
     });
 
+    it("exits 1 and prints the value for any other non-integer code", async () => {
+      const env = new Bash({ python: true });
+      const empty = await env.exec(`python3 -c "import sys; sys.exit('')"`);
+      expect(empty.stderr).toBe("\n");
+      expect(empty.exitCode).toBe(1);
+      const float = await env.exec(`python3 -c "import sys; sys.exit(0.0)"`);
+      expect(float.stderr).toBe("0.0\n");
+      expect(float.exitCode).toBe(1);
+    });
+
     it("should return exit code 1 from sys.exit(None)", async () => {
       const env = new Bash({ python: true });
       const result = await env.exec(`python3 -c "import sys; sys.exit(None)"`);

--- a/packages/just-bash/src/commands/python3/python3.env.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.env.test.ts
@@ -167,6 +167,7 @@ python3 -c "import os; print(os.getcwd())"
         `python3 -c "import sys; sys.exit('error message')"`,
       );
       // sys.exit with string message prints to stderr and exits with 1
+      expect(result.stderr).toBe("error message\n");
       expect(result.exitCode).toBe(1);
     });
 

--- a/packages/just-bash/src/commands/python3/python3.files.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.files.test.ts
@@ -160,6 +160,70 @@ EOF`);
     });
   });
 
+  describe("tracebacks and the program's namespace", () => {
+    it("names <string> and the program's own line for -c code", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(`python3 -c "import json
+x = 1
+raise KeyError(2)"`);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        'Traceback (most recent call last):\n  File "<string>", line 3, in <module>\nKeyError: 2\n',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("names a script file by its path and its own lines", async () => {
+      const env = new Bash({ python: true });
+      await env.exec(`cat > /tmp/report.py << 'EOF'
+def fail():
+    raise ValueError("boom")
+
+fail()
+EOF`);
+      const result = await env.exec("cd /tmp && python3 report.py");
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        [
+          "Traceback (most recent call last):",
+          '  File "report.py", line 4, in <module>',
+          "    fail()",
+          "    ~~~~^^",
+          '  File "report.py", line 2, in fail',
+          '    raise ValueError("boom")',
+          "ValueError: boom",
+          "",
+        ].join("\n"),
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("sets __file__ and puts the script's directory on sys.path", async () => {
+      const env = new Bash({ python: true });
+      await env.exec(
+        "mkdir -p /tmp/app && echo 'ANSWER = 42' > /tmp/app/helper.py",
+      );
+      await env.exec(`cat > /tmp/app/main.py << 'EOF'
+import helper
+print(__file__, __name__, helper.ANSWER)
+EOF`);
+      const result = await env.exec("python3 /tmp/app/main.py");
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("/tmp/app/main.py __main__ 42\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("keeps the wrapper's own imports out of the program's globals", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(
+        `python3 -c "print(sorted(k for k in globals() if not k.startswith('__')))"`,
+      );
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("[]\n");
+      expect(result.exitCode).toBe(0);
+    });
+  });
+
   describe("directory operations", () => {
     it("should list directory contents", async () => {
       const env = new Bash({ python: true });

--- a/packages/just-bash/src/commands/python3/python3.files.test.ts
+++ b/packages/just-bash/src/commands/python3/python3.files.test.ts
@@ -213,6 +213,46 @@ EOF`);
       expect(result.exitCode).toBe(0);
     });
 
+    it("prints a syntax error the way CPython does, naming no wrapper", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(`python3 -c "x = = 1"`);
+      expect(result.stdout).toBe("");
+      expect(result.stderr).toBe(
+        '  File "<string>", line 1\n    x = = 1\n        ^\nSyntaxError: invalid syntax\n',
+      );
+      expect(result.exitCode).toBe(1);
+    });
+
+    it("is the __main__ module, so a class it defines pickles", async () => {
+      const env = new Bash({ python: true });
+      const result = await env.exec(`python3 -c "
+import pickle, sys, __main__
+class Point:
+    def __init__(self, x):
+        self.x = x
+print(__main__ is sys.modules['__main__'], hasattr(__main__, 'Point'))
+print(pickle.loads(pickle.dumps(Point(7))).x)
+"`);
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("True True\n7\n");
+      expect(result.exitCode).toBe(0);
+    });
+
+    it("accepts a coding cookie on the first line", async () => {
+      // The source is compiled as a str the filesystem already decoded, and
+      // CPython accepts a cookie in a str; a latin-1 cookie on UTF-8 text
+      // would re-decode the literals if the source were compiled as bytes.
+      const env = new Bash({ python: true });
+      await env.exec(`cat > /tmp/cookie.py << 'EOF'
+# -*- coding: latin-1 -*-
+print("caf\u00e9")
+EOF`);
+      const result = await env.exec("python3 /tmp/cookie.py");
+      expect(result.stderr).toBe("");
+      expect(result.stdout).toBe("caf\u00e9\n");
+      expect(result.exitCode).toBe(0);
+    });
+
     it("keeps the wrapper's own imports out of the program's globals", async () => {
       const env = new Bash({ python: true });
       const result = await env.exec(

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -477,7 +477,7 @@ async function executePython(
   ctx: RuntimeCommandContext,
   scriptPath?: string,
   scriptArgs: string[] = [],
-  fileName?: string,
+  source: WorkerInput["source"] = "inline",
 ): Promise<ExecResult> {
   const sharedBuffer = createSharedBuffer();
   const bridgeHandler = new BridgeHandler(
@@ -517,7 +517,7 @@ async function executePython(
     env: mapToRecord(ctx.env),
     args: scriptArgs,
     scriptPath,
-    fileName,
+    source,
     timeoutMs,
     maxFileSize: ctx.limits.maxStringLength,
   };
@@ -655,10 +655,10 @@ export const python3Command: RuntimeCommand = {
 
     let pythonCode: string;
     let scriptPath: string | undefined;
-    // What the program is compiled under, so a traceback names it: the
-    // script's path as typed, `<stdin>` for a program read from stdin, and
-    // `<string>` (the default) for `-c` code and `-m` bootstraps.
-    let fileName: string | undefined;
+    // Where the program came from, which is what a traceback names it by:
+    // a script file by its path as typed, a program read from stdin as
+    // `<stdin>`, and `-c` code or an `-m` bootstrap as `<string>`.
+    let source: WorkerInput["source"] = "inline";
     let stdin = latin1FromBytes(ctx.stdin);
 
     if (parsed.code !== null) {
@@ -684,7 +684,7 @@ export const python3Command: RuntimeCommand = {
       pythonCode = decodeBytesToUtf8(ctx.stdin);
       stdin = "";
       scriptPath = "-";
-      fileName = "<stdin>";
+      source = "stdin";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
 
@@ -699,7 +699,7 @@ export const python3Command: RuntimeCommand = {
       try {
         pythonCode = await ctx.fs.readFile(filePath);
         scriptPath = parsed.scriptFile;
-        fileName = parsed.scriptFile;
+        source = "file";
       } catch (e) {
         const message = sanitizeErrorMessage((e as Error).message);
         return {
@@ -712,7 +712,7 @@ export const python3Command: RuntimeCommand = {
       pythonCode = decodeBytesToUtf8(ctx.stdin);
       stdin = "";
       scriptPath = "<stdin>";
-      fileName = "<stdin>";
+      source = "stdin";
     } else {
       return {
         stdout: "",
@@ -728,7 +728,7 @@ export const python3Command: RuntimeCommand = {
       ctx,
       scriptPath,
       parsed.scriptArgs,
-      fileName,
+      source,
     );
   },
 };

--- a/packages/just-bash/src/commands/python3/python3.ts
+++ b/packages/just-bash/src/commands/python3/python3.ts
@@ -477,6 +477,7 @@ async function executePython(
   ctx: RuntimeCommandContext,
   scriptPath?: string,
   scriptArgs: string[] = [],
+  fileName?: string,
 ): Promise<ExecResult> {
   const sharedBuffer = createSharedBuffer();
   const bridgeHandler = new BridgeHandler(
@@ -516,6 +517,7 @@ async function executePython(
     env: mapToRecord(ctx.env),
     args: scriptArgs,
     scriptPath,
+    fileName,
     timeoutMs,
     maxFileSize: ctx.limits.maxStringLength,
   };
@@ -653,6 +655,10 @@ export const python3Command: RuntimeCommand = {
 
     let pythonCode: string;
     let scriptPath: string | undefined;
+    // What the program is compiled under, so a traceback names it: the
+    // script's path as typed, `<stdin>` for a program read from stdin, and
+    // `<string>` (the default) for `-c` code and `-m` bootstraps.
+    let fileName: string | undefined;
     let stdin = latin1FromBytes(ctx.stdin);
 
     if (parsed.code !== null) {
@@ -678,6 +684,7 @@ export const python3Command: RuntimeCommand = {
       pythonCode = decodeBytesToUtf8(ctx.stdin);
       stdin = "";
       scriptPath = "-";
+      fileName = "<stdin>";
     } else if (parsed.scriptFile !== null) {
       const filePath = ctx.fs.resolvePath(ctx.cwd, parsed.scriptFile);
 
@@ -692,6 +699,7 @@ export const python3Command: RuntimeCommand = {
       try {
         pythonCode = await ctx.fs.readFile(filePath);
         scriptPath = parsed.scriptFile;
+        fileName = parsed.scriptFile;
       } catch (e) {
         const message = sanitizeErrorMessage((e as Error).message);
         return {
@@ -704,6 +712,7 @@ export const python3Command: RuntimeCommand = {
       pythonCode = decodeBytesToUtf8(ctx.stdin);
       stdin = "";
       scriptPath = "<stdin>";
+      fileName = "<stdin>";
     } else {
       return {
         stdout: "",
@@ -713,7 +722,14 @@ export const python3Command: RuntimeCommand = {
       };
     }
 
-    return executePython(pythonCode, stdin, ctx, scriptPath, parsed.scriptArgs);
+    return executePython(
+      pythonCode,
+      stdin,
+      ctx,
+      scriptPath,
+      parsed.scriptArgs,
+      fileName,
+    );
   },
 };
 

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -33,6 +33,12 @@ export interface WorkerInput {
   env: Record<string, string>;
   args: string[];
   scriptPath?: string;
+  /**
+   * The name the program is compiled under, which is what a traceback shows:
+   * a script file's path as typed, or `<stdin>`. Undefined compiles it as
+   * `<string>`, the name CPython gives `-c` code.
+   */
+  fileName?: string;
   timeoutMs?: number;
   /** Maximum size of one HOSTFS file, enforced before guest allocations. */
   maxFileSize?: number;
@@ -1419,6 +1425,27 @@ async function runPython(input: WorkerInput): Promise<WorkerOutput> {
   // Create the setup + user code as a single Python script
   const setupCode = generateSetupCode(input);
   const httpBridgeCode = generateHttpBridgeCode();
+  // The program is compiled under its own name and run in a fresh __main__
+  // namespace rather than pasted into this wrapper, so a traceback names
+  // the script and its own line numbers, the wrapper's helpers stay out of
+  // its globals, and sys.path[0] and __file__ are what CPython would set.
+  // JSON escapes are a subset of Python string escapes, so JSON.stringify
+  // yields a valid Python literal.
+  const isScriptFile =
+    input.fileName !== undefined && input.fileName !== "<stdin>";
+  const fileName = input.fileName ?? "<string>";
+  const programCode = `
+import builtins as _jb_builtins
+_jb_main = {'__name__': '__main__', '__builtins__': _jb_builtins, '__doc__': None, '__package__': None, '__spec__': None, '__loader__': None}
+if ${isScriptFile ? "True" : "False"}:
+    _jb_main['__file__'] = os.path.abspath(${JSON.stringify(fileName)})
+    sys.path.insert(0, '/host' + os.path.dirname(_jb_main['__file__']))
+else:
+    sys.path.insert(0, '')
+_jb_code = compile(${JSON.stringify(input.pythonCode)}, ${JSON.stringify(fileName)}, 'exec')
+del _jb_builtins
+exec(_jb_code, _jb_main)
+`;
   const wrappedCode = `
 import sys
 _jb_exit_code = 0
@@ -1431,15 +1458,18 @@ ${httpBridgeCode
   .split("\n")
   .map((line) => `    ${line}`)
   .join("\n")}
-${input.pythonCode
+${programCode
   .split("\n")
   .map((line) => `    ${line}`)
   .join("\n")}
 except SystemExit as e:
+    if e.code is not None and not isinstance(e.code, int):
+        print(e.code, file=sys.stderr)
     _jb_exit_code = e.code if isinstance(e.code, int) else (1 if e.code else 0)
 except Exception as e:
     import traceback
-    traceback.print_exc()
+    _jb_tb = e.__traceback__
+    traceback.print_exception(type(e), e, _jb_tb.tb_next if _jb_tb is not None and _jb_tb.tb_next is not None else _jb_tb)
     _jb_exit_code = 1
 sys.exit(_jb_exit_code)
 `;

--- a/packages/just-bash/src/commands/python3/worker.ts
+++ b/packages/just-bash/src/commands/python3/worker.ts
@@ -34,11 +34,12 @@ export interface WorkerInput {
   args: string[];
   scriptPath?: string;
   /**
-   * The name the program is compiled under, which is what a traceback shows:
-   * a script file's path as typed, or `<stdin>`. Undefined compiles it as
-   * `<string>`, the name CPython gives `-c` code.
+   * Where the program came from, which decides the name it is compiled under
+   * and so what a traceback shows: a script file is named by `scriptPath` as
+   * typed, a program read from stdin `<stdin>`, and inline code (`-c`, or an
+   * `-m` bootstrap) `<string>`, the name CPython gives `-c` code.
    */
-  fileName?: string;
+  source?: "file" | "inline" | "stdin";
   timeoutMs?: number;
   /** Maximum size of one HOSTFS file, enforced before guest allocations. */
   maxFileSize?: number;
@@ -1425,26 +1426,35 @@ async function runPython(input: WorkerInput): Promise<WorkerOutput> {
   // Create the setup + user code as a single Python script
   const setupCode = generateSetupCode(input);
   const httpBridgeCode = generateHttpBridgeCode();
-  // The program is compiled under its own name and run in a fresh __main__
-  // namespace rather than pasted into this wrapper, so a traceback names
-  // the script and its own line numbers, the wrapper's helpers stay out of
-  // its globals, and sys.path[0] and __file__ are what CPython would set.
-  // JSON escapes are a subset of Python string escapes, so JSON.stringify
-  // yields a valid Python literal.
+  // The program is compiled under its own name and run in a real __main__
+  // module rather than pasted into this wrapper, so a traceback names the
+  // script and its own line numbers, the wrapper's helpers stay out of its
+  // globals, sys.modules['__main__'] is the program (pickle, unittest.main
+  // and doctest all look it up there), and sys.path[0] and __file__ are what
+  // CPython would set. The source is compiled as the str it already is: the
+  // filesystem decoded it as UTF-8, and a coding cookie in a str is accepted
+  // and ignored, where compiling bytes would re-decode UTF-8 text under
+  // whatever the cookie names. JSON escapes are a subset of Python string
+  // escapes, so JSON.stringify yields a valid Python literal.
   const isScriptFile =
-    input.fileName !== undefined && input.fileName !== "<stdin>";
-  const fileName = input.fileName ?? "<string>";
+    input.source === "file" && input.scriptPath !== undefined;
+  const fileName = isScriptFile
+    ? input.scriptPath
+    : input.source === "stdin"
+      ? "<stdin>"
+      : "<string>";
   const programCode = `
-import builtins as _jb_builtins
-_jb_main = {'__name__': '__main__', '__builtins__': _jb_builtins, '__doc__': None, '__package__': None, '__spec__': None, '__loader__': None}
+import types as _jb_types
+_jb_main = _jb_types.ModuleType('__main__')
 if ${isScriptFile ? "True" : "False"}:
-    _jb_main['__file__'] = os.path.abspath(${JSON.stringify(fileName)})
-    sys.path.insert(0, '/host' + os.path.dirname(_jb_main['__file__']))
+    _jb_main.__file__ = os.path.abspath(${JSON.stringify(fileName)})
+    sys.path.insert(0, '/host' + os.path.dirname(_jb_main.__file__))
 else:
     sys.path.insert(0, '')
+sys.modules['__main__'] = _jb_main
 _jb_code = compile(${JSON.stringify(input.pythonCode)}, ${JSON.stringify(fileName)}, 'exec')
-del _jb_builtins
-exec(_jb_code, _jb_main)
+del _jb_types
+exec(_jb_code, _jb_main.__dict__)
 `;
   const wrappedCode = `
 import sys
@@ -1463,13 +1473,20 @@ ${programCode
   .map((line) => `    ${line}`)
   .join("\n")}
 except SystemExit as e:
-    if e.code is not None and not isinstance(e.code, int):
+    if e.code is None:
+        _jb_exit_code = 0
+    elif isinstance(e.code, int):
+        _jb_exit_code = e.code
+    else:
         print(e.code, file=sys.stderr)
-    _jb_exit_code = e.code if isinstance(e.code, int) else (1 if e.code else 0)
+        _jb_exit_code = 1
 except Exception as e:
     import traceback
+    # The outermost frame is this wrapper's; the program's frames follow it.
+    # A compile-time error has no program frame at all, and prints as CPython
+    # prints a SyntaxError, from the exception alone.
     _jb_tb = e.__traceback__
-    traceback.print_exception(type(e), e, _jb_tb.tb_next if _jb_tb is not None and _jb_tb.tb_next is not None else _jb_tb)
+    traceback.print_exception(type(e), e, None if _jb_tb is None else _jb_tb.tb_next)
     _jb_exit_code = 1
 sys.exit(_jb_exit_code)
 `;


### PR DESCRIPTION
## Problem

```js
await bash.exec(`python3 -c "import json
x = 1
raise KeyError(2)"`);
// Traceback (most recent call last):
//   File "/tmp/_jb_script.py", line 413, in <module>
//     raise KeyError(2)
// KeyError: 2
```

A three-line program fails at line 413 of a file nobody wrote. A script file gets the same treatment: `python3 report.py` reports `/tmp/_jb_script.py` too, so the path and line number are wrong in every traceback the runtime produces, which is the one output an agent debugging its script reads most carefully. Related: `sys.exit("message")` exits 1 silently where CPython prints the message, `__file__` is unset for a script, `sys.path[0]` is the wrapper's `/tmp`, and the wrapper's own imports leak into the program:

```js
await bash.exec(`python3 -c "print(sorted(k for k in globals() if not k.startswith('__')))"`);
// ['Path', '_JbHttp', '_JbHttpResponse', '_base64', '_glob_module', ... 'json', 'os', 'sys', 'types']
```

## Cause

`runPython` pastes `input.pythonCode` into the wrapper's `try:` block after roughly four hundred lines of path shims and the HTTP bridge, and runs the whole file:

```ts
${input.pythonCode
  .split("\n")
  .map((line) => `    ${line}`)
  .join("\n")}
except SystemExit as e:
```

So the program is part of `/tmp/_jb_script.py`, its line numbers are offset by the wrapper's length (which varies with the environment variable count), and it shares the wrapper's module globals. `traceback.print_exc()` then prints the wrapper's own frame first. The existing tests assert on stdout and on `ValueError` appearing in stderr, never on the file or line a traceback names.

## Fix

The program is compiled with `compile(code, name, 'exec')` under its own name (`<string>` for `-c` and `-m`, `<stdin>` for a program read from stdin, the script path as typed for a file) and run with `exec` in a fresh `__main__` namespace. `python3.ts` passes the name as a new `fileName` on `WorkerInput`. For a script file, `__file__` is the absolute path and `sys.path[0]` is `/host` plus the script's directory, so a sibling module imports without the `/host` prefix the current test comment documents; for inline code, `sys.path[0]` is `''` as CPython sets it. The `except` clause prints from `e.__traceback__.tb_next`, which drops the wrapper's frame, and `sys.exit` with a non-integer code prints it to stderr.

`JSON.stringify` produces the Python literal: JSON's escapes are a subset of Python's, and the wrapper is written to MEMFS as UTF-8.

## Scope

Unchanged: the path shims, the HTTP bridge and `jb_http`, `sys.argv`, exit codes, and `runpy` behavior for `-m`, whose tracebacks already named real files because `runpy` compiles them itself.

Not addressed, deliberately: frames inside the shims themselves (`_redir_open` and friends) still appear below the program's frame when an `OSError` comes through one, and `BaseException`s other than `Exception` still propagate through the wrapper. Both are small; say the word and either is a few lines.

## Tests

`python3.files.test.ts`: `-c` code fails at `File "<string>", line 3`; a script fails at `File "report.py", line 4` and `line 2, in fail` with no wrapper frame; `__file__` is `/tmp/app/main.py` and `import helper` finds a sibling without touching `sys.path`; the program's non-dunder globals are `[]`. `python3.env.test.ts`: `sys.exit('error message')` writes `error message\n` to stderr. All five fail before the change. The existing `runpy` and `/host/tmp` `sys.path` tests still pass unchanged.

Suite: 242 passed, 2 skipped across the 16 files.

---

Authored with Claude Opus 5
